### PR TITLE
feat: Add local music library browsing and playback

### DIFF
--- a/app/schemas/com.metrolist.music.db.InternalDatabase/33.json
+++ b/app/schemas/com.metrolist.music.db.InternalDatabase/33.json
@@ -1,0 +1,1204 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 33,
+    "identityHash": "d568dba2729ab9cd3c6cba2b0c9473c9",
+    "entities": [
+      {
+        "tableName": "song",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `duration` INTEGER NOT NULL, `thumbnailUrl` TEXT, `albumId` TEXT, `albumName` TEXT, `explicit` INTEGER NOT NULL DEFAULT 0, `year` INTEGER, `date` INTEGER, `dateModified` INTEGER, `liked` INTEGER NOT NULL, `likedDate` INTEGER, `totalPlayTime` INTEGER NOT NULL, `inLibrary` INTEGER, `dateDownload` INTEGER, `isLocal` INTEGER NOT NULL DEFAULT false, `downloadUri` TEXT DEFAULT NULL, `libraryAddToken` TEXT, `libraryRemoveToken` TEXT, `lyricsOffset` INTEGER NOT NULL DEFAULT 0, `romanizeLyrics` INTEGER NOT NULL DEFAULT true, `isDownloaded` INTEGER NOT NULL DEFAULT 0, `isUploaded` INTEGER NOT NULL DEFAULT false, `isVideo` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumName",
+            "columnName": "albumName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "explicit",
+            "columnName": "explicit",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "dateModified",
+            "columnName": "dateModified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "liked",
+            "columnName": "liked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "likedDate",
+            "columnName": "likedDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalPlayTime",
+            "columnName": "totalPlayTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inLibrary",
+            "columnName": "inLibrary",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "dateDownload",
+            "columnName": "dateDownload",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isLocal",
+            "columnName": "isLocal",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "downloadUri",
+            "columnName": "downloadUri",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "libraryAddToken",
+            "columnName": "libraryAddToken",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "libraryRemoveToken",
+            "columnName": "libraryRemoveToken",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lyricsOffset",
+            "columnName": "lyricsOffset",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "romanizeLyrics",
+            "columnName": "romanizeLyrics",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "isDownloaded",
+            "columnName": "isDownloaded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isUploaded",
+            "columnName": "isUploaded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "isVideo",
+            "columnName": "isVideo",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_song_albumId",
+            "unique": false,
+            "columnNames": [
+              "albumId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_albumId` ON `${TABLE_NAME}` (`albumId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "artist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `thumbnailUrl` TEXT, `channelId` TEXT, `lastUpdateTime` INTEGER NOT NULL, `bookmarkedAt` INTEGER, `isLocal` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "lastUpdateTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkedAt",
+            "columnName": "bookmarkedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isLocal",
+            "columnName": "isLocal",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "album",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `playlistId` TEXT, `title` TEXT NOT NULL, `year` INTEGER, `thumbnailUrl` TEXT, `themeColor` INTEGER, `songCount` INTEGER NOT NULL, `duration` INTEGER NOT NULL, `explicit` INTEGER NOT NULL DEFAULT 0, `lastUpdateTime` INTEGER NOT NULL, `bookmarkedAt` INTEGER, `likedDate` INTEGER, `inLibrary` INTEGER, `isLocal` INTEGER NOT NULL DEFAULT false, `isUploaded` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "themeColor",
+            "columnName": "themeColor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "songCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "explicit",
+            "columnName": "explicit",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "lastUpdateTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkedAt",
+            "columnName": "bookmarkedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "likedDate",
+            "columnName": "likedDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "inLibrary",
+            "columnName": "inLibrary",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isLocal",
+            "columnName": "isLocal",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "isUploaded",
+            "columnName": "isUploaded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `browseId` TEXT, `createdAt` INTEGER, `lastUpdateTime` INTEGER, `isEditable` INTEGER NOT NULL DEFAULT true, `bookmarkedAt` INTEGER, `remoteSongCount` INTEGER, `playEndpointParams` TEXT, `thumbnailUrl` TEXT, `shuffleEndpointParams` TEXT, `radioEndpointParams` TEXT, `isLocal` INTEGER NOT NULL DEFAULT false, `isAutoSync` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browseId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "lastUpdateTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isEditable",
+            "columnName": "isEditable",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "bookmarkedAt",
+            "columnName": "bookmarkedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "remoteSongCount",
+            "columnName": "remoteSongCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playEndpointParams",
+            "columnName": "playEndpointParams",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shuffleEndpointParams",
+            "columnName": "shuffleEndpointParams",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "radioEndpointParams",
+            "columnName": "radioEndpointParams",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isLocal",
+            "columnName": "isLocal",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "isAutoSync",
+            "columnName": "isAutoSync",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "song_artist_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`songId` TEXT NOT NULL, `artistId` TEXT NOT NULL, `position` INTEGER NOT NULL, PRIMARY KEY(`songId`, `artistId`), FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`artistId`) REFERENCES `artist`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "songId",
+            "artistId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_song_artist_map_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_artist_map_songId` ON `${TABLE_NAME}` (`songId`)"
+          },
+          {
+            "name": "index_song_artist_map_artistId",
+            "unique": false,
+            "columnNames": [
+              "artistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_artist_map_artistId` ON `${TABLE_NAME}` (`artistId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "artist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "artistId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "song_album_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`songId` TEXT NOT NULL, `albumId` TEXT NOT NULL, `index` INTEGER NOT NULL, PRIMARY KEY(`songId`, `albumId`), FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`albumId`) REFERENCES `album`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "songId",
+            "albumId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_song_album_map_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_album_map_songId` ON `${TABLE_NAME}` (`songId`)"
+          },
+          {
+            "name": "index_song_album_map_albumId",
+            "unique": false,
+            "columnNames": [
+              "albumId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_album_map_albumId` ON `${TABLE_NAME}` (`albumId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "album",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "albumId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "album_artist_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`albumId` TEXT NOT NULL, `artistId` TEXT NOT NULL, `order` INTEGER NOT NULL, PRIMARY KEY(`albumId`, `artistId`), FOREIGN KEY(`albumId`) REFERENCES `album`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`artistId`) REFERENCES `artist`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "albumId",
+            "artistId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_album_artist_map_albumId",
+            "unique": false,
+            "columnNames": [
+              "albumId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_album_artist_map_albumId` ON `${TABLE_NAME}` (`albumId`)"
+          },
+          {
+            "name": "index_album_artist_map_artistId",
+            "unique": false,
+            "columnNames": [
+              "artistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_album_artist_map_artistId` ON `${TABLE_NAME}` (`artistId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "album",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "albumId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "artist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "artistId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_song_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `playlistId` TEXT NOT NULL, `songId` TEXT NOT NULL, `position` INTEGER NOT NULL, `setVideoId` TEXT, FOREIGN KEY(`playlistId`) REFERENCES `playlist`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "setVideoId",
+            "columnName": "setVideoId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_song_map_playlistId",
+            "unique": false,
+            "columnNames": [
+              "playlistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_song_map_playlistId` ON `${TABLE_NAME}` (`playlistId`)"
+          },
+          {
+            "name": "index_playlist_song_map_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_song_map_songId` ON `${TABLE_NAME}` (`songId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlistId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `query` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_search_history_query",
+            "unique": true,
+            "columnNames": [
+              "query"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_query` ON `${TABLE_NAME}` (`query`)"
+          }
+        ]
+      },
+      {
+        "tableName": "format",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `itag` INTEGER NOT NULL, `mimeType` TEXT NOT NULL, `codecs` TEXT NOT NULL, `bitrate` INTEGER NOT NULL, `sampleRate` INTEGER, `contentLength` INTEGER NOT NULL, `loudnessDb` REAL, `perceptualLoudnessDb` REAL, `playbackUrl` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itag",
+            "columnName": "itag",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mimeType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "codecs",
+            "columnName": "codecs",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bitrate",
+            "columnName": "bitrate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sampleRate",
+            "columnName": "sampleRate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "contentLength",
+            "columnName": "contentLength",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "loudnessDb",
+            "columnName": "loudnessDb",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "perceptualLoudnessDb",
+            "columnName": "perceptualLoudnessDb",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "playbackUrl",
+            "columnName": "playbackUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lyrics",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `lyrics` TEXT NOT NULL, `provider` TEXT NOT NULL DEFAULT 'Unknown', `translatedLyrics` TEXT NOT NULL DEFAULT '', `translationLanguage` TEXT NOT NULL DEFAULT '', `translationMode` TEXT NOT NULL DEFAULT '', PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lyrics",
+            "columnName": "lyrics",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Unknown'"
+          },
+          {
+            "fieldPath": "translatedLyrics",
+            "columnName": "translatedLyrics",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "translationLanguage",
+            "columnName": "translationLanguage",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "translationMode",
+            "columnName": "translationMode",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "event",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `songId` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `playTime` INTEGER NOT NULL, FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playTime",
+            "columnName": "playTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_event_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_event_songId` ON `${TABLE_NAME}` (`songId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "related_song_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `songId` TEXT NOT NULL, `relatedSongId` TEXT NOT NULL, FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`relatedSongId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "relatedSongId",
+            "columnName": "relatedSongId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_related_song_map_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_related_song_map_songId` ON `${TABLE_NAME}` (`songId`)"
+          },
+          {
+            "name": "index_related_song_map_relatedSongId",
+            "unique": false,
+            "columnNames": [
+              "relatedSongId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_related_song_map_relatedSongId` ON `${TABLE_NAME}` (`relatedSongId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "relatedSongId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "set_video_id",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`videoId` TEXT NOT NULL, `setVideoId` TEXT, PRIMARY KEY(`videoId`))",
+        "fields": [
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "setVideoId",
+            "columnName": "setVideoId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "videoId"
+          ]
+        }
+      },
+      {
+        "tableName": "playCount",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`song` TEXT NOT NULL, `year` INTEGER NOT NULL, `month` INTEGER NOT NULL, `count` INTEGER NOT NULL, PRIMARY KEY(`song`, `year`, `month`))",
+        "fields": [
+          {
+            "fieldPath": "song",
+            "columnName": "song",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "song",
+            "year",
+            "month"
+          ]
+        }
+      },
+      {
+        "tableName": "recognition_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `trackId` TEXT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT, `coverArtUrl` TEXT, `coverArtHqUrl` TEXT, `genre` TEXT, `releaseDate` TEXT, `label` TEXT, `shazamUrl` TEXT, `appleMusicUrl` TEXT, `spotifyUrl` TEXT, `isrc` TEXT, `youtubeVideoId` TEXT, `recognizedAt` INTEGER NOT NULL, `liked` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "trackId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtUrl",
+            "columnName": "coverArtUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtHqUrl",
+            "columnName": "coverArtHqUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "releaseDate",
+            "columnName": "releaseDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shazamUrl",
+            "columnName": "shazamUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "appleMusicUrl",
+            "columnName": "appleMusicUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "spotifyUrl",
+            "columnName": "spotifyUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isrc",
+            "columnName": "isrc",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "youtubeVideoId",
+            "columnName": "youtubeVideoId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "recognizedAt",
+            "columnName": "recognizedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "liked",
+            "columnName": "liked",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_recognition_history_trackId",
+            "unique": false,
+            "columnNames": [
+              "trackId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recognition_history_trackId` ON `${TABLE_NAME}` (`trackId`)"
+          }
+        ]
+      }
+    ],
+    "views": [
+      {
+        "viewName": "sorted_song_artist_map",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT * FROM song_artist_map ORDER BY position"
+      },
+      {
+        "viewName": "sorted_song_album_map",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT * FROM song_album_map ORDER BY `index`"
+      },
+      {
+        "viewName": "playlist_song_map_preview",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT * FROM playlist_song_map WHERE position <= 3 ORDER BY position"
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd568dba2729ab9cd3c6cba2b0c9473c9')"
+    ]
+  }
+}

--- a/app/schemas/com.metrolist.music.db.InternalDatabase/33.json
+++ b/app/schemas/com.metrolist.music.db.InternalDatabase/33.json
@@ -2,11 +2,11 @@
   "formatVersion": 1,
   "database": {
     "version": 33,
-    "identityHash": "d568dba2729ab9cd3c6cba2b0c9473c9",
+    "identityHash": "4a29a43af6e4ac6b46a754dea3ddf670",
     "entities": [
       {
         "tableName": "song",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `duration` INTEGER NOT NULL, `thumbnailUrl` TEXT, `albumId` TEXT, `albumName` TEXT, `explicit` INTEGER NOT NULL DEFAULT 0, `year` INTEGER, `date` INTEGER, `dateModified` INTEGER, `liked` INTEGER NOT NULL, `likedDate` INTEGER, `totalPlayTime` INTEGER NOT NULL, `inLibrary` INTEGER, `dateDownload` INTEGER, `isLocal` INTEGER NOT NULL DEFAULT false, `downloadUri` TEXT DEFAULT NULL, `libraryAddToken` TEXT, `libraryRemoveToken` TEXT, `lyricsOffset` INTEGER NOT NULL DEFAULT 0, `romanizeLyrics` INTEGER NOT NULL DEFAULT true, `isDownloaded` INTEGER NOT NULL DEFAULT 0, `isUploaded` INTEGER NOT NULL DEFAULT false, `isVideo` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `duration` INTEGER NOT NULL, `thumbnailUrl` TEXT, `albumId` TEXT, `albumName` TEXT, `explicit` INTEGER NOT NULL DEFAULT 0, `year` INTEGER, `date` INTEGER, `dateModified` INTEGER, `liked` INTEGER NOT NULL, `likedDate` INTEGER, `totalPlayTime` INTEGER NOT NULL, `inLibrary` INTEGER, `dateDownload` INTEGER, `isLocal` INTEGER NOT NULL DEFAULT false, `downloadUri` TEXT DEFAULT NULL, `localPath` TEXT DEFAULT NULL, `libraryAddToken` TEXT, `libraryRemoveToken` TEXT, `lyricsOffset` INTEGER NOT NULL DEFAULT 0, `romanizeLyrics` INTEGER NOT NULL DEFAULT true, `isDownloaded` INTEGER NOT NULL DEFAULT 0, `isUploaded` INTEGER NOT NULL DEFAULT false, `isVideo` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -100,6 +100,12 @@
           {
             "fieldPath": "downloadUri",
             "columnName": "downloadUri",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "localPath",
+            "columnName": "localPath",
             "affinity": "TEXT",
             "defaultValue": "NULL"
           },
@@ -1198,7 +1204,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd568dba2729ab9cd3c6cba2b0c9473c9')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '4a29a43af6e4ac6b46a754dea3ddf670')"
     ]
   }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,13 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
+    <!-- For reading local audio files -->
+    <!-- For Android 13+ (API 33+) -->
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+    <!-- For Android 12 and below -->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+
     <!-- Microphone feature for music recognition (not required) -->
     <uses-feature android:name="android.hardware.microphone" android:required="false" />
 

--- a/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
@@ -704,6 +704,16 @@ class MainActivity : ComponentActivity() {
                                 playerBottomSheetState.collapseSoft()
                             }
                         }
+
+                        override fun onTimelineChanged(
+                            timeline: androidx.media3.common.Timeline,
+                            reason: Int,
+                        ) {
+                            // Dismiss mini player when timeline is cleared (e.g., Listen Together blocking local content)
+                            if (timeline.isEmpty && !playerBottomSheetState.isDismissed) {
+                                playerBottomSheetState.dismiss()
+                            }
+                        }
                     }
                     player.addListener(listener)
                     onDispose {

--- a/app/src/main/kotlin/com/metrolist/music/constants/LibraryFilter.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/LibraryFilter.kt
@@ -11,4 +11,5 @@ enum class LibraryFilter {
     ALBUMS,
     PLAYLISTS,
     LIBRARY,
+    LOCAL,
 }

--- a/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
@@ -199,6 +199,7 @@ val ShowDownloadedPlaylistKey = booleanPreferencesKey("show_downloaded_playlist"
 val ShowTopPlaylistKey = booleanPreferencesKey("show_top_playlist")
 val ShowCachedPlaylistKey = booleanPreferencesKey("show_cached_playlist")
 val ShowUploadedPlaylistKey = booleanPreferencesKey("show_uploaded_playlist")
+val ShowLocalPlaylistKey = booleanPreferencesKey("show_local_playlist")
 
 enum class LibraryViewType {
     LIST,

--- a/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
@@ -1548,6 +1548,18 @@ interface DatabaseDao {
     @Upsert
     fun upsert(song: SongEntity)
 
+    @Upsert
+    fun upsert(artist: ArtistEntity)
+
+    @Upsert
+    fun upsert(album: AlbumEntity)
+
+    @Upsert
+    fun upsert(map: SongArtistMap)
+
+    @Upsert
+    fun upsert(map: AlbumArtistMap)
+
     @Delete
     fun delete(song: SongEntity)
 
@@ -1591,6 +1603,106 @@ interface DatabaseDao {
         playlistId: String,
         from: Int,
     ): List<PlaylistSongMap>
+
+    // Local Music Queries
+    @Transaction
+    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
+    @Query("""
+        SELECT *, (SELECT COUNT(1) FROM song_artist_map JOIN song ON song_artist_map.songId = song.id
+                   WHERE artistId = artist.id AND song.isLocal = 1) AS songCount
+        FROM artist
+        WHERE isLocal = 1
+          AND (SELECT COUNT(1) FROM song_artist_map JOIN song ON song_artist_map.songId = song.id
+               WHERE artistId = artist.id AND song.isLocal = 1) > 0
+        ORDER BY name COLLATE NOCASE ASC
+    """)
+    fun localArtists(): Flow<List<Artist>>
+
+    @Transaction
+    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
+    @Query("""
+        SELECT album.*
+        FROM album
+        WHERE album.isLocal = 1
+        AND album.id IN (
+            SELECT DISTINCT sam.albumId
+            FROM song_album_map sam
+            JOIN song ON sam.songId = song.id
+            JOIN song_artist_map sarm ON song.id = sarm.songId
+            WHERE sarm.artistId = :artistId AND song.isLocal = 1
+        )
+        ORDER BY album.title COLLATE NOCASE ASC
+    """)
+    fun localAlbumsByArtist(artistId: String): Flow<List<Album>>
+
+    @Transaction
+    @Query("""
+        SELECT song.*
+        FROM song
+        JOIN song_album_map sam ON song.id = sam.songId
+        WHERE sam.albumId = :albumId AND song.isLocal = 1
+        ORDER BY sam.`index` ASC, song.title COLLATE NOCASE ASC
+    """)
+    fun localSongsByAlbum(albumId: String): Flow<List<Song>>
+
+    @Transaction
+    @Query("SELECT * FROM song WHERE isLocal = 1 ORDER BY title COLLATE NOCASE ASC")
+    fun allLocalSongs(): Flow<List<Song>>
+
+    @Transaction
+    @Query("""
+        SELECT song.*
+        FROM song
+        JOIN song_artist_map sam ON song.id = sam.songId
+        WHERE sam.artistId = :artistId AND song.isLocal = 1
+        ORDER BY song.title COLLATE NOCASE ASC
+    """)
+    fun localSongsByArtist(artistId: String): Flow<List<Song>>
+
+    @Transaction
+    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
+    @Query("""
+        SELECT album.*
+        FROM album
+        WHERE album.isLocal = 1
+        ORDER BY album.title COLLATE NOCASE ASC
+    """)
+    fun allLocalAlbums(): Flow<List<Album>>
+
+    @Transaction
+    @Query("""
+        SELECT * FROM song
+        WHERE isLocal = 1 AND (
+            title LIKE '%' || :query || '%'
+            OR albumName LIKE '%' || :query || '%'
+        )
+        ORDER BY title COLLATE NOCASE ASC
+        LIMIT :limit
+    """)
+    fun searchLocalSongs(query: String, limit: Int = Int.MAX_VALUE): Flow<List<Song>>
+
+    @Transaction
+    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
+    @Query("""
+        SELECT *, (SELECT COUNT(1) FROM song_artist_map JOIN song ON song_artist_map.songId = song.id
+                   WHERE artistId = artist.id AND song.isLocal = 1) AS songCount
+        FROM artist
+        WHERE isLocal = 1 AND name LIKE '%' || :query || '%'
+        ORDER BY name COLLATE NOCASE ASC
+        LIMIT :limit
+    """)
+    fun searchLocalArtists(query: String, limit: Int = Int.MAX_VALUE): Flow<List<Artist>>
+
+    @Transaction
+    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
+    @Query("""
+        SELECT album.*
+        FROM album
+        WHERE album.isLocal = 1 AND album.title LIKE '%' || :query || '%'
+        ORDER BY album.title COLLATE NOCASE ASC
+        LIMIT :limit
+    """)
+    fun searchLocalAlbums(query: String, limit: Int = Int.MAX_VALUE): Flow<List<Album>>
 
     @RawQuery
     fun raw(supportSQLiteQuery: SupportSQLiteQuery): Int

--- a/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
@@ -1704,6 +1704,34 @@ interface DatabaseDao {
     """)
     fun searchLocalAlbums(query: String, limit: Int = Int.MAX_VALUE): Flow<List<Album>>
 
+    // Folder browsing queries
+    @Query("""
+        SELECT DISTINCT localPath
+        FROM song
+        WHERE isLocal = 1 AND localPath IS NOT NULL
+        ORDER BY localPath COLLATE NOCASE ASC
+    """)
+    fun localSongPaths(): Flow<List<String>>
+
+    @Transaction
+    @Query("""
+        SELECT * FROM song
+        WHERE isLocal = 1
+        AND localPath LIKE :folderPath || '/%'
+        AND localPath NOT LIKE :folderPath || '/%/%'
+        ORDER BY title COLLATE NOCASE ASC
+    """)
+    fun localSongsInFolder(folderPath: String): Flow<List<Song>>
+
+    @Transaction
+    @Query("""
+        SELECT * FROM song
+        WHERE isLocal = 1
+        AND localPath LIKE :folderPath || '/%'
+        ORDER BY localPath COLLATE NOCASE ASC, title COLLATE NOCASE ASC
+    """)
+    fun localSongsInFolderRecursive(folderPath: String): Flow<List<Song>>
+
     @RawQuery
     fun raw(supportSQLiteQuery: SupportSQLiteQuery): Int
 

--- a/app/src/main/kotlin/com/metrolist/music/db/MusicDatabase.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/MusicDatabase.kt
@@ -107,7 +107,7 @@ class MusicDatabase(
         SortedSongAlbumMap::class,
         PlaylistSongMapPreview::class,
     ],
-    version = 32,
+    version = 33,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 2, to = 3),
@@ -140,6 +140,7 @@ class MusicDatabase(
         AutoMigration(from = 29, to = 30, spec = Migration29To30::class),
         AutoMigration(from = 30, to = 31),
         AutoMigration(from = 31, to = 32),
+        AutoMigration(from = 32, to = 33),  // Add downloadUri column for local music
     ],
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/kotlin/com/metrolist/music/db/MusicDatabase.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/MusicDatabase.kt
@@ -140,7 +140,7 @@ class MusicDatabase(
         AutoMigration(from = 29, to = 30, spec = Migration29To30::class),
         AutoMigration(from = 30, to = 31),
         AutoMigration(from = 31, to = 32),
-        AutoMigration(from = 32, to = 33),  // Add downloadUri column for local music
+        AutoMigration(from = 32, to = 33),  // Add downloadUri and localPath columns for local music
     ],
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/SongEntity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/SongEntity.kt
@@ -46,6 +46,8 @@ data class SongEntity(
     val isLocal: Boolean = false,
     @ColumnInfo(name = "downloadUri", defaultValue = "NULL")
     val downloadUri: String? = null,
+    @ColumnInfo(name = "localPath", defaultValue = "NULL")
+    val localPath: String? = null,
     val libraryAddToken: String? = null,
     val libraryRemoveToken: String? = null,
     @ColumnInfo(defaultValue = "0")

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/SongEntity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/SongEntity.kt
@@ -44,6 +44,8 @@ data class SongEntity(
     val dateDownload: LocalDateTime? = null,
     @ColumnInfo(name = "isLocal", defaultValue = false.toString())
     val isLocal: Boolean = false,
+    @ColumnInfo(name = "downloadUri", defaultValue = "NULL")
+    val downloadUri: String? = null,
     val libraryAddToken: String? = null,
     val libraryRemoveToken: String? = null,
     @ColumnInfo(defaultValue = "0")

--- a/app/src/main/kotlin/com/metrolist/music/extensions/MediaItemExt.kt
+++ b/app/src/main/kotlin/com/metrolist/music/extensions/MediaItemExt.kt
@@ -14,33 +14,43 @@ import com.metrolist.music.db.entities.Song
 import com.metrolist.music.models.MediaMetadata
 import com.metrolist.music.models.toMediaMetadata
 import com.metrolist.music.ui.utils.resize
+import timber.log.Timber
 
 val MediaItem.metadata: MediaMetadata?
     get() = localConfiguration?.tag as? MediaMetadata
 
-fun Song.toMediaItem() = MediaItem.Builder()
-    .setMediaId(song.id)
-    .setUri(song.id)
-    .setCustomCacheKey(song.id)
-    .setTag(toMediaMetadata())
-    .setMediaMetadata(
-        androidx.media3.common.MediaMetadata.Builder()
-            .setTitle(song.title)
-            .setSubtitle(artists.joinToString { it.name })
-            .setArtist(artists.joinToString { it.name })
-            .setArtworkUri(song.thumbnailUrl?.toUri())
-            .setAlbumTitle(song.albumName)
-            .setAlbumArtist(artists.firstOrNull()?.name)
-            .setDisplayTitle(song.title)
-            .setMediaType(MEDIA_TYPE_MUSIC)
-            .setIsBrowsable(false)
-            .setIsPlayable(true)
-            .setExtras(Bundle().apply {
-                putString("artwork_uri", song.thumbnailUrl)
-            })
-            .build()
-    )
-    .build()
+fun Song.toMediaItem(): MediaItem {
+    val uri = if (song.isLocal && !song.downloadUri.isNullOrEmpty()) {
+        song.downloadUri
+    } else {
+        song.id
+    }
+    Timber.d("MediaItemExt: Song.toMediaItem() - id=${song.id}, isLocal=${song.isLocal}, downloadUri=${song.downloadUri}, resolvedUri=$uri")
+    return MediaItem.Builder()
+        .setMediaId(song.id)
+        .setUri(uri)
+        .setCustomCacheKey(song.id)
+        .setTag(toMediaMetadata())
+        .setMediaMetadata(
+            androidx.media3.common.MediaMetadata.Builder()
+                .setTitle(song.title)
+                .setSubtitle(artists.joinToString { it.name })
+                .setArtist(artists.joinToString { it.name })
+                .setArtworkUri(song.thumbnailUrl?.toUri())
+                .setAlbumTitle(song.albumName)
+                .setAlbumArtist(artists.firstOrNull()?.name)
+                .setDisplayTitle(song.title)
+                .setMediaType(MEDIA_TYPE_MUSIC)
+                .setIsBrowsable(false)
+                .setIsPlayable(true)
+                .setExtras(Bundle().apply {
+                    putString("artwork_uri", song.thumbnailUrl)
+                    putBoolean("is_local", song.isLocal)
+                })
+                .build()
+        )
+        .build()
+}
 
 fun SongItem.toMediaItem() = MediaItem.Builder()
     .setMediaId(id)

--- a/app/src/main/kotlin/com/metrolist/music/listentogether/ListenTogetherManager.kt
+++ b/app/src/main/kotlin/com/metrolist/music/listentogether/ListenTogetherManager.kt
@@ -6,6 +6,8 @@
 package com.metrolist.music.listentogether
 
 import android.content.Context
+import android.widget.Toast
+import com.metrolist.music.R
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import com.metrolist.innertube.YouTube
@@ -407,23 +409,66 @@ class ListenTogetherManager @Inject constructor(
                             Timber.tag(TAG).e(e, "Failed to add player listener on room create")
                         }
                     }
-                    // Initialize sync state
-                    lastSyncedIsPlaying = player?.playWhenReady
-                    lastSyncedTrackId = player?.currentMediaItem?.mediaId
 
-                    // If there's already a track loaded, send it to the server
-                    player?.currentMetadata?.let { metadata ->
-                        Timber.tag(TAG).d("Room created with existing track: ${metadata.title}")
-                        // Send track change so server has the current track info
-                        sendTrackChangeInternal(metadata)
-                        // If host is already playing, immediately send PLAY with current position
-                        val isPlaying = player.playWhenReady
-                        if (isPlaying) {
-                            lastSyncedIsPlaying = true
-                            val position = player.currentPosition
-                            Timber.tag(TAG).d("Host already playing on room create, sending PLAY at $position")
-                            client.sendPlaybackAction(PlaybackActions.PLAY, position = position)
+                    // Filter out local tracks from queue (local files can't be synced)
+                    val itemCount = player?.mediaItemCount ?: 0
+                    val localIndices = mutableListOf<Int>()
+                    for (i in 0 until itemCount) {
+                        if (player?.getMediaItemAt(i)?.mediaId?.startsWith("LOCAL_") == true) {
+                            localIndices.add(i)
                         }
+                    }
+
+                    if (localIndices.isNotEmpty()) {
+                        Timber.tag(TAG).d("Room created with ${localIndices.size} local tracks, filtering them out")
+                        val currentIndex = player?.currentMediaItemIndex ?: 0
+                        val currentIsLocal = currentIndex in localIndices
+
+                        // Remove local items from end to start to avoid index shifting
+                        for (i in localIndices.reversed()) {
+                            player?.removeMediaItem(i)
+                        }
+
+                        // Show toast about removed local files
+                        scope.launch(Dispatchers.Main) {
+                            Toast.makeText(context, R.string.local_playback_blocked_listen_together, Toast.LENGTH_LONG).show()
+                        }
+
+                        // Check if queue is now empty
+                        if (player?.mediaItemCount == 0) {
+                            Timber.tag(TAG).d("Queue empty after filtering local tracks")
+                            player?.stop()
+                            lastSyncedIsPlaying = false
+                            lastSyncedTrackId = null
+                        } else if (currentIsLocal) {
+                            // Current track was local, seek to first available track
+                            Timber.tag(TAG).d("Current track was local, seeking to first non-local track")
+                            player?.seekTo(0, 0)
+                        }
+                    }
+
+                    // Initialize sync state if we have content
+                    if (player?.mediaItemCount ?: 0 > 0) {
+                        lastSyncedIsPlaying = player?.playWhenReady
+                        lastSyncedTrackId = player?.currentMediaItem?.mediaId
+
+                        // If there's already a track loaded, send it to the server
+                        player?.currentMetadata?.let { metadata ->
+                            Timber.tag(TAG).d("Room created with existing track: ${metadata.title}")
+                            // Send track change so server has the current track info
+                            sendTrackChangeInternal(metadata)
+                            // If host is already playing, immediately send PLAY with current position
+                            val isPlaying = player.playWhenReady
+                            if (isPlaying) {
+                                lastSyncedIsPlaying = true
+                                val position = player.currentPosition
+                                Timber.tag(TAG).d("Host already playing on room create, sending PLAY at $position")
+                                client.sendPlaybackAction(PlaybackActions.PLAY, position = position)
+                            }
+                        }
+                    } else {
+                        lastSyncedIsPlaying = false
+                        lastSyncedTrackId = null
                     }
                     startQueueSyncObservation()
                     startHeartbeat()
@@ -437,6 +482,22 @@ class ListenTogetherManager @Inject constructor(
                 Timber.tag(TAG).d("Join approved for room: ${event.roomCode}")
                 // Save current mute state before joining as guest so we can restore it on leave
                 saveMuteStateOnJoin()
+
+                // Stop any local content before syncing (local files can't be synced)
+                val connection = playerConnection
+                val player = connection?.player
+                val hasLocalContent = (0 until (player?.mediaItemCount ?: 0)).any { i ->
+                    player?.getMediaItemAt(i)?.mediaId?.startsWith("LOCAL_") == true
+                }
+                if (hasLocalContent) {
+                    Timber.tag(TAG).d("Joining room with local content in queue, stopping playback")
+                    player?.stop()
+                    player?.clearMediaItems()
+                    scope.launch(Dispatchers.Main) {
+                        Toast.makeText(context, R.string.local_playback_blocked_listen_together, Toast.LENGTH_LONG).show()
+                    }
+                }
+
                 // Apply the full initial state including queue
                 applyPlaybackState(
                     currentTrack = event.state.currentTrack,

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -59,6 +59,7 @@ import androidx.media3.exoplayer.audio.DefaultAudioSink
 import androidx.media3.exoplayer.audio.SilenceSkippingAudioProcessor
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.source.ShuffleOrder.DefaultShuffleOrder
+import androidx.media3.extractor.DefaultExtractorsFactory
 import androidx.media3.extractor.ExtractorsFactory
 import androidx.media3.extractor.mkv.MatroskaExtractor
 import androidx.media3.extractor.mp4.FragmentedMp4Extractor
@@ -2627,19 +2628,39 @@ class MusicService :
             // Check if we need to bypass cache for quality change
             val shouldBypassCache = bypassCacheForQualityChange.contains(mediaId)
 
+            // Check for local file or downloaded file URI first
+            Timber.tag("CacheResolver").d("Resolving mediaId=$mediaId, position=${dataSpec.position}, uri=${dataSpec.uri}")
             if (!shouldBypassCache) {
-                if (downloadCache.isCached(
-                        mediaId,
-                        dataSpec.position,
-                        if (dataSpec.length >= 0) dataSpec.length else 1
-                    ) ||
-                    playerCache.isCached(mediaId, dataSpec.position, CHUNK_LENGTH)
-                ) {
+                val song = runBlocking(Dispatchers.IO) {
+                    database.song(mediaId).first()
+                }
+                Timber.tag("CacheResolver").d("Database lookup for $mediaId: song=${song?.song?.title}, isLocal=${song?.song?.isLocal}, downloadUri=${song?.song?.downloadUri}")
+
+                // Use local/downloaded file directly if available
+                if (song?.song?.downloadUri != null && dataSpec.position == 0L) {
+                    val localUri = song.song.downloadUri.toUri()
+                    Timber.tag("CacheResolver").d("Using local file for $mediaId: $localUri (isLocal=${song.song.isLocal})")
+                    scope.launch(Dispatchers.IO) { recoverSong(mediaId) }
+                    return@Factory dataSpec.withUri(localUri)
+                }
+
+                // Check download cache
+                if (downloadCache.isCached(mediaId, dataSpec.position, CHUNK_LENGTH)) {
+                    Timber.tag("CacheResolver").d("Using download cache for $mediaId at pos=${dataSpec.position}")
                     scope.launch(Dispatchers.IO) { recoverSong(mediaId) }
                     return@Factory dataSpec
                 }
 
+                // Check player cache
+                if (playerCache.isCached(mediaId, dataSpec.position, CHUNK_LENGTH)) {
+                    Timber.tag("CacheResolver").d("Using player cache for $mediaId at pos=${dataSpec.position}")
+                    scope.launch(Dispatchers.IO) { recoverSong(mediaId) }
+                    return@Factory dataSpec
+                }
+
+                // Check URL cache
                 songUrlCache[mediaId]?.takeIf { it.second > System.currentTimeMillis() }?.let {
+                    Timber.tag("CacheResolver").d("Using URL cache for $mediaId")
                     scope.launch(Dispatchers.IO) { recoverSong(mediaId) }
                     return@Factory dataSpec.withUri(it.first.toUri())
                 }
@@ -2730,9 +2751,10 @@ class MusicService :
     private fun createMediaSourceFactory() =
         DefaultMediaSourceFactory(
             createDataSourceFactory(),
-            ExtractorsFactory {
-                arrayOf(MatroskaExtractor(), FragmentedMp4Extractor())
-            },
+            // Use DefaultExtractorsFactory to support all audio formats including:
+            // - Local files: MP3, FLAC, OGG, AAC, WAV, etc.
+            // - YouTube streams: M4A (FragmentedMp4), WebM/OPUS (Matroska)
+            DefaultExtractorsFactory(),
         )
 
     private fun createRenderersFactory(

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -234,6 +234,9 @@ class MusicService :
     @Inject
     lateinit var widgetManager: MetrolistWidgetManager
 
+    @Inject
+    lateinit var listenTogetherManager: com.metrolist.music.listentogether.ListenTogetherManager
+
     private lateinit var audioManager: AudioManager
     private var audioFocusRequest: AudioFocusRequest? = null
     private var lastAudioFocusState = AudioManager.AUDIOFOCUS_NONE
@@ -1248,18 +1251,49 @@ class MusicService :
         }
         // Reset original queue size when starting a new queue
         originalQueueSize = 0
-        if (queue.preloadItem != null) {
-            player.setMediaItem(queue.preloadItem!!.toMediaItem())
+        // Block local preload item during Listen Together
+        val preloadItem = queue.preloadItem
+        val preloadIsLocal = preloadItem?.id?.startsWith("LOCAL_") == true
+        if (preloadItem != null && !(listenTogetherManager.isInRoom && preloadIsLocal)) {
+            player.setMediaItem(preloadItem.toMediaItem())
             player.prepare()
             player.playWhenReady = playWhenReady
+        } else if (listenTogetherManager.isInRoom && preloadIsLocal) {
+            // Show toast for blocked local preload
+            scope.launch(Dispatchers.Main) {
+                Toast.makeText(this@MusicService, R.string.local_playback_blocked_listen_together, Toast.LENGTH_LONG).show()
+            }
         }
         scope.launch(SilentHandler) {
-            val initialStatus =
+            var initialStatus =
                 withContext(Dispatchers.IO) {
                     queue.getInitialStatus()
                         .filterExplicit(dataStore.get(HideExplicitKey, false))
                         .filterVideoSongs(dataStore.get(HideVideoSongsKey, false))
                 }
+
+            // Filter out local files when Listen Together is active
+            if (listenTogetherManager.isInRoom) {
+                val originalCount = initialStatus.items.size
+                val filteredItems = initialStatus.items.filter { !it.mediaId.startsWith("LOCAL_") }
+                if (filteredItems.size < originalCount) {
+                    withContext(Dispatchers.Main) {
+                        Toast.makeText(this@MusicService, R.string.local_playback_blocked_listen_together, Toast.LENGTH_LONG).show()
+                    }
+                    if (filteredItems.isEmpty()) {
+                        return@launch
+                    }
+                    // Adjust media item index if needed
+                    val newIndex = if (initialStatus.mediaItemIndex >= filteredItems.size) 0 else {
+                        // Count how many items before original index were removed
+                        val removedBefore = initialStatus.items.take(initialStatus.mediaItemIndex)
+                            .count { it.mediaId.startsWith("LOCAL_") }
+                        (initialStatus.mediaItemIndex - removedBefore).coerceAtLeast(0)
+                    }
+                    initialStatus = initialStatus.copy(items = filteredItems, mediaItemIndex = newIndex)
+                }
+            }
+
             if (queue.preloadItem != null && player.playbackState == STATE_IDLE) return@launch
             if (initialStatus.title != null) {
                 queueTitle = initialStatus.title
@@ -2637,9 +2671,11 @@ class MusicService :
                 Timber.tag("CacheResolver").d("Database lookup for $mediaId: song=${song?.song?.title}, isLocal=${song?.song?.isLocal}, downloadUri=${song?.song?.downloadUri}")
 
                 // Use local/downloaded file directly if available
-                if (song?.song?.downloadUri != null && dataSpec.position == 0L) {
+                // For local files (isLocal=true), always use downloadUri regardless of position
+                // since local playback handles seeking internally
+                if (song?.song?.downloadUri != null && (song.song.isLocal || dataSpec.position == 0L)) {
                     val localUri = song.song.downloadUri.toUri()
-                    Timber.tag("CacheResolver").d("Using local file for $mediaId: $localUri (isLocal=${song.song.isLocal})")
+                    Timber.tag("CacheResolver").d("Using local file for $mediaId: $localUri (isLocal=${song.song.isLocal}, position=${dataSpec.position})")
                     scope.launch(Dispatchers.IO) { recoverSong(mediaId) }
                     return@Factory dataSpec.withUri(localUri)
                 }

--- a/app/src/main/kotlin/com/metrolist/music/playback/PlayerConnection.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/PlayerConnection.kt
@@ -450,6 +450,10 @@ class PlayerConnection(
     ) {
         queueWindows.value = player.getQueueWindows()
         queueTitle.value = service.queueTitle
+        // Update mediaMetadata when timeline is cleared (e.g., Listen Together blocking local content)
+        if (timeline.isEmpty) {
+            mediaMetadata.value = null
+        }
         currentMediaItemIndex.value = player.currentMediaItemIndex
         currentWindowIndex.value = player.getCurrentQueueIndex()
         updateCanSkipPreviousAndNext()

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
@@ -794,6 +794,7 @@ fun PlaylistListItem(
                     stringResource(R.string.cached_playlist) -> R.drawable.cached
                     // R.drawable.backup as placeholder
                     stringResource(R.string.uploaded_playlist) -> R.drawable.backup
+                    stringResource(R.string.filter_local) -> R.drawable.storage
                     else -> if (autoPlaylist) R.drawable.trending_up else R.drawable.queue_music
                 }
                 Icon(
@@ -894,6 +895,7 @@ fun PlaylistGridItem(
                     stringResource(R.string.cached_playlist) -> R.drawable.cached
                     // R.drawable.backup as placeholder
                     stringResource(R.string.uploaded_playlist) -> R.drawable.backup
+                    stringResource(R.string.filter_local) -> R.drawable.storage
                     else -> if (autoPlaylist) R.drawable.trending_up else R.drawable.queue_music
                 }
                 Box(

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/AlbumMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/AlbumMenu.kt
@@ -225,7 +225,8 @@ fun AlbumMenu(
                     Modifier
                         .height(ListItemHeight)
                         .clickable {
-                            navController.navigate("artist/${artist.id}")
+                            val artistRoute = if (album.album.isLocal) "local_artist/${artist.id}" else "artist/${artist.id}"
+                            navController.navigate(artistRoute)
                             showSelectArtistDialog = false
                             onDismiss()
                         }
@@ -288,6 +289,8 @@ fun AlbumMenu(
     val configuration = LocalConfiguration.current
     val isPortrait = configuration.orientation == Configuration.ORIENTATION_PORTRAIT
 
+    val isLocalAlbum = album.album.isLocal
+
     LazyColumn(
         contentPadding = PaddingValues(
             start = 0.dp,
@@ -336,8 +339,10 @@ fun AlbumMenu(
                             onClick = {
                                 onDismiss()
                                 if (songs.isNotEmpty()) {
-                                    album.album.playlistId?.let { playlistId ->
-                                        playerConnection.service.getAutomix(playlistId)
+                                    if (!isLocalAlbum) {
+                                        album.album.playlistId?.let { playlistId ->
+                                            playerConnection.service.getAutomix(playlistId)
+                                        }
                                     }
                                     playerConnection.playQueue(
                                         ListQueue(
@@ -349,29 +354,32 @@ fun AlbumMenu(
                             }
                         )
                     } else null,
-                    NewAction(
-                        icon = {
-                            Icon(
-                                painter = painterResource(R.drawable.share),
-                                contentDescription = null,
-                                modifier = Modifier.size(28.dp),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        },
-                        text = stringResource(R.string.share),
-                        onClick = {
-                            onDismiss()
-                            val intent = Intent().apply {
-                                action = Intent.ACTION_SEND
-                                type = "text/plain"
-                                putExtra(Intent.EXTRA_TEXT, "https://music.youtube.com/playlist?list=${album.album.playlistId}")
+                    // Hide share for local albums (no YouTube URL)
+                    if (!isLocalAlbum) {
+                        NewAction(
+                            icon = {
+                                Icon(
+                                    painter = painterResource(R.drawable.share),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(28.dp),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            },
+                            text = stringResource(R.string.share),
+                            onClick = {
+                                onDismiss()
+                                val intent = Intent().apply {
+                                    action = Intent.ACTION_SEND
+                                    type = "text/plain"
+                                    putExtra(Intent.EXTRA_TEXT, "https://music.youtube.com/playlist?list=${album.album.playlistId}")
+                                }
+                                context.startActivity(Intent.createChooser(intent, null))
                             }
-                            context.startActivity(Intent.createChooser(intent, null))
-                        }
-                    )
+                        )
+                    } else null
                 ),
                 modifier = Modifier.padding(horizontal = 4.dp, vertical = 16.dp),
-                columns = if (isGuest) 1 else 3
+                columns = if (isGuest) 1 else if (isLocalAlbum) 2 else 3
             )
         }
         item {
@@ -426,96 +434,99 @@ fun AlbumMenu(
             )
         }
 
-        item { Spacer(modifier = Modifier.height(12.dp)) }
+        // Hide download section for local albums (already on device)
+        if (!isLocalAlbum) {
+            item { Spacer(modifier = Modifier.height(12.dp)) }
 
-        item {
-            Material3MenuGroup(
-                items = listOf(
-                    when (downloadState) {
-                        STATE_COMPLETED -> {
-                            Material3MenuItemData(
-                                title = {
-                                    Text(
-                                        text = stringResource(R.string.remove_download)
-                                    )
-                                },
-                                icon = {
-                                    Icon(
-                                        painter = painterResource(R.drawable.offline),
-                                        contentDescription = null
-                                    )
-                                },
-                                onClick = {
-                                    songs.forEach { song ->
-                                        DownloadService.sendRemoveDownload(
-                                            context,
-                                            ExoDownloadService::class.java,
-                                            song.id,
-                                            false,
+            item {
+                Material3MenuGroup(
+                    items = listOf(
+                        when (downloadState) {
+                            STATE_COMPLETED -> {
+                                Material3MenuItemData(
+                                    title = {
+                                        Text(
+                                            text = stringResource(R.string.remove_download)
                                         )
-                                    }
-                                }
-                            )
-                        }
-                        STATE_QUEUED, STATE_DOWNLOADING -> {
-                            Material3MenuItemData(
-                                title = { Text(text = stringResource(R.string.downloading)) },
-                                icon = {
-                                    CircularProgressIndicator(
-                                        modifier = Modifier.size(24.dp),
-                                        strokeWidth = 2.dp
-                                    )
-                                },
-                                onClick = {
-                                    songs.forEach { song ->
-                                        DownloadService.sendRemoveDownload(
-                                            context,
-                                            ExoDownloadService::class.java,
-                                            song.id,
-                                            false,
+                                    },
+                                    icon = {
+                                        Icon(
+                                            painter = painterResource(R.drawable.offline),
+                                            contentDescription = null
                                         )
+                                    },
+                                    onClick = {
+                                        songs.forEach { song ->
+                                            DownloadService.sendRemoveDownload(
+                                                context,
+                                                ExoDownloadService::class.java,
+                                                song.id,
+                                                false,
+                                            )
+                                        }
                                     }
-                                }
-                            )
-                        }
-                        else -> {
-                            Material3MenuItemData(
-                                title = { Text(text = stringResource(R.string.action_download)) },
-                                description = { Text(text = stringResource(R.string.download_desc)) },
-                                icon = {
-                                    Icon(
-                                        painter = painterResource(R.drawable.download),
-                                        contentDescription = null
-                                    )
-                                },
-                                onClick = {
-                                    songs.forEach { song ->
-                                        val downloadRequest =
-                                            DownloadRequest
-                                                .Builder(song.id, song.id.toUri())
-                                                .setCustomCacheKey(song.id)
-                                                .setData(song.song.title.toByteArray())
-                                                .build()
-                                        DownloadService.sendAddDownload(
-                                            context,
-                                            ExoDownloadService::class.java,
-                                            downloadRequest,
-                                            false,
+                                )
+                            }
+                            STATE_QUEUED, STATE_DOWNLOADING -> {
+                                Material3MenuItemData(
+                                    title = { Text(text = stringResource(R.string.downloading)) },
+                                    icon = {
+                                        CircularProgressIndicator(
+                                            modifier = Modifier.size(24.dp),
+                                            strokeWidth = 2.dp
                                         )
+                                    },
+                                    onClick = {
+                                        songs.forEach { song ->
+                                            DownloadService.sendRemoveDownload(
+                                                context,
+                                                ExoDownloadService::class.java,
+                                                song.id,
+                                                false,
+                                            )
+                                        }
                                     }
-                                }
-                            )
+                                )
+                            }
+                            else -> {
+                                Material3MenuItemData(
+                                    title = { Text(text = stringResource(R.string.action_download)) },
+                                    description = { Text(text = stringResource(R.string.download_desc)) },
+                                    icon = {
+                                        Icon(
+                                            painter = painterResource(R.drawable.download),
+                                            contentDescription = null
+                                        )
+                                    },
+                                    onClick = {
+                                        songs.forEach { song ->
+                                            val downloadRequest =
+                                                DownloadRequest
+                                                    .Builder(song.id, song.id.toUri())
+                                                    .setCustomCacheKey(song.id)
+                                                    .setData(song.song.title.toByteArray())
+                                                    .build()
+                                            DownloadService.sendAddDownload(
+                                                context,
+                                                ExoDownloadService::class.java,
+                                                downloadRequest,
+                                                false,
+                                            )
+                                        }
+                                    }
+                                )
+                            }
                         }
-                    }
+                    )
                 )
-            )
+            }
         }
 
         item { Spacer(modifier = Modifier.height(12.dp)) }
 
         item {
             Material3MenuGroup(
-                items = listOf(
+                items = listOfNotNull(
                     Material3MenuItemData(
                         title = { Text(text = stringResource(R.string.view_artist)) },
                         description = { Text(text = album.artists.joinToString { it.name }) },
@@ -527,34 +538,38 @@ fun AlbumMenu(
                         },
                         onClick = {
                             if (album.artists.size == 1) {
-                                navController.navigate("artist/${album.artists[0].id}")
+                                val artistRoute = if (isLocalAlbum) "local_artist/${album.artists[0].id}" else "artist/${album.artists[0].id}"
+                                navController.navigate(artistRoute)
                                 onDismiss()
                             } else {
                                 showSelectArtistDialog = true
                             }
                         }
                     ),
-                    Material3MenuItemData(
-                        title = { Text(text = stringResource(R.string.refetch)) },
-                        description = { Text(text = stringResource(R.string.refetch_desc)) },
-                        icon = {
-                            Icon(
-                                painter = painterResource(R.drawable.sync),
-                                contentDescription = null,
-                                modifier = Modifier.graphicsLayer(rotationZ = rotationAnimation)
-                            )
-                        },
-                        onClick = {
-                            refetchIconDegree -= 360
-                            scope.launch(Dispatchers.IO) {
-                                YouTube.album(album.id).onSuccess {
-                                    database.transaction {
-                                        update(album.album, it, album.artists)
+                    // Hide refetch for local albums
+                    if (!isLocalAlbum) {
+                        Material3MenuItemData(
+                            title = { Text(text = stringResource(R.string.refetch)) },
+                            description = { Text(text = stringResource(R.string.refetch_desc)) },
+                            icon = {
+                                Icon(
+                                    painter = painterResource(R.drawable.sync),
+                                    contentDescription = null,
+                                    modifier = Modifier.graphicsLayer(rotationZ = rotationAnimation)
+                                )
+                            },
+                            onClick = {
+                                refetchIconDegree -= 360
+                                scope.launch(Dispatchers.IO) {
+                                    YouTube.album(album.id).onSuccess {
+                                        database.transaction {
+                                            update(album.album, it, album.artists)
+                                        }
                                     }
                                 }
                             }
-                        }
-                    )
+                        )
+                    } else null
                 )
             )
         }

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/PlayerMenu.kt
@@ -284,7 +284,8 @@ fun PlayerMenu(
             val startingRadioText = stringResource(R.string.starting_radio)
             NewActionGrid(
                 actions = listOfNotNull(
-                    if (!isListenTogetherGuest) {
+                    // Hide start radio for local songs (requires YouTube)
+                    if (!isListenTogetherGuest && librarySong?.song?.isLocal != true) {
                         NewAction(
                             icon = {
                                 Icon(
@@ -431,87 +432,90 @@ fun PlayerMenu(
 
         item { Spacer(modifier = Modifier.height(12.dp)) }
 
-        item {
-            Material3MenuGroup(
-                items = listOf(
-                    when (download?.state) {
-                        Download.STATE_COMPLETED -> {
-                            Material3MenuItemData(
-                                title = {
-                                    Text(
-                                        text = stringResource(R.string.remove_download)
-                                    )
-                                },
-                                icon = {
-                                    Icon(
-                                        painter = painterResource(R.drawable.offline),
-                                        contentDescription = null,
-                                        modifier = Modifier.size(24.dp)
-                                    )
-                                },
-                                onClick = {
-                                    DownloadService.sendRemoveDownload(
-                                        context,
-                                        ExoDownloadService::class.java,
-                                        mediaMetadata.id,
-                                        false,
-                                    )
-                                }
-                            )
-                        }
-
-                        Download.STATE_QUEUED, Download.STATE_DOWNLOADING -> {
-                            Material3MenuItemData(
-                                title = { Text(text = stringResource(R.string.downloading)) },
-                                icon = {
-                                    CircularProgressIndicator(
-                                        modifier = Modifier.size(24.dp),
-                                        strokeWidth = 2.dp
-                                    )
-                                },
-                                onClick = {
-                                    DownloadService.sendRemoveDownload(
-                                        context,
-                                        ExoDownloadService::class.java,
-                                        mediaMetadata.id,
-                                        false,
-                                    )
-                                }
-                            )
-                        }
-
-                        else -> {
-                            Material3MenuItemData(
-                                title = { Text(text = stringResource(R.string.action_download)) },
-                                icon = {
-                                    Icon(
-                                        painter = painterResource(R.drawable.download),
-                                        contentDescription = null,
-                                        modifier = Modifier.size(24.dp)
-                                    )
-                                },
-                                onClick = {
-                                    database.transaction {
-                                        insert(mediaMetadata)
+        // Hide download option for local songs (they're already on device)
+        if (librarySong?.song?.isLocal != true) {
+            item {
+                Material3MenuGroup(
+                    items = listOf(
+                        when (download?.state) {
+                            Download.STATE_COMPLETED -> {
+                                Material3MenuItemData(
+                                    title = {
+                                        Text(
+                                            text = stringResource(R.string.remove_download)
+                                        )
+                                    },
+                                    icon = {
+                                        Icon(
+                                            painter = painterResource(R.drawable.offline),
+                                            contentDescription = null,
+                                            modifier = Modifier.size(24.dp)
+                                        )
+                                    },
+                                    onClick = {
+                                        DownloadService.sendRemoveDownload(
+                                            context,
+                                            ExoDownloadService::class.java,
+                                            mediaMetadata.id,
+                                            false,
+                                        )
                                     }
-                                    val downloadRequest =
-                                        DownloadRequest
-                                            .Builder(mediaMetadata.id, mediaMetadata.id.toUri())
-                                            .setCustomCacheKey(mediaMetadata.id)
-                                            .setData(mediaMetadata.title.toByteArray())
-                                            .build()
-                                    DownloadService.sendAddDownload(
-                                        context,
-                                        ExoDownloadService::class.java,
-                                        downloadRequest,
-                                        false,
-                                    )
-                                }
-                            )
+                                )
+                            }
+
+                            Download.STATE_QUEUED, Download.STATE_DOWNLOADING -> {
+                                Material3MenuItemData(
+                                    title = { Text(text = stringResource(R.string.downloading)) },
+                                    icon = {
+                                        CircularProgressIndicator(
+                                            modifier = Modifier.size(24.dp),
+                                            strokeWidth = 2.dp
+                                        )
+                                    },
+                                    onClick = {
+                                        DownloadService.sendRemoveDownload(
+                                            context,
+                                            ExoDownloadService::class.java,
+                                            mediaMetadata.id,
+                                            false,
+                                        )
+                                    }
+                                )
+                            }
+
+                            else -> {
+                                Material3MenuItemData(
+                                    title = { Text(text = stringResource(R.string.action_download)) },
+                                    icon = {
+                                        Icon(
+                                            painter = painterResource(R.drawable.download),
+                                            contentDescription = null,
+                                            modifier = Modifier.size(24.dp)
+                                        )
+                                    },
+                                    onClick = {
+                                        database.transaction {
+                                            insert(mediaMetadata)
+                                        }
+                                        val downloadRequest =
+                                            DownloadRequest
+                                                .Builder(mediaMetadata.id, mediaMetadata.id.toUri())
+                                                .setCustomCacheKey(mediaMetadata.id)
+                                                .setData(mediaMetadata.title.toByteArray())
+                                                .build()
+                                        DownloadService.sendAddDownload(
+                                            context,
+                                            ExoDownloadService::class.java,
+                                            downloadRequest,
+                                            false,
+                                        )
+                                    }
+                                )
+                            }
                         }
-                    }
+                    )
                 )
-            )
+            }
         }
 
         item { Spacer(modifier = Modifier.height(12.dp)) }

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/PlayerMenu.kt
@@ -398,34 +398,36 @@ fun PlayerMenu(
                             )
                         )
                     }
-                    // Add to Library option
-                    val isInLibrary = librarySong?.song?.inLibrary != null
-                    add(
-                        Material3MenuItemData(
-                            title = { 
-                                Text(
-                                    text = stringResource(
-                                        if (isInLibrary) R.string.remove_from_library
-                                        else R.string.add_to_library
+                    // Add to Library option (not for local songs - they're always in library)
+                    if (librarySong?.song?.isLocal != true) {
+                        val isInLibrary = librarySong?.song?.inLibrary != null
+                        add(
+                            Material3MenuItemData(
+                                title = {
+                                    Text(
+                                        text = stringResource(
+                                            if (isInLibrary) R.string.remove_from_library
+                                            else R.string.add_to_library
+                                        )
                                     )
-                                )
-                            },
-                            icon = {
-                                Icon(
-                                    painter = painterResource(
-                                        if (isInLibrary) R.drawable.library_add_check
-                                        else R.drawable.library_add
-                                    ),
-                                    contentDescription = null,
-                                    modifier = Modifier.size(24.dp)
-                                )
-                            },
-                            onClick = {
-                                playerConnection.toggleLibrary()
-                                onDismiss()
-                            }
+                                },
+                                icon = {
+                                    Icon(
+                                        painter = painterResource(
+                                            if (isInLibrary) R.drawable.library_add_check
+                                            else R.drawable.library_add
+                                        ),
+                                        contentDescription = null,
+                                        modifier = Modifier.size(24.dp)
+                                    )
+                                },
+                                onClick = {
+                                    playerConnection.toggleLibrary()
+                                    onDismiss()
+                                }
+                            )
                         )
-                    )
+                    }
                 }
             )
         }

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/PlayerMenu.kt
@@ -522,41 +522,43 @@ fun PlayerMenu(
 
         item { Spacer(modifier = Modifier.height(12.dp)) }
 
-        item {
-            Material3MenuGroup(
-                items = buildList {
-                    add(
-                        Material3MenuItemData(
-                            title = { Text(text = stringResource(R.string.listen_together)) },
-                            icon = {
-                                // Show a small badge when there are pending suggestions
-                                Box {
-                                    Icon(
-                                        painter = painterResource(R.drawable.group),
-                                        contentDescription = null,
-                                        modifier = Modifier.size(24.dp)
-                                    )
-                                    if (pendingSuggestions.isNotEmpty()) {
-                                        Surface(
-                                            shape = RoundedCornerShape(12.dp),
-                                            color = MaterialTheme.colorScheme.primary,
-                                            modifier = Modifier
-                                                .offset(x = 8.dp, y = (-6).dp)
-                                                .align(Alignment.TopEnd)
-                                        ) {
-                                            Text(
-                                                text = pendingSuggestions.size.toString(),
-                                                color = MaterialTheme.colorScheme.onPrimary,
-                                                modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
-                                                style = MaterialTheme.typography.labelSmall
-                                            )
+        // Only show Listen Together section if current song is not local
+        if (librarySong?.song?.isLocal != true) {
+            item {
+                Material3MenuGroup(
+                    items = buildList {
+                        add(
+                            Material3MenuItemData(
+                                title = { Text(text = stringResource(R.string.listen_together)) },
+                                icon = {
+                                    // Show a small badge when there are pending suggestions
+                                    Box {
+                                        Icon(
+                                            painter = painterResource(R.drawable.group),
+                                            contentDescription = null,
+                                            modifier = Modifier.size(24.dp)
+                                        )
+                                        if (pendingSuggestions.isNotEmpty()) {
+                                            Surface(
+                                                shape = RoundedCornerShape(12.dp),
+                                                color = MaterialTheme.colorScheme.primary,
+                                                modifier = Modifier
+                                                    .offset(x = 8.dp, y = (-6).dp)
+                                                    .align(Alignment.TopEnd)
+                                            ) {
+                                                Text(
+                                                    text = pendingSuggestions.size.toString(),
+                                                    color = MaterialTheme.colorScheme.onPrimary,
+                                                    modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+                                                    style = MaterialTheme.typography.labelSmall
+                                                )
+                                            }
                                         }
                                     }
-                                }
-                            },
-                            onClick = { showListenTogetherDialog = true }
+                                },
+                                onClick = { showListenTogetherDialog = true }
+                            )
                         )
-                    )
                     if (isListenTogetherGuest) {
                         add(
                             Material3MenuItemData(
@@ -578,6 +580,7 @@ fun PlayerMenu(
                 }
             )
         }
+        } // End of isLocal check for Listen Together
 
         item { Spacer(modifier = Modifier.height(12.dp)) }
 

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/QueueMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/QueueMenu.kt
@@ -233,24 +233,27 @@ fun QueueMenu(
         // Quick actions grid
         item {
             NewActionGrid(
-                actions = listOf(
-                    NewAction(
-                        icon = {
-                            Icon(
-                                painter = painterResource(R.drawable.radio),
-                                contentDescription = null,
-                                modifier = Modifier.size(28.dp),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        },
-                        text = stringResource(R.string.start_radio),
-                        onClick = {
-                            onDismiss()
-                            playerConnection.playQueue(
-                                YouTubeQueue.radio(mediaMetadata)
-                            )
-                        }
-                    ),
+                actions = listOfNotNull(
+                    // Hide start radio for local songs (requires YouTube)
+                    if (librarySong?.song?.isLocal != true) {
+                        NewAction(
+                            icon = {
+                                Icon(
+                                    painter = painterResource(R.drawable.radio),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(28.dp),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            },
+                            text = stringResource(R.string.start_radio),
+                            onClick = {
+                                onDismiss()
+                                playerConnection.playQueue(
+                                    YouTubeQueue.radio(mediaMetadata)
+                                )
+                            }
+                        )
+                    } else null,
                     NewAction(
                         icon = {
                             Icon(
@@ -263,29 +266,32 @@ fun QueueMenu(
                         text = stringResource(R.string.add_to_playlist),
                         onClick = { showChoosePlaylistDialog = true }
                     ),
-                    NewAction(
-                        icon = {
-                            Icon(
-                                painter = painterResource(R.drawable.share),
-                                contentDescription = null,
-                                modifier = Modifier.size(28.dp),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        },
-                        text = stringResource(R.string.share),
-                        onClick = {
-                            onDismiss()
-                            val intent = Intent().apply {
-                                action = Intent.ACTION_SEND
-                                type = "text/plain"
-                                putExtra(
-                                    Intent.EXTRA_TEXT,
-                                    "https://music.youtube.com/watch?v=${mediaMetadata.id}"
+                    // Hide share for local songs (shares YouTube URL)
+                    if (librarySong?.song?.isLocal != true) {
+                        NewAction(
+                            icon = {
+                                Icon(
+                                    painter = painterResource(R.drawable.share),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(28.dp),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant
                                 )
+                            },
+                            text = stringResource(R.string.share),
+                            onClick = {
+                                onDismiss()
+                                val intent = Intent().apply {
+                                    action = Intent.ACTION_SEND
+                                    type = "text/plain"
+                                    putExtra(
+                                        Intent.EXTRA_TEXT,
+                                        "https://music.youtube.com/watch?v=${mediaMetadata.id}"
+                                    )
+                                }
+                                context.startActivity(Intent.createChooser(intent, null))
                             }
-                            context.startActivity(Intent.createChooser(intent, null))
-                        }
-                    )
+                        )
+                    } else null
                 ),
                 modifier = Modifier.padding(horizontal = 4.dp, vertical = 16.dp)
             )
@@ -337,87 +343,89 @@ fun QueueMenu(
 
         item { Spacer(modifier = Modifier.height(12.dp)) }
 
-        // Download section
-        item {
-            Material3MenuGroup(
-                items = listOf(
-                    when (download?.state) {
-                        Download.STATE_COMPLETED -> {
-                            Material3MenuItemData(
-                                title = {
-                                    Text(text = stringResource(R.string.remove_download))
-                                },
-                                icon = {
-                                    Icon(
-                                        painter = painterResource(R.drawable.offline),
-                                        contentDescription = null,
-                                        modifier = Modifier.size(24.dp)
-                                    )
-                                },
-                                onClick = {
-                                    DownloadService.sendRemoveDownload(
-                                        context,
-                                        ExoDownloadService::class.java,
-                                        mediaMetadata.id,
-                                        false,
-                                    )
-                                }
-                            )
-                        }
-
-                        Download.STATE_QUEUED, Download.STATE_DOWNLOADING -> {
-                            Material3MenuItemData(
-                                title = { Text(text = stringResource(R.string.downloading)) },
-                                icon = {
-                                    CircularProgressIndicator(
-                                        modifier = Modifier.size(24.dp),
-                                        strokeWidth = 2.dp
-                                    )
-                                },
-                                onClick = {
-                                    DownloadService.sendRemoveDownload(
-                                        context,
-                                        ExoDownloadService::class.java,
-                                        mediaMetadata.id,
-                                        false,
-                                    )
-                                }
-                            )
-                        }
-
-                        else -> {
-                            Material3MenuItemData(
-                                title = { Text(text = stringResource(R.string.action_download)) },
-                                description = { Text(text = stringResource(R.string.download_desc)) },
-                                icon = {
-                                    Icon(
-                                        painter = painterResource(R.drawable.download),
-                                        contentDescription = null,
-                                        modifier = Modifier.size(24.dp)
-                                    )
-                                },
-                                onClick = {
-                                    database.transaction {
-                                        insert(mediaMetadata)
+        // Download section - hide for local songs (they're already on device)
+        if (librarySong?.song?.isLocal != true) {
+            item {
+                Material3MenuGroup(
+                    items = listOf(
+                        when (download?.state) {
+                            Download.STATE_COMPLETED -> {
+                                Material3MenuItemData(
+                                    title = {
+                                        Text(text = stringResource(R.string.remove_download))
+                                    },
+                                    icon = {
+                                        Icon(
+                                            painter = painterResource(R.drawable.offline),
+                                            contentDescription = null,
+                                            modifier = Modifier.size(24.dp)
+                                        )
+                                    },
+                                    onClick = {
+                                        DownloadService.sendRemoveDownload(
+                                            context,
+                                            ExoDownloadService::class.java,
+                                            mediaMetadata.id,
+                                            false,
+                                        )
                                     }
-                                    val downloadRequest =
-                                        DownloadRequest
-                                            .Builder(mediaMetadata.id, mediaMetadata.id.toUri())
-                                            .setCustomCacheKey(mediaMetadata.id)
-                                            .setData(mediaMetadata.title.toByteArray())
-                                            .build()
-                                    DownloadService.sendAddDownload(
-                                        context,
-                                        ExoDownloadService::class.java,
-                                        downloadRequest,
-                                        false,
-                                    )
-                                }
-                            )
+                                )
+                            }
+
+                            Download.STATE_QUEUED, Download.STATE_DOWNLOADING -> {
+                                Material3MenuItemData(
+                                    title = { Text(text = stringResource(R.string.downloading)) },
+                                    icon = {
+                                        CircularProgressIndicator(
+                                            modifier = Modifier.size(24.dp),
+                                            strokeWidth = 2.dp
+                                        )
+                                    },
+                                    onClick = {
+                                        DownloadService.sendRemoveDownload(
+                                            context,
+                                            ExoDownloadService::class.java,
+                                            mediaMetadata.id,
+                                            false,
+                                        )
+                                    }
+                                )
+                            }
+
+                            else -> {
+                                Material3MenuItemData(
+                                    title = { Text(text = stringResource(R.string.action_download)) },
+                                    description = { Text(text = stringResource(R.string.download_desc)) },
+                                    icon = {
+                                        Icon(
+                                            painter = painterResource(R.drawable.download),
+                                            contentDescription = null,
+                                            modifier = Modifier.size(24.dp)
+                                        )
+                                    },
+                                    onClick = {
+                                        database.transaction {
+                                            insert(mediaMetadata)
+                                        }
+                                        val downloadRequest =
+                                            DownloadRequest
+                                                .Builder(mediaMetadata.id, mediaMetadata.id.toUri())
+                                                .setCustomCacheKey(mediaMetadata.id)
+                                                .setData(mediaMetadata.title.toByteArray())
+                                                .build()
+                                        DownloadService.sendAddDownload(
+                                            context,
+                                            ExoDownloadService::class.java,
+                                            downloadRequest,
+                                            false,
+                                        )
+                                    }
+                                )
+                            }
                         }
-                    }
+                    )
                 )
-            )
+            }
         }
 
         item { Spacer(modifier = Modifier.height(12.dp)) }

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/SongMenu.kt
@@ -413,7 +413,8 @@ fun SongMenu(
                             }
                         )
                     } else null,
-                    if (!isGuest) {
+                    // Hide start radio for local songs (requires YouTube)
+                    if (!isGuest && !song.song.isLocal) {
                         Material3MenuItemData(
                             title = { Text(text = stringResource(R.string.start_radio)) },
                             description = { Text(text = stringResource(R.string.start_radio_desc)) },
@@ -585,81 +586,84 @@ fun SongMenu(
 
         item { Spacer(modifier = Modifier.height(12.dp)) }
 
-        item {
-            Material3MenuGroup(
-                items = listOf(
-                    when (download?.state) {
-                        Download.STATE_COMPLETED -> {
-                            Material3MenuItemData(
-                                title = {
-                                    Text(
-                                        text = stringResource(R.string.remove_download)
-                                    )
-                                },
-                                icon = {
-                                    Icon(
-                                        painter = painterResource(R.drawable.offline),
-                                        contentDescription = null
-                                    )
-                                },
-                                onClick = {
-                                    DownloadService.sendRemoveDownload(
-                                        context,
-                                        ExoDownloadService::class.java,
-                                        song.id,
-                                        false,
-                                    )
-                                }
-                            )
+        // Hide download option for local songs (they're already on device)
+        if (!song.song.isLocal) {
+            item {
+                Material3MenuGroup(
+                    items = listOf(
+                        when (download?.state) {
+                            Download.STATE_COMPLETED -> {
+                                Material3MenuItemData(
+                                    title = {
+                                        Text(
+                                            text = stringResource(R.string.remove_download)
+                                        )
+                                    },
+                                    icon = {
+                                        Icon(
+                                            painter = painterResource(R.drawable.offline),
+                                            contentDescription = null
+                                        )
+                                    },
+                                    onClick = {
+                                        DownloadService.sendRemoveDownload(
+                                            context,
+                                            ExoDownloadService::class.java,
+                                            song.id,
+                                            false,
+                                        )
+                                    }
+                                )
+                            }
+                            Download.STATE_QUEUED, Download.STATE_DOWNLOADING -> {
+                                Material3MenuItemData(
+                                    title = { Text(text = stringResource(R.string.downloading)) },
+                                    icon = {
+                                        CircularProgressIndicator(
+                                            modifier = Modifier.size(24.dp),
+                                            strokeWidth = 2.dp
+                                        )
+                                    },
+                                    onClick = {
+                                        DownloadService.sendRemoveDownload(
+                                            context,
+                                            ExoDownloadService::class.java,
+                                            song.id,
+                                            false,
+                                        )
+                                    }
+                                )
+                            }
+                            else -> {
+                                Material3MenuItemData(
+                                    title = { Text(text = stringResource(R.string.action_download)) },
+                                    description = { Text(text = stringResource(R.string.download_desc)) },
+                                    icon = {
+                                        Icon(
+                                            painter = painterResource(R.drawable.download),
+                                            contentDescription = null,
+                                        )
+                                    },
+                                    onClick = {
+                                        val downloadRequest =
+                                            DownloadRequest
+                                                .Builder(song.id, song.id.toUri())
+                                                .setCustomCacheKey(song.id)
+                                                .setData(song.song.title.toByteArray())
+                                                .build()
+                                        DownloadService.sendAddDownload(
+                                            context,
+                                            ExoDownloadService::class.java,
+                                            downloadRequest,
+                                            false,
+                                        )
+                                    }
+                                )
+                            }
                         }
-                        Download.STATE_QUEUED, Download.STATE_DOWNLOADING -> {
-                            Material3MenuItemData(
-                                title = { Text(text = stringResource(R.string.downloading)) },
-                                icon = {
-                                    CircularProgressIndicator(
-                                        modifier = Modifier.size(24.dp),
-                                        strokeWidth = 2.dp
-                                    )
-                                },
-                                onClick = {
-                                    DownloadService.sendRemoveDownload(
-                                        context,
-                                        ExoDownloadService::class.java,
-                                        song.id,
-                                        false,
-                                    )
-                                }
-                            )
-                        }
-                        else -> {
-                            Material3MenuItemData(
-                                title = { Text(text = stringResource(R.string.action_download)) },
-                                description = { Text(text = stringResource(R.string.download_desc)) },
-                                icon = {
-                                    Icon(
-                                        painter = painterResource(R.drawable.download),
-                                        contentDescription = null,
-                                    )
-                                },
-                                onClick = {
-                                    val downloadRequest =
-                                        DownloadRequest
-                                            .Builder(song.id, song.id.toUri())
-                                            .setCustomCacheKey(song.id)
-                                            .setData(song.song.title.toByteArray())
-                                            .build()
-                                    DownloadService.sendAddDownload(
-                                        context,
-                                        ExoDownloadService::class.java,
-                                        downloadRequest,
-                                        false,
-                                    )
-                                }
-                            )
-                        }
-                    }
+                    )
                 )
-            )
+            }
         }
 
         item { Spacer(modifier = Modifier.height(12.dp)) }

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/SongMenu.kt
@@ -471,44 +471,47 @@ fun SongMenu(
         item {
             Material3MenuGroup(
                 items = buildList {
-                    add(
-                        Material3MenuItemData(
-                            title = {
-                                Text(
-                                    text = stringResource(
-                                        if (song.song.inLibrary == null) R.string.add_to_library
-                                        else R.string.remove_from_library
+                    // Hide add/remove from library for local songs (they're always in library)
+                    if (!song.song.isLocal) {
+                        add(
+                            Material3MenuItemData(
+                                title = {
+                                    Text(
+                                        text = stringResource(
+                                            if (song.song.inLibrary == null) R.string.add_to_library
+                                            else R.string.remove_from_library
+                                        )
                                     )
-                                )
-                            },
-                            description = { Text(text = stringResource(R.string.add_to_library_desc)) },
-                            icon = {
-                                Icon(
-                                    painter = painterResource(
-                                        if (song.song.inLibrary == null) R.drawable.library_add
-                                        else R.drawable.library_add_check
-                                    ),
-                                    contentDescription = null,
-                                )
-                            },
-                            onClick = {
-                                val currentSong = song.song
-                                val isInLibrary = currentSong.inLibrary != null
-                                val token =
-                                    if (isInLibrary) currentSong.libraryRemoveToken else currentSong.libraryAddToken
+                                },
+                                description = { Text(text = stringResource(R.string.add_to_library_desc)) },
+                                icon = {
+                                    Icon(
+                                        painter = painterResource(
+                                            if (song.song.inLibrary == null) R.drawable.library_add
+                                            else R.drawable.library_add_check
+                                        ),
+                                        contentDescription = null,
+                                    )
+                                },
+                                onClick = {
+                                    val currentSong = song.song
+                                    val isInLibrary = currentSong.inLibrary != null
+                                    val token =
+                                        if (isInLibrary) currentSong.libraryRemoveToken else currentSong.libraryAddToken
 
-                                token?.let {
-                                    coroutineScope.launch {
-                                        YouTube.feedback(listOf(it))
+                                    token?.let {
+                                        coroutineScope.launch {
+                                            YouTube.feedback(listOf(it))
+                                        }
+                                    }
+
+                                    database.query {
+                                        update(song.song.toggleLibrary())
                                     }
                                 }
-
-                                database.query {
-                                    update(song.song.toggleLibrary())
-                                }
-                            }
+                            )
                         )
-                    )
+                    }
                     if (event != null) {
                         add(
                             Material3MenuItemData(

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/SongMenu.kt
@@ -326,6 +326,8 @@ fun SongMenu(
     val isPortrait = configuration.orientation == Configuration.ORIENTATION_PORTRAIT
 
     val isGuest = listenTogetherManager?.isInRoom == true && !listenTogetherManager.isHost
+    // Block queue modifications for local songs when in Listen Together (local files can't be synced)
+    val isLocalInListenTogether = listenTogetherManager?.isInRoom == true && song.song.isLocal
 
     LazyColumn(
         contentPadding = PaddingValues(
@@ -430,7 +432,7 @@ fun SongMenu(
                             }
                         )
                     } else null,
-                    if (!isGuest) {
+                    if (!isGuest && !isLocalInListenTogether) {
                         Material3MenuItemData(
                             title = { Text(text = stringResource(R.string.play_next)) },
                             description = { Text(text = stringResource(R.string.play_next_desc)) },
@@ -446,7 +448,7 @@ fun SongMenu(
                             }
                         )
                     } else null,
-                    if (!isGuest) {
+                    if (!isGuest && !isLocalInListenTogether) {
                         Material3MenuItemData(
                             title = { Text(text = stringResource(R.string.add_to_queue)) },
                             description = { Text(text = stringResource(R.string.add_to_queue_desc)) },

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/NavigationBuilder.kt
@@ -31,6 +31,9 @@ import com.metrolist.music.ui.screens.artist.ArtistScreen
 import com.metrolist.music.ui.screens.artist.ArtistSongsScreen
 import com.metrolist.music.ui.screens.equalizer.EqScreen
 import com.metrolist.music.ui.screens.library.LibraryScreen
+import com.metrolist.music.ui.screens.library.LocalAlbumScreen
+import com.metrolist.music.ui.screens.library.LocalArtistScreen
+import com.metrolist.music.ui.screens.library.LocalMusicScreen
 import com.metrolist.music.ui.screens.playlist.AutoPlaylistScreen
 import com.metrolist.music.ui.screens.playlist.CachePlaylistScreen
 import com.metrolist.music.ui.screens.playlist.LocalPlaylistScreen
@@ -205,6 +208,34 @@ fun NavGraphBuilder.navigationBuilder(
         ),
     ) {
         ArtistSongsScreen(navController, scrollBehavior)
+    }
+
+    composable(
+        route = "local_music",
+    ) {
+        LocalMusicScreen(navController, scrollBehavior)
+    }
+
+    composable(
+        route = "local_artist/{artistId}",
+        arguments = listOf(
+            navArgument("artistId") {
+                type = NavType.StringType
+            },
+        ),
+    ) {
+        LocalArtistScreen(navController, scrollBehavior)
+    }
+
+    composable(
+        route = "local_album/{albumId}",
+        arguments = listOf(
+            navArgument("albumId") {
+                type = NavType.StringType
+            },
+        ),
+    ) {
+        LocalAlbumScreen(navController, scrollBehavior)
     }
 
     composable(

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/NavigationBuilder.kt
@@ -33,6 +33,7 @@ import com.metrolist.music.ui.screens.equalizer.EqScreen
 import com.metrolist.music.ui.screens.library.LibraryScreen
 import com.metrolist.music.ui.screens.library.LocalAlbumScreen
 import com.metrolist.music.ui.screens.library.LocalArtistScreen
+import com.metrolist.music.ui.screens.library.LocalFolderScreen
 import com.metrolist.music.ui.screens.library.LocalMusicScreen
 import com.metrolist.music.ui.screens.playlist.AutoPlaylistScreen
 import com.metrolist.music.ui.screens.playlist.CachePlaylistScreen
@@ -236,6 +237,23 @@ fun NavGraphBuilder.navigationBuilder(
         ),
     ) {
         LocalAlbumScreen(navController, scrollBehavior)
+    }
+
+    composable(
+        route = "local_folder/{folderPath}",
+        arguments = listOf(
+            navArgument("folderPath") {
+                type = NavType.StringType
+            },
+        ),
+    ) {
+        LocalFolderScreen(
+            navController = navController,
+            scrollBehavior = scrollBehavior,
+            folderPath = it.arguments?.getString("folderPath")?.let { path ->
+                java.net.URLDecoder.decode(path, "UTF-8")
+            } ?: ""
+        )
     }
 
     composable(

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryMixScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryMixScreen.kt
@@ -61,6 +61,7 @@ import com.metrolist.music.constants.MixSortTypeKey
 import com.metrolist.music.constants.ShowCachedPlaylistKey
 import com.metrolist.music.constants.ShowDownloadedPlaylistKey
 import com.metrolist.music.constants.ShowLikedPlaylistKey
+import com.metrolist.music.constants.ShowLocalPlaylistKey
 import com.metrolist.music.constants.ShowTopPlaylistKey
 import com.metrolist.music.constants.ShowUploadedPlaylistKey
 import com.metrolist.music.constants.YtmSyncKey
@@ -164,11 +165,22 @@ fun LibraryMixScreen(
             songThumbnails = emptyList(),
         )
 
+    val localPlaylist =
+        Playlist(
+            playlist = PlaylistEntity(
+                id = UUID.randomUUID().toString(),
+                name = stringResource(R.string.filter_local)
+            ),
+            songCount = 0,
+            songThumbnails = emptyList(),
+        )
+
     val (showLiked) = rememberPreference(ShowLikedPlaylistKey, true)
     val (showDownloaded) = rememberPreference(ShowDownloadedPlaylistKey, true)
     val (showTop) = rememberPreference(ShowTopPlaylistKey, true)
     val (showCached) = rememberPreference(ShowCachedPlaylistKey, true)
     val (showUploaded) = rememberPreference(ShowUploadedPlaylistKey, true)
+    val (showLocal) = rememberPreference(ShowLocalPlaylistKey, true)
 
     val albums = viewModel.albums.collectAsState()
     val artist = viewModel.artists.collectAsState()
@@ -400,6 +412,25 @@ fun LibraryMixScreen(
                                         .fillMaxWidth()
                                         .clickable {
                                             navController.navigate("auto_playlist/uploaded")
+                                        }
+                                        .animateItem(),
+                            )
+                        }
+                    }
+
+                    if (showLocal) {
+                        item(
+                            key = "localPlaylist",
+                            contentType = { CONTENT_TYPE_PLAYLIST },
+                        ) {
+                            PlaylistListItem(
+                                playlist = localPlaylist,
+                                autoPlaylist = true,
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .clickable {
+                                            navController.navigate("local_music")
                                         }
                                         .animateItem(),
                             )
@@ -675,6 +706,26 @@ fun LibraryMixScreen(
                                         .fillMaxWidth()
                                         .clickable {
                                             navController.navigate("auto_playlist/uploaded")
+                                        }
+                                        .animateItem(),
+                            )
+                        }
+                    }
+
+                    if (showLocal) {
+                        item(
+                            key = "localPlaylist",
+                            contentType = { CONTENT_TYPE_PLAYLIST },
+                        ) {
+                            PlaylistGridItem(
+                                playlist = localPlaylist,
+                                fillMaxWidth = true,
+                                autoPlaylist = true,
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .clickable {
+                                            navController.navigate("local_music")
                                         }
                                         .animateItem(),
                             )

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryScreen.kt
@@ -65,6 +65,11 @@ fun LibraryScreen(navController: NavController) {
             LibraryFilter.ARTISTS -> LibraryArtistsScreen(
                 navController,
                 { filterType = LibraryFilter.LIBRARY })
+
+            LibraryFilter.LOCAL -> {
+                // LOCAL is accessed via the Local box in LibraryMixScreen, not via chip
+                // This case shouldn't be reached in normal flow
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalAlbumScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalAlbumScreen.kt
@@ -1,0 +1,294 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.ui.screens.library
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import coil3.compose.AsyncImage
+import com.metrolist.music.LocalPlayerAwareWindowInsets
+import com.metrolist.music.LocalPlayerConnection
+import com.metrolist.music.R
+import com.metrolist.music.constants.CONTENT_TYPE_HEADER
+import com.metrolist.music.constants.CONTENT_TYPE_SONG
+import com.metrolist.music.constants.ThumbnailCornerRadius
+import com.metrolist.music.extensions.toMediaItem
+import com.metrolist.music.playback.queues.ListQueue
+import com.metrolist.music.ui.component.EmptyPlaceholder
+import com.metrolist.music.ui.component.LocalMenuState
+import com.metrolist.music.ui.component.SongListItem
+import com.metrolist.music.ui.menu.SongMenu
+import com.metrolist.music.utils.makeTimeString
+import com.metrolist.music.viewmodels.LocalAlbumViewModel
+import timber.log.Timber
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@Composable
+fun LocalAlbumScreen(
+    navController: NavController,
+    scrollBehavior: TopAppBarScrollBehavior,
+    viewModel: LocalAlbumViewModel = hiltViewModel(),
+) {
+    val menuState = LocalMenuState.current
+    val playerConnection = LocalPlayerConnection.current ?: return
+
+    val album by viewModel.album.collectAsState()
+    val songs by viewModel.songs.collectAsState()
+
+    Timber.d("LocalAlbumScreen: COMPOSE - album=${album?.album?.title}, songCount=${songs.size}")
+
+    val totalDuration = songs.sumOf { it.song.duration }
+    Timber.d("LocalAlbumScreen: totalDuration=$totalDuration seconds")
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .nestedScroll(scrollBehavior.nestedScrollConnection)
+    ) {
+        LazyColumn(
+            contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues(),
+        ) {
+            item(key = "header", contentType = CONTENT_TYPE_HEADER) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    AsyncImage(
+                        model = album?.album?.thumbnailUrl,
+                        contentDescription = null,
+                        modifier = Modifier
+                            .size(200.dp)
+                            .clip(RoundedCornerShape(ThumbnailCornerRadius))
+                    )
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    Text(
+                        text = album?.album?.title ?: "",
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+
+                    album?.artists?.firstOrNull()?.let { artist ->
+                        Text(
+                            text = artist.name,
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.secondary,
+                            modifier = Modifier.padding(top = 4.dp)
+                        )
+                    }
+
+                    Row(
+                        modifier = Modifier.padding(top = 8.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        album?.album?.year?.let { year ->
+                            Text(
+                                text = year.toString(),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        Text(
+                            text = pluralStringResource(R.plurals.n_song, songs.size, songs.size),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Text(
+                            text = makeTimeString(totalDuration * 1000L),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        Button(
+                            onClick = {
+                                Timber.d("LocalAlbumScreen: Play button clicked - ${songs.size} songs")
+                                if (songs.isNotEmpty()) {
+                                    val mediaItems = songs.map { it.toMediaItem() }
+                                    Timber.d("LocalAlbumScreen: Playing queue with ${mediaItems.size} items")
+                                    mediaItems.forEachIndexed { idx, item ->
+                                        Timber.d("LocalAlbumScreen: MediaItem[$idx] id=${item.mediaId}, uri=${item.localConfiguration?.uri}")
+                                    }
+                                    playerConnection.playQueue(
+                                        ListQueue(
+                                            title = album?.album?.title ?: "Local Album",
+                                            items = mediaItems
+                                        )
+                                    )
+                                }
+                            },
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.play),
+                                contentDescription = null,
+                                modifier = Modifier.size(ButtonDefaults.IconSize)
+                            )
+                            Spacer(Modifier.size(ButtonDefaults.IconSpacing))
+                            Text(stringResource(R.string.play))
+                        }
+
+                        OutlinedButton(
+                            onClick = {
+                                Timber.d("LocalAlbumScreen: Shuffle button clicked - ${songs.size} songs")
+                                if (songs.isNotEmpty()) {
+                                    playerConnection.playQueue(
+                                        ListQueue(
+                                            title = album?.album?.title ?: "Local Album",
+                                            items = songs.shuffled().map { it.toMediaItem() }
+                                        )
+                                    )
+                                }
+                            },
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.shuffle),
+                                contentDescription = null,
+                                modifier = Modifier.size(ButtonDefaults.IconSize)
+                            )
+                            Spacer(Modifier.size(ButtonDefaults.IconSpacing))
+                            Text(stringResource(R.string.shuffle))
+                        }
+                    }
+                }
+            }
+
+            if (songs.isEmpty()) {
+                item(key = "empty") {
+                    EmptyPlaceholder(
+                        icon = R.drawable.music_note,
+                        text = stringResource(R.string.no_results_found)
+                    )
+                }
+            }
+
+            itemsIndexed(
+                items = songs,
+                key = { _, song -> song.id },
+                contentType = { _, _ -> CONTENT_TYPE_SONG }
+            ) { index, song ->
+                SongListItem(
+                    song = song,
+                    albumIndex = index + 1,
+                    showInLibraryIcon = true,
+                    trailingContent = {
+                        IconButton(
+                            onClick = {
+                                menuState.show {
+                                    SongMenu(
+                                        originalSong = song,
+                                        navController = navController,
+                                        onDismiss = menuState::dismiss
+                                    )
+                                }
+                            }
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.more_vert),
+                                contentDescription = null
+                            )
+                        }
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .combinedClickable(
+                            onClick = {
+                                Timber.d("LocalAlbumScreen: Song clicked - index=$index, id=${song.id}, title=${song.song.title}")
+                                val mediaItem = song.toMediaItem()
+                                Timber.d("LocalAlbumScreen: Song MediaItem uri=${mediaItem.localConfiguration?.uri}")
+                                playerConnection.playQueue(
+                                    ListQueue(
+                                        title = album?.album?.title ?: "Local Album",
+                                        items = songs.map { it.toMediaItem() },
+                                        startIndex = index
+                                    )
+                                )
+                            },
+                            onLongClick = {
+                                menuState.show {
+                                    SongMenu(
+                                        originalSong = song,
+                                        navController = navController,
+                                        onDismiss = menuState::dismiss
+                                    )
+                                }
+                            }
+                        )
+                        .animateItem()
+                )
+            }
+        }
+    }
+
+    TopAppBar(
+        title = {
+            Text(
+                text = album?.album?.title ?: "",
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        },
+        navigationIcon = {
+            IconButton(onClick = navController::navigateUp) {
+                Icon(
+                    painterResource(R.drawable.arrow_back),
+                    contentDescription = null
+                )
+            }
+        },
+        scrollBehavior = scrollBehavior
+    )
+}

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalAlbumScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalAlbumScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -48,6 +49,8 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import coil3.compose.AsyncImage
+import android.widget.Toast
+import com.metrolist.music.LocalListenTogetherManager
 import com.metrolist.music.LocalPlayerAwareWindowInsets
 import com.metrolist.music.LocalPlayerConnection
 import com.metrolist.music.R
@@ -73,6 +76,8 @@ fun LocalAlbumScreen(
 ) {
     val menuState = LocalMenuState.current
     val playerConnection = LocalPlayerConnection.current ?: return
+    val listenTogetherManager = LocalListenTogetherManager.current
+    val context = LocalContext.current
 
     val album by viewModel.album.collectAsState()
     val songs by viewModel.songs.collectAsState()
@@ -154,6 +159,10 @@ fun LocalAlbumScreen(
                     ) {
                         Button(
                             onClick = {
+                                if (listenTogetherManager?.isInRoom == true) {
+                                    Toast.makeText(context, R.string.local_playback_blocked_listen_together, Toast.LENGTH_SHORT).show()
+                                    return@Button
+                                }
                                 Timber.d("LocalAlbumScreen: Play button clicked - ${songs.size} songs")
                                 if (songs.isNotEmpty()) {
                                     val mediaItems = songs.map { it.toMediaItem() }
@@ -182,6 +191,10 @@ fun LocalAlbumScreen(
 
                         OutlinedButton(
                             onClick = {
+                                if (listenTogetherManager?.isInRoom == true) {
+                                    Toast.makeText(context, R.string.local_playback_blocked_listen_together, Toast.LENGTH_SHORT).show()
+                                    return@OutlinedButton
+                                }
                                 Timber.d("LocalAlbumScreen: Shuffle button clicked - ${songs.size} songs")
                                 if (songs.isNotEmpty()) {
                                     playerConnection.playQueue(
@@ -246,6 +259,10 @@ fun LocalAlbumScreen(
                         .fillMaxWidth()
                         .combinedClickable(
                             onClick = {
+                                if (listenTogetherManager?.isInRoom == true) {
+                                    Toast.makeText(context, R.string.local_playback_blocked_listen_together, Toast.LENGTH_SHORT).show()
+                                    return@combinedClickable
+                                }
                                 Timber.d("LocalAlbumScreen: Song clicked - index=$index, id=${song.id}, title=${song.song.title}")
                                 val mediaItem = song.toMediaItem()
                                 Timber.d("LocalAlbumScreen: Song MediaItem uri=${mediaItem.localConfiguration?.uri}")

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalArtistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalArtistScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -95,7 +96,6 @@ fun LocalArtistScreen(
     val artist by viewModel.artist.collectAsState()
     val albums by viewModel.albums.collectAsState()
     val songs by viewModel.songs.collectAsState()
-    val isLoading by viewModel.isLoading.collectAsState()
 
     Timber.d("LocalArtistScreen: COMPOSE - artist=${artist?.artist?.name}, albumCount=${albums.size}, songCount=${songs.size}")
 
@@ -141,7 +141,14 @@ fun LocalArtistScreen(
                                     style = MaterialTheme.typography.headlineSmall,
                                     modifier = Modifier.padding(top = 16.dp)
                                 )
-                                if (!isLoading) {
+                                if (songs.isEmpty()) {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier
+                                            .padding(top = 8.dp)
+                                            .size(16.dp),
+                                        strokeWidth = 2.dp
+                                    )
+                                } else {
                                     Text(
                                         text = pluralStringResource(
                                             R.plurals.n_song,
@@ -379,7 +386,14 @@ fun LocalArtistScreen(
                                     style = MaterialTheme.typography.headlineSmall,
                                     modifier = Modifier.padding(top = 16.dp)
                                 )
-                                if (!isLoading) {
+                                if (songs.isEmpty()) {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier
+                                            .padding(top = 8.dp)
+                                            .size(16.dp),
+                                        strokeWidth = 2.dp
+                                    )
+                                } else {
                                     Text(
                                         text = pluralStringResource(
                                             R.plurals.n_song,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalArtistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalArtistScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -52,6 +53,8 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import coil3.compose.AsyncImage
+import android.widget.Toast
+import com.metrolist.music.LocalListenTogetherManager
 import com.metrolist.music.LocalPlayerAwareWindowInsets
 import com.metrolist.music.LocalPlayerConnection
 import com.metrolist.music.R
@@ -91,6 +94,8 @@ fun LocalArtistScreen(
 ) {
     val menuState = LocalMenuState.current
     val playerConnection = LocalPlayerConnection.current ?: return
+    val listenTogetherManager = LocalListenTogetherManager.current
+    val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
 
     val artist by viewModel.artist.collectAsState()
@@ -166,6 +171,10 @@ fun LocalArtistScreen(
                             ) {
                                 IconButton(
                                     onClick = {
+                                        if (listenTogetherManager?.isInRoom == true) {
+                                            Toast.makeText(context, R.string.local_playback_blocked_listen_together, Toast.LENGTH_SHORT).show()
+                                            return@IconButton
+                                        }
                                         Timber.d("LocalArtistScreen: [LIST] Play all clicked - ${songs.size} songs")
                                         if (songs.isNotEmpty()) {
                                             val mediaItems = songs.map { it.toMediaItem() }
@@ -189,6 +198,10 @@ fun LocalArtistScreen(
                                 }
                                 IconButton(
                                     onClick = {
+                                        if (listenTogetherManager?.isInRoom == true) {
+                                            Toast.makeText(context, R.string.local_playback_blocked_listen_together, Toast.LENGTH_SHORT).show()
+                                            return@IconButton
+                                        }
                                         Timber.d("LocalArtistScreen: [LIST] Shuffle clicked - ${songs.size} songs")
                                         if (songs.isNotEmpty()) {
                                             playerConnection.playQueue(
@@ -321,6 +334,10 @@ fun LocalArtistScreen(
                                     .fillMaxWidth()
                                     .combinedClickable(
                                         onClick = {
+                                            if (listenTogetherManager?.isInRoom == true) {
+                                                Toast.makeText(context, R.string.local_playback_blocked_listen_together, Toast.LENGTH_SHORT).show()
+                                                return@combinedClickable
+                                            }
                                             Timber.d("LocalArtistScreen: [LIST] Song clicked - id=${song.id}, title=${song.song.title}")
                                             val mediaItem = song.toMediaItem()
                                             Timber.d("LocalArtistScreen: [LIST] Song MediaItem uri=${mediaItem.localConfiguration?.uri}")
@@ -411,6 +428,10 @@ fun LocalArtistScreen(
                             ) {
                                 IconButton(
                                     onClick = {
+                                        if (listenTogetherManager?.isInRoom == true) {
+                                            Toast.makeText(context, R.string.local_playback_blocked_listen_together, Toast.LENGTH_SHORT).show()
+                                            return@IconButton
+                                        }
                                         Timber.d("LocalArtistScreen: [GRID] Play all clicked - ${songs.size} songs")
                                         if (songs.isNotEmpty()) {
                                             val mediaItems = songs.map { it.toMediaItem() }
@@ -431,6 +452,10 @@ fun LocalArtistScreen(
                                 }
                                 IconButton(
                                     onClick = {
+                                        if (listenTogetherManager?.isInRoom == true) {
+                                            Toast.makeText(context, R.string.local_playback_blocked_listen_together, Toast.LENGTH_SHORT).show()
+                                            return@IconButton
+                                        }
                                         Timber.d("LocalArtistScreen: [GRID] Shuffle clicked - ${songs.size} songs")
                                         if (songs.isNotEmpty()) {
                                             playerConnection.playQueue(

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalArtistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalArtistScreen.kt
@@ -1,0 +1,512 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.ui.screens.library
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import coil3.compose.AsyncImage
+import com.metrolist.music.LocalPlayerAwareWindowInsets
+import com.metrolist.music.LocalPlayerConnection
+import com.metrolist.music.R
+import com.metrolist.music.constants.AlbumSortDescendingKey
+import com.metrolist.music.constants.AlbumSortType
+import com.metrolist.music.constants.AlbumSortTypeKey
+import com.metrolist.music.constants.AlbumViewTypeKey
+import com.metrolist.music.constants.CONTENT_TYPE_ALBUM
+import com.metrolist.music.constants.CONTENT_TYPE_HEADER
+import com.metrolist.music.constants.CONTENT_TYPE_SONG
+import com.metrolist.music.constants.GridItemSize
+import com.metrolist.music.constants.GridItemsSizeKey
+import com.metrolist.music.constants.GridThumbnailHeight
+import com.metrolist.music.constants.LibraryViewType
+import com.metrolist.music.extensions.toMediaItem
+import com.metrolist.music.playback.queues.ListQueue
+import com.metrolist.music.ui.component.AlbumGridItem
+import com.metrolist.music.ui.component.AlbumListItem
+import com.metrolist.music.ui.component.EmptyPlaceholder
+import com.metrolist.music.ui.component.IconButton
+import com.metrolist.music.ui.component.LocalMenuState
+import com.metrolist.music.ui.component.SongListItem
+import com.metrolist.music.ui.component.SortHeader
+import com.metrolist.music.ui.menu.SongMenu
+import com.metrolist.music.utils.rememberEnumPreference
+import com.metrolist.music.utils.rememberPreference
+import com.metrolist.music.viewmodels.LocalArtistViewModel
+import timber.log.Timber
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@Composable
+fun LocalArtistScreen(
+    navController: NavController,
+    scrollBehavior: TopAppBarScrollBehavior,
+    viewModel: LocalArtistViewModel = hiltViewModel(),
+) {
+    val menuState = LocalMenuState.current
+    val playerConnection = LocalPlayerConnection.current ?: return
+    val coroutineScope = rememberCoroutineScope()
+
+    val artist by viewModel.artist.collectAsState()
+    val albums by viewModel.albums.collectAsState()
+    val songs by viewModel.songs.collectAsState()
+
+    Timber.d("LocalArtistScreen: COMPOSE - artist=${artist?.artist?.name}, albumCount=${albums.size}, songCount=${songs.size}")
+
+    var viewType by rememberEnumPreference(AlbumViewTypeKey, LibraryViewType.GRID)
+    val (sortType, onSortTypeChange) = rememberEnumPreference(AlbumSortTypeKey, AlbumSortType.NAME)
+    val (sortDescending, onSortDescendingChange) = rememberPreference(AlbumSortDescendingKey, false)
+    val gridItemSize by rememberEnumPreference(GridItemsSizeKey, GridItemSize.BIG)
+
+    val sortedAlbums = albums.let { albumList ->
+        when (sortType) {
+            AlbumSortType.NAME -> albumList.sortedBy { it.album.title.lowercase() }
+            AlbumSortType.YEAR -> albumList.sortedBy { it.album.year ?: 0 }
+            AlbumSortType.SONG_COUNT -> albumList.sortedBy { it.album.songCount }
+            else -> albumList
+        }.let { if (sortDescending) it.reversed() else it }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .nestedScroll(scrollBehavior.nestedScrollConnection)
+    ) {
+        when (viewType) {
+            LibraryViewType.LIST ->
+                LazyColumn(
+                    contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues(),
+                ) {
+                    item(key = "header", contentType = CONTENT_TYPE_HEADER) {
+                        Column(
+                            modifier = Modifier.padding(16.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            artist?.let { a ->
+                                AsyncImage(
+                                    model = a.artist.thumbnailUrl,
+                                    contentDescription = null,
+                                    modifier = Modifier
+                                        .size(120.dp)
+                                        .clip(CircleShape)
+                                )
+                                Text(
+                                    text = a.artist.name,
+                                    style = MaterialTheme.typography.headlineSmall,
+                                    modifier = Modifier.padding(top = 16.dp)
+                                )
+                                Text(
+                                    text = pluralStringResource(
+                                        R.plurals.n_song,
+                                        songs.size,
+                                        songs.size
+                                    ),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.secondary
+                                )
+                            }
+
+                            Row(
+                                modifier = Modifier.padding(top = 16.dp)
+                            ) {
+                                IconButton(
+                                    onClick = {
+                                        Timber.d("LocalArtistScreen: [LIST] Play all clicked - ${songs.size} songs")
+                                        if (songs.isNotEmpty()) {
+                                            val mediaItems = songs.map { it.toMediaItem() }
+                                            Timber.d("LocalArtistScreen: [LIST] Playing queue with ${mediaItems.size} items")
+                                            mediaItems.forEachIndexed { idx, item ->
+                                                Timber.d("LocalArtistScreen: [LIST] MediaItem[$idx] id=${item.mediaId}, uri=${item.localConfiguration?.uri}")
+                                            }
+                                            playerConnection.playQueue(
+                                                ListQueue(
+                                                    title = artist?.artist?.name ?: "Local Artist",
+                                                    items = mediaItems
+                                                )
+                                            )
+                                        }
+                                    }
+                                ) {
+                                    Icon(
+                                        painter = painterResource(R.drawable.play),
+                                        contentDescription = stringResource(R.string.play)
+                                    )
+                                }
+                                IconButton(
+                                    onClick = {
+                                        Timber.d("LocalArtistScreen: [LIST] Shuffle clicked - ${songs.size} songs")
+                                        if (songs.isNotEmpty()) {
+                                            playerConnection.playQueue(
+                                                ListQueue(
+                                                    title = artist?.artist?.name ?: "Local Artist",
+                                                    items = songs.shuffled().map { it.toMediaItem() }
+                                                )
+                                            )
+                                        }
+                                    }
+                                ) {
+                                    Icon(
+                                        painter = painterResource(R.drawable.shuffle),
+                                        contentDescription = stringResource(R.string.shuffle)
+                                    )
+                                }
+                            }
+                        }
+                    }
+
+                    if (albums.isNotEmpty()) {
+                        item(key = "albums_header", contentType = CONTENT_TYPE_HEADER) {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier.padding(start = 16.dp),
+                            ) {
+                                Text(
+                                    text = stringResource(R.string.albums),
+                                    style = MaterialTheme.typography.titleMedium,
+                                    modifier = Modifier.weight(1f)
+                                )
+                                SortHeader(
+                                    sortType = sortType,
+                                    sortDescending = sortDescending,
+                                    onSortTypeChange = onSortTypeChange,
+                                    onSortDescendingChange = onSortDescendingChange,
+                                    sortTypeText = { sortType ->
+                                        when (sortType) {
+                                            AlbumSortType.CREATE_DATE -> R.string.sort_by_create_date
+                                            AlbumSortType.NAME -> R.string.sort_by_name
+                                            AlbumSortType.ARTIST -> R.string.sort_by_artist
+                                            AlbumSortType.YEAR -> R.string.sort_by_year
+                                            AlbumSortType.SONG_COUNT -> R.string.sort_by_song_count
+                                            AlbumSortType.LENGTH -> R.string.sort_by_length
+                                            AlbumSortType.PLAY_TIME -> R.string.sort_by_play_time
+                                        }
+                                    },
+                                )
+                                IconButton(
+                                    onClick = { viewType = viewType.toggle() },
+                                ) {
+                                    Icon(
+                                        painter = painterResource(
+                                            when (viewType) {
+                                                LibraryViewType.LIST -> R.drawable.list
+                                                LibraryViewType.GRID -> R.drawable.grid_view
+                                            }
+                                        ),
+                                        contentDescription = null,
+                                    )
+                                }
+                            }
+                        }
+
+                        items(
+                            items = sortedAlbums,
+                            key = { it.id },
+                            contentType = { CONTENT_TYPE_ALBUM }
+                        ) { album ->
+                            AlbumListItem(
+                                album = album,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable {
+                                        Timber.d("LocalArtistScreen: [LIST] Album clicked - id=${album.id}, title=${album.album.title}")
+                                        navController.navigate("local_album/${album.id}")
+                                    }
+                                    .animateItem()
+                            )
+                        }
+                    }
+
+                    if (songs.isNotEmpty()) {
+                        item(key = "songs_header", contentType = CONTENT_TYPE_HEADER) {
+                            Text(
+                                text = stringResource(R.string.songs),
+                                style = MaterialTheme.typography.titleMedium,
+                                modifier = Modifier.padding(16.dp)
+                            )
+                        }
+
+                        items(
+                            items = songs,
+                            key = { it.id },
+                            contentType = { CONTENT_TYPE_SONG }
+                        ) { song ->
+                            SongListItem(
+                                song = song,
+                                showInLibraryIcon = true,
+                                trailingContent = {
+                                    IconButton(
+                                        onClick = {
+                                            menuState.show {
+                                                SongMenu(
+                                                    originalSong = song,
+                                                    navController = navController,
+                                                    onDismiss = menuState::dismiss
+                                                )
+                                            }
+                                        }
+                                    ) {
+                                        Icon(
+                                            painter = painterResource(R.drawable.more_vert),
+                                            contentDescription = null
+                                        )
+                                    }
+                                },
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .combinedClickable(
+                                        onClick = {
+                                            Timber.d("LocalArtistScreen: [LIST] Song clicked - id=${song.id}, title=${song.song.title}")
+                                            val mediaItem = song.toMediaItem()
+                                            Timber.d("LocalArtistScreen: [LIST] Song MediaItem uri=${mediaItem.localConfiguration?.uri}")
+                                            playerConnection.playQueue(
+                                                ListQueue(
+                                                    title = artist?.artist?.name ?: "Local Artist",
+                                                    items = songs.map { it.toMediaItem() },
+                                                    startIndex = songs.indexOf(song)
+                                                )
+                                            )
+                                        },
+                                        onLongClick = {
+                                            menuState.show {
+                                                SongMenu(
+                                                    originalSong = song,
+                                                    navController = navController,
+                                                    onDismiss = menuState::dismiss
+                                                )
+                                            }
+                                        }
+                                    )
+                                    .animateItem()
+                            )
+                        }
+                    }
+
+                    if (albums.isEmpty() && songs.isEmpty()) {
+                        item(key = "empty") {
+                            EmptyPlaceholder(
+                                icon = R.drawable.music_note,
+                                text = stringResource(R.string.no_results_found)
+                            )
+                        }
+                    }
+                }
+
+            LibraryViewType.GRID ->
+                LazyVerticalGrid(
+                    columns = GridCells.Adaptive(
+                        minSize = GridThumbnailHeight + if (gridItemSize == GridItemSize.BIG) 24.dp else (-24).dp,
+                    ),
+                    contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues(),
+                ) {
+                    item(
+                        key = "header",
+                        span = { GridItemSpan(maxLineSpan) },
+                        contentType = CONTENT_TYPE_HEADER
+                    ) {
+                        Column(
+                            modifier = Modifier.padding(16.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            artist?.let { a ->
+                                AsyncImage(
+                                    model = a.artist.thumbnailUrl,
+                                    contentDescription = null,
+                                    modifier = Modifier
+                                        .size(120.dp)
+                                        .clip(CircleShape)
+                                )
+                                Text(
+                                    text = a.artist.name,
+                                    style = MaterialTheme.typography.headlineSmall,
+                                    modifier = Modifier.padding(top = 16.dp)
+                                )
+                                Text(
+                                    text = pluralStringResource(
+                                        R.plurals.n_song,
+                                        songs.size,
+                                        songs.size
+                                    ),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.secondary
+                                )
+                            }
+
+                            Row(
+                                modifier = Modifier.padding(top = 16.dp)
+                            ) {
+                                IconButton(
+                                    onClick = {
+                                        Timber.d("LocalArtistScreen: [GRID] Play all clicked - ${songs.size} songs")
+                                        if (songs.isNotEmpty()) {
+                                            val mediaItems = songs.map { it.toMediaItem() }
+                                            Timber.d("LocalArtistScreen: [GRID] Playing queue with ${mediaItems.size} items")
+                                            playerConnection.playQueue(
+                                                ListQueue(
+                                                    title = artist?.artist?.name ?: "Local Artist",
+                                                    items = mediaItems
+                                                )
+                                            )
+                                        }
+                                    }
+                                ) {
+                                    Icon(
+                                        painter = painterResource(R.drawable.play),
+                                        contentDescription = stringResource(R.string.play)
+                                    )
+                                }
+                                IconButton(
+                                    onClick = {
+                                        Timber.d("LocalArtistScreen: [GRID] Shuffle clicked - ${songs.size} songs")
+                                        if (songs.isNotEmpty()) {
+                                            playerConnection.playQueue(
+                                                ListQueue(
+                                                    title = artist?.artist?.name ?: "Local Artist",
+                                                    items = songs.shuffled().map { it.toMediaItem() }
+                                                )
+                                            )
+                                        }
+                                    }
+                                ) {
+                                    Icon(
+                                        painter = painterResource(R.drawable.shuffle),
+                                        contentDescription = stringResource(R.string.shuffle)
+                                    )
+                                }
+                            }
+                        }
+                    }
+
+                    if (albums.isNotEmpty()) {
+                        item(
+                            key = "albums_header",
+                            span = { GridItemSpan(maxLineSpan) },
+                            contentType = CONTENT_TYPE_HEADER
+                        ) {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier.padding(start = 16.dp),
+                            ) {
+                                Text(
+                                    text = stringResource(R.string.albums),
+                                    style = MaterialTheme.typography.titleMedium,
+                                    modifier = Modifier.weight(1f)
+                                )
+                                SortHeader(
+                                    sortType = sortType,
+                                    sortDescending = sortDescending,
+                                    onSortTypeChange = onSortTypeChange,
+                                    onSortDescendingChange = onSortDescendingChange,
+                                    sortTypeText = { sortType ->
+                                        when (sortType) {
+                                            AlbumSortType.CREATE_DATE -> R.string.sort_by_create_date
+                                            AlbumSortType.NAME -> R.string.sort_by_name
+                                            AlbumSortType.ARTIST -> R.string.sort_by_artist
+                                            AlbumSortType.YEAR -> R.string.sort_by_year
+                                            AlbumSortType.SONG_COUNT -> R.string.sort_by_song_count
+                                            AlbumSortType.LENGTH -> R.string.sort_by_length
+                                            AlbumSortType.PLAY_TIME -> R.string.sort_by_play_time
+                                        }
+                                    },
+                                )
+                                IconButton(
+                                    onClick = { viewType = viewType.toggle() },
+                                ) {
+                                    Icon(
+                                        painter = painterResource(
+                                            when (viewType) {
+                                                LibraryViewType.LIST -> R.drawable.list
+                                                LibraryViewType.GRID -> R.drawable.grid_view
+                                            }
+                                        ),
+                                        contentDescription = null,
+                                    )
+                                }
+                            }
+                        }
+
+                        items(
+                            items = sortedAlbums,
+                            key = { it.id },
+                            contentType = { CONTENT_TYPE_ALBUM }
+                        ) { album ->
+                            AlbumGridItem(
+                                album = album,
+                                fillMaxWidth = true,
+                                coroutineScope = coroutineScope,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable {
+                                        Timber.d("LocalArtistScreen: [GRID] Album clicked - id=${album.id}, title=${album.album.title}")
+                                        navController.navigate("local_album/${album.id}")
+                                    }
+                                    .animateItem()
+                            )
+                        }
+                    }
+                }
+        }
+    }
+
+    TopAppBar(
+        title = {
+            Text(
+                text = artist?.artist?.name ?: "",
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        },
+        navigationIcon = {
+            IconButton(onClick = navController::navigateUp) {
+                Icon(
+                    painterResource(R.drawable.arrow_back),
+                    contentDescription = null
+                )
+            }
+        },
+        scrollBehavior = scrollBehavior
+    )
+}

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalArtistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalArtistScreen.kt
@@ -74,6 +74,7 @@ import com.metrolist.music.ui.component.IconButton
 import com.metrolist.music.ui.component.LocalMenuState
 import com.metrolist.music.ui.component.SongListItem
 import com.metrolist.music.ui.component.SortHeader
+import com.metrolist.music.ui.menu.AlbumMenu
 import com.metrolist.music.ui.menu.SongMenu
 import com.metrolist.music.utils.rememberEnumPreference
 import com.metrolist.music.utils.rememberPreference
@@ -254,10 +255,21 @@ fun LocalArtistScreen(
                                 album = album,
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .clickable {
-                                        Timber.d("LocalArtistScreen: [LIST] Album clicked - id=${album.id}, title=${album.album.title}")
-                                        navController.navigate("local_album/${album.id}")
-                                    }
+                                    .combinedClickable(
+                                        onClick = {
+                                            Timber.d("LocalArtistScreen: [LIST] Album clicked - id=${album.id}, title=${album.album.title}")
+                                            navController.navigate("local_album/${album.id}")
+                                        },
+                                        onLongClick = {
+                                            menuState.show {
+                                                AlbumMenu(
+                                                    originalAlbum = album,
+                                                    navController = navController,
+                                                    onDismiss = menuState::dismiss
+                                                )
+                                            }
+                                        }
+                                    )
                                     .animateItem()
                             )
                         }
@@ -484,10 +496,21 @@ fun LocalArtistScreen(
                                 coroutineScope = coroutineScope,
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .clickable {
-                                        Timber.d("LocalArtistScreen: [GRID] Album clicked - id=${album.id}, title=${album.album.title}")
-                                        navController.navigate("local_album/${album.id}")
-                                    }
+                                    .combinedClickable(
+                                        onClick = {
+                                            Timber.d("LocalArtistScreen: [GRID] Album clicked - id=${album.id}, title=${album.album.title}")
+                                            navController.navigate("local_album/${album.id}")
+                                        },
+                                        onLongClick = {
+                                            menuState.show {
+                                                AlbumMenu(
+                                                    originalAlbum = album,
+                                                    navController = navController,
+                                                    onDismiss = menuState::dismiss
+                                                )
+                                            }
+                                        }
+                                    )
                                     .animateItem()
                             )
                         }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalArtistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalArtistScreen.kt
@@ -94,6 +94,7 @@ fun LocalArtistScreen(
     val artist by viewModel.artist.collectAsState()
     val albums by viewModel.albums.collectAsState()
     val songs by viewModel.songs.collectAsState()
+    val isLoading by viewModel.isLoading.collectAsState()
 
     Timber.d("LocalArtistScreen: COMPOSE - artist=${artist?.artist?.name}, albumCount=${albums.size}, songCount=${songs.size}")
 
@@ -139,15 +140,17 @@ fun LocalArtistScreen(
                                     style = MaterialTheme.typography.headlineSmall,
                                     modifier = Modifier.padding(top = 16.dp)
                                 )
-                                Text(
-                                    text = pluralStringResource(
-                                        R.plurals.n_song,
-                                        songs.size,
-                                        songs.size
-                                    ),
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.secondary
-                                )
+                                if (!isLoading) {
+                                    Text(
+                                        text = pluralStringResource(
+                                            R.plurals.n_song,
+                                            songs.size,
+                                            songs.size
+                                        ),
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.secondary
+                                    )
+                                }
                             }
 
                             Row(
@@ -364,15 +367,17 @@ fun LocalArtistScreen(
                                     style = MaterialTheme.typography.headlineSmall,
                                     modifier = Modifier.padding(top = 16.dp)
                                 )
-                                Text(
-                                    text = pluralStringResource(
-                                        R.plurals.n_song,
-                                        songs.size,
-                                        songs.size
-                                    ),
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.secondary
-                                )
+                                if (!isLoading) {
+                                    Text(
+                                        text = pluralStringResource(
+                                            R.plurals.n_song,
+                                            songs.size,
+                                            songs.size
+                                        ),
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.secondary
+                                    )
+                                }
                             }
 
                             Row(

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalFolderScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalFolderScreen.kt
@@ -1,0 +1,294 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.ui.screens.library
+
+import android.widget.Toast
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import com.metrolist.music.LocalListenTogetherManager
+import com.metrolist.music.LocalPlayerAwareWindowInsets
+import com.metrolist.music.LocalPlayerConnection
+import com.metrolist.music.R
+import com.metrolist.music.constants.CONTENT_TYPE_HEADER
+import com.metrolist.music.constants.CONTENT_TYPE_SONG
+import com.metrolist.music.extensions.toMediaItem
+import com.metrolist.music.playback.queues.ListQueue
+import com.metrolist.music.ui.component.EmptyPlaceholder
+import com.metrolist.music.ui.component.IconButton
+import com.metrolist.music.ui.component.LocalMenuState
+import com.metrolist.music.ui.component.SongListItem
+import com.metrolist.music.ui.menu.SongMenu
+import com.metrolist.music.viewmodels.LocalFolderViewModel
+import timber.log.Timber
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@Composable
+fun LocalFolderScreen(
+    navController: NavController,
+    scrollBehavior: TopAppBarScrollBehavior,
+    folderPath: String,
+    viewModel: LocalFolderViewModel = hiltViewModel(),
+) {
+    val menuState = LocalMenuState.current
+    val playerConnection = LocalPlayerConnection.current ?: return
+    val listenTogetherManager = LocalListenTogetherManager.current
+    val context = LocalContext.current
+    val haptic = LocalHapticFeedback.current
+
+    val songs by viewModel.songs.collectAsState()
+    val allSongs by viewModel.allSongs.collectAsState()
+    val subfolders by viewModel.subfolders.collectAsState()
+
+    val folderName = folderPath.substringAfterLast('/')
+
+    Timber.d("LocalFolderScreen: COMPOSE - folderPath='$folderPath', directSongs=${songs.size}, allSongs=${allSongs.size}, subfolders=${subfolders.size}")
+    Timber.d("LocalFolderScreen: Subfolders = $subfolders")
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .nestedScroll(scrollBehavior.nestedScrollConnection)
+    ) {
+        LazyColumn(
+            contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues(),
+        ) {
+            // Header with play all / shuffle buttons
+            item(key = "header", contentType = CONTENT_TYPE_HEADER) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.library_music),
+                        contentDescription = null,
+                        modifier = Modifier.padding(bottom = 8.dp),
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                    Text(
+                        text = folderName,
+                        style = MaterialTheme.typography.headlineSmall
+                    )
+                    Text(
+                        text = pluralStringResource(R.plurals.n_song, allSongs.size, allSongs.size),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.secondary
+                    )
+
+                    Row(
+                        modifier = Modifier.padding(top = 16.dp)
+                    ) {
+                        IconButton(
+                            onClick = {
+                                if (listenTogetherManager?.isInRoom == true) {
+                                    Toast.makeText(context, R.string.local_playback_blocked_listen_together, Toast.LENGTH_SHORT).show()
+                                    return@IconButton
+                                }
+                                if (allSongs.isNotEmpty()) {
+                                    playerConnection.playQueue(
+                                        ListQueue(
+                                            title = folderName,
+                                            items = allSongs.map { it.toMediaItem() }
+                                        )
+                                    )
+                                }
+                            }
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.play),
+                                contentDescription = stringResource(R.string.play)
+                            )
+                        }
+                        IconButton(
+                            onClick = {
+                                if (listenTogetherManager?.isInRoom == true) {
+                                    Toast.makeText(context, R.string.local_playback_blocked_listen_together, Toast.LENGTH_SHORT).show()
+                                    return@IconButton
+                                }
+                                if (allSongs.isNotEmpty()) {
+                                    playerConnection.playQueue(
+                                        ListQueue(
+                                            title = folderName,
+                                            items = allSongs.shuffled().map { it.toMediaItem() }
+                                        )
+                                    )
+                                }
+                            }
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.shuffle),
+                                contentDescription = stringResource(R.string.shuffle)
+                            )
+                        }
+                    }
+                }
+            }
+
+            // Subfolders section
+            if (subfolders.isNotEmpty()) {
+                item(key = "subfolders_header") {
+                    Text(
+                        text = stringResource(R.string.folders),
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                    )
+                }
+
+                items(
+                    items = subfolders,
+                    key = { "subfolder_$it" }
+                ) { subfolder ->
+                    ListItem(
+                        headlineContent = { Text(subfolder.substringAfterLast('/')) },
+                        leadingContent = {
+                            Icon(
+                                painter = painterResource(R.drawable.library_music),
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        },
+                        modifier = Modifier
+                            .clickable {
+                                val encodedPath = java.net.URLEncoder.encode(subfolder, "UTF-8")
+                                navController.navigate("local_folder/$encodedPath")
+                            }
+                            .animateItem()
+                    )
+                }
+            }
+
+            // Songs section
+            if (songs.isNotEmpty()) {
+                item(key = "songs_header") {
+                    Text(
+                        text = stringResource(R.string.songs),
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                    )
+                }
+
+                items(
+                    items = songs,
+                    key = { it.id },
+                    contentType = { CONTENT_TYPE_SONG }
+                ) { song ->
+                    SongListItem(
+                        song = song,
+                        showInLibraryIcon = true,
+                        trailingContent = {
+                            IconButton(
+                                onClick = {
+                                    menuState.show {
+                                        SongMenu(
+                                            originalSong = song,
+                                            navController = navController,
+                                            onDismiss = menuState::dismiss
+                                        )
+                                    }
+                                }
+                            ) {
+                                Icon(
+                                    painter = painterResource(R.drawable.more_vert),
+                                    contentDescription = null
+                                )
+                            }
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .combinedClickable(
+                                onClick = {
+                                    if (listenTogetherManager?.isInRoom == true) {
+                                        Toast.makeText(context, R.string.local_playback_blocked_listen_together, Toast.LENGTH_SHORT).show()
+                                        return@combinedClickable
+                                    }
+                                    playerConnection.playQueue(
+                                        ListQueue(
+                                            title = folderName,
+                                            items = songs.map { it.toMediaItem() },
+                                            startIndex = songs.indexOf(song)
+                                        )
+                                    )
+                                },
+                                onLongClick = {
+                                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                    menuState.show {
+                                        SongMenu(
+                                            originalSong = song,
+                                            navController = navController,
+                                            onDismiss = menuState::dismiss
+                                        )
+                                    }
+                                }
+                            )
+                            .animateItem()
+                    )
+                }
+            }
+
+            // Empty state
+            if (songs.isEmpty() && subfolders.isEmpty()) {
+                item(key = "empty") {
+                    EmptyPlaceholder(
+                        icon = R.drawable.library_music,
+                        text = stringResource(R.string.no_local_folders)
+                    )
+                }
+            }
+        }
+    }
+
+    TopAppBar(
+        title = {
+            Text(
+                text = folderName,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        },
+        navigationIcon = {
+            IconButton(onClick = navController::navigateUp) {
+                Icon(
+                    painterResource(R.drawable.arrow_back),
+                    contentDescription = null
+                )
+            }
+        },
+        scrollBehavior = scrollBehavior
+    )
+}

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalMusicScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalMusicScreen.kt
@@ -64,7 +64,9 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.currentBackStackEntryAsState
+import android.widget.Toast
 import com.metrolist.music.LocalDatabase
+import com.metrolist.music.LocalListenTogetherManager
 import com.metrolist.music.LocalPlayerAwareWindowInsets
 import com.metrolist.music.LocalPlayerConnection
 import com.metrolist.music.R
@@ -113,6 +115,8 @@ fun LocalMusicScreen(
 ) {
     val menuState = LocalMenuState.current
     val playerConnection = LocalPlayerConnection.current
+    val listenTogetherManager = LocalListenTogetherManager.current
+    val context = LocalContext.current
     val haptic = LocalHapticFeedback.current
     val coroutineScope = rememberCoroutineScope()
     val database = LocalDatabase.current
@@ -514,6 +518,10 @@ fun LocalMusicScreen(
                                                 .fillMaxWidth()
                                                 .combinedClickable(
                                                     onClick = {
+                                                        if (listenTogetherManager?.isInRoom == true) {
+                                                            Toast.makeText(context, R.string.local_playback_blocked_listen_together, Toast.LENGTH_SHORT).show()
+                                                            return@combinedClickable
+                                                        }
                                                         playerConnection?.playQueue(
                                                             ListQueue(
                                                                 title = song.song.title,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalMusicScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalMusicScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -48,6 +49,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -96,6 +98,7 @@ import com.metrolist.music.ui.component.SongListItem
 import com.metrolist.music.ui.component.SortHeader
 import com.metrolist.music.ui.component.AlbumListItem
 import com.metrolist.music.ui.component.AlbumGridItem
+import com.metrolist.music.ui.component.ChipsRow
 import com.metrolist.music.ui.menu.AlbumMenu
 import com.metrolist.music.ui.menu.SongMenu
 import com.metrolist.music.utils.LocalMusicRepository
@@ -135,6 +138,10 @@ fun LocalMusicScreen(
     val localArtists by viewModel.localArtists.collectAsState()
     val allLocalAlbums by viewModel.allLocalAlbums.collectAsState()
     val allLocalSongs by viewModel.allLocalSongs.collectAsState()
+    val rootFolders by viewModel.rootFolders.collectAsState()
+
+    // Tab state: 0=Artists, 1=Folders
+    var selectedTab by rememberSaveable { mutableStateOf(0) }
 
     Timber.d("LocalMusicScreen: COMPOSE - hasPermission=$hasPermission, syncStatus=$syncStatus, syncProgress=$syncProgress, artistCount=${localArtists.size}")
 
@@ -258,6 +265,17 @@ fun LocalMusicScreen(
                         .padding(horizontal = 16.dp, vertical = 8.dp),
                 )
             }
+
+            // Tab chips for Artists/Folders
+            ChipsRow(
+                chips = listOf(
+                    0 to stringResource(R.string.artists),
+                    1 to stringResource(R.string.folders)
+                ),
+                currentValue = selectedTab,
+                onValueUpdate = { selectedTab = it },
+                modifier = Modifier.padding(vertical = 8.dp)
+            )
 
             Row(
                 verticalAlignment = Alignment.CenterVertically,
@@ -545,37 +563,68 @@ fun LocalMusicScreen(
                                     }
                                 }
                             } else {
-                                // Normal artist list mode
-                                if (filteredArtists.isEmpty() && syncStatus !is LocalSyncStatus.Syncing) {
-                                    item(key = "empty_placeholder") {
-                                        EmptyPlaceholder(
-                                            icon = R.drawable.artist,
-                                            text = stringResource(R.string.no_local_artists),
-                                        )
-                                    }
-                                }
+                                // Normal mode - show artists or folders based on selected tab
+                                when (selectedTab) {
+                                    0 -> {
+                                        // Artists tab
+                                        if (filteredArtists.isEmpty() && syncStatus !is LocalSyncStatus.Syncing) {
+                                            item(key = "empty_placeholder") {
+                                                EmptyPlaceholder(
+                                                    icon = R.drawable.artist,
+                                                    text = stringResource(R.string.no_local_artists),
+                                                )
+                                            }
+                                        }
 
-                                items(
-                                    items = filteredArtists,
-                                    key = { it.id },
-                                    contentType = { CONTENT_TYPE_ARTIST },
-                                ) { artist ->
-                                    ArtistListItem(
-                                        artist = artist,
-                                        modifier = Modifier
-                                            .fillMaxWidth()
-                                            .combinedClickable(
-                                                onClick = {
-                                                    Timber.d("LocalMusicScreen: Artist clicked - id=${artist.id}, name=${artist.artist.name}")
-                                                    navController.navigate("local_artist/${artist.id}")
-                                                },
-                                                onLongClick = {
-                                                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                                    Timber.d("LocalMusicScreen: Artist long-pressed - id=${artist.id}")
-                                                },
+                                        items(
+                                            items = filteredArtists,
+                                            key = { it.id },
+                                            contentType = { CONTENT_TYPE_ARTIST },
+                                        ) { artist ->
+                                            ArtistListItem(
+                                                artist = artist,
+                                                modifier = Modifier
+                                                    .fillMaxWidth()
+                                                    .combinedClickable(
+                                                        onClick = {
+                                                            Timber.d("LocalMusicScreen: Artist clicked - id=${artist.id}, name=${artist.artist.name}")
+                                                            navController.navigate("local_artist/${artist.id}")
+                                                        },
+                                                        onLongClick = {
+                                                            haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                                            Timber.d("LocalMusicScreen: Artist long-pressed - id=${artist.id}")
+                                                        },
+                                                    )
+                                                    .animateItem()
                                             )
-                                            .animateItem()
-                                    )
+                                        }
+                                    }
+                                    1 -> {
+                                        // Folders tab
+                                        if (rootFolders.isEmpty() && syncStatus !is LocalSyncStatus.Syncing) {
+                                            item(key = "empty_folders") {
+                                                EmptyPlaceholder(
+                                                    icon = R.drawable.library_music,
+                                                    text = stringResource(R.string.no_local_folders),
+                                                )
+                                            }
+                                        }
+
+                                        items(
+                                            items = rootFolders,
+                                            key = { "folder_${it.first}" },
+                                        ) { (folderPath, songCount) ->
+                                            FolderListItem(
+                                                folderPath = folderPath,
+                                                songCount = songCount,
+                                                onClick = {
+                                                    val encodedPath = java.net.URLEncoder.encode(folderPath, "UTF-8")
+                                                    navController.navigate("local_folder/$encodedPath")
+                                                },
+                                                modifier = Modifier.animateItem()
+                                            )
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -583,9 +632,7 @@ fun LocalMusicScreen(
                     LibraryViewType.GRID ->
                         LazyVerticalGrid(
                             state = lazyGridState,
-                            columns = GridCells.Adaptive(
-                                minSize = GridThumbnailHeight + if (gridItemSize == GridItemSize.BIG) 24.dp else (-24).dp,
-                            ),
+                            columns = GridCells.Fixed(3),
                             contentPadding = PaddingValues(bottom = bottomPadding),
                         ) {
                             item(
@@ -596,37 +643,69 @@ fun LocalMusicScreen(
                                 headerContent()
                             }
 
-                            if (filteredArtists.isEmpty() && syncStatus !is LocalSyncStatus.Syncing) {
-                                item(span = { GridItemSpan(maxLineSpan) }) {
-                                    EmptyPlaceholder(
-                                        icon = R.drawable.artist,
-                                        text = stringResource(R.string.no_local_artists),
-                                    )
-                                }
-                            }
+                            when (selectedTab) {
+                                0 -> {
+                                    // Artists tab
+                                    if (filteredArtists.isEmpty() && syncStatus !is LocalSyncStatus.Syncing) {
+                                        item(span = { GridItemSpan(maxLineSpan) }) {
+                                            EmptyPlaceholder(
+                                                icon = R.drawable.artist,
+                                                text = stringResource(R.string.no_local_artists),
+                                            )
+                                        }
+                                    }
 
-                            items(
-                                items = filteredArtists,
-                                key = { it.id },
-                                contentType = { CONTENT_TYPE_ARTIST },
-                            ) { artist ->
-                                ArtistGridItem(
-                                    artist = artist,
-                                    fillMaxWidth = true,
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .combinedClickable(
-                                            onClick = {
-                                                Timber.d("LocalMusicScreen: Artist grid item clicked - id=${artist.id}, name=${artist.artist.name}")
-                                                navController.navigate("local_artist/${artist.id}")
-                                            },
-                                            onLongClick = {
-                                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                                Timber.d("LocalMusicScreen: Artist long-pressed - id=${artist.id}")
-                                            },
+                                    items(
+                                        items = filteredArtists,
+                                        key = { it.id },
+                                        contentType = { CONTENT_TYPE_ARTIST },
+                                    ) { artist ->
+                                        ArtistGridItem(
+                                            artist = artist,
+                                            fillMaxWidth = true,
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .combinedClickable(
+                                                    onClick = {
+                                                        Timber.d("LocalMusicScreen: Artist grid item clicked - id=${artist.id}, name=${artist.artist.name}")
+                                                        navController.navigate("local_artist/${artist.id}")
+                                                    },
+                                                    onLongClick = {
+                                                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                                        Timber.d("LocalMusicScreen: Artist long-pressed - id=${artist.id}")
+                                                    },
+                                                )
+                                                .animateItem()
                                         )
-                                        .animateItem()
-                                )
+                                    }
+                                }
+                                1 -> {
+                                    // Folders tab - use list layout in grid for better folder display
+                                    if (rootFolders.isEmpty() && syncStatus !is LocalSyncStatus.Syncing) {
+                                        item(span = { GridItemSpan(maxLineSpan) }) {
+                                            EmptyPlaceholder(
+                                                icon = R.drawable.library_music,
+                                                text = stringResource(R.string.no_local_folders),
+                                            )
+                                        }
+                                    }
+
+                                    items(
+                                        items = rootFolders,
+                                        key = { "folder_${it.first}" },
+                                        span = { GridItemSpan(maxLineSpan) },
+                                    ) { (folderPath, songCount) ->
+                                        FolderListItem(
+                                            folderPath = folderPath,
+                                            songCount = songCount,
+                                            onClick = {
+                                                val encodedPath = java.net.URLEncoder.encode(folderPath, "UTF-8")
+                                                navController.navigate("local_folder/$encodedPath")
+                                            },
+                                            modifier = Modifier.animateItem()
+                                        )
+                                    }
+                                }
                             }
                         }
                 }
@@ -648,5 +727,26 @@ fun LocalMusicScreen(
             }
         },
         scrollBehavior = scrollBehavior,
+    )
+}
+
+@Composable
+fun FolderListItem(
+    folderPath: String,
+    songCount: Int,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    ListItem(
+        headlineContent = { Text(folderPath.substringAfterLast('/')) },
+        supportingContent = { Text(pluralStringResource(R.plurals.n_song, songCount, songCount)) },
+        leadingContent = {
+            Icon(
+                painter = painterResource(R.drawable.library_music),
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        },
+        modifier = modifier.clickable(onClick = onClick)
     )
 }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalMusicScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalMusicScreen.kt
@@ -50,6 +50,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -127,6 +129,14 @@ fun LocalMusicScreen(
 
     var searchQuery by remember { mutableStateOf(TextFieldValue("")) }
     var isSearching by remember { mutableStateOf(false) }
+    val searchFocusRequester = remember { FocusRequester() }
+
+    // Auto-focus search field when search is opened
+    LaunchedEffect(isSearching) {
+        if (isSearching) {
+            searchFocusRequester.requestFocus()
+        }
+    }
     var showPermissionDialog by remember { mutableStateOf(false) }
 
     val filteredArtists = remember(localArtists, searchQuery.text, sortType, sortDescending) {
@@ -246,6 +256,7 @@ fun LocalMusicScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp, vertical = 8.dp)
+                        .focusRequester(searchFocusRequester)
                 )
             }
 

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalMusicScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalMusicScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
@@ -29,12 +28,8 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilterChip
-import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
@@ -199,22 +194,6 @@ fun LocalMusicScreen(
         }
     }
 
-    val filterContent = @Composable {
-        Row {
-            Spacer(Modifier.width(12.dp))
-            FilterChip(
-                label = { Text(stringResource(R.string.filter_local)) },
-                selected = true,
-                colors = FilterChipDefaults.filterChipColors(containerColor = MaterialTheme.colorScheme.surface),
-                onClick = { navController.navigateUp() },
-                shape = RoundedCornerShape(16.dp),
-                leadingIcon = {
-                    Icon(painter = painterResource(R.drawable.close), contentDescription = "")
-                },
-            )
-        }
-    }
-
     val lazyListState = rememberLazyListState()
     val lazyGridState = rememberLazyGridState()
     val backStackEntry by navController.currentBackStackEntryAsState()
@@ -334,12 +313,7 @@ fun LocalMusicScreen(
 
     Box(modifier = Modifier.fillMaxSize()) {
         if (!hasPermission) {
-            // Just show filter chip, dialog handles permission request
-            Column(
-                modifier = Modifier.fillMaxSize(),
-            ) {
-                filterContent()
-            }
+            // Permission dialog handles permission request
         } else if (isInitialSync) {
             // Full-screen loading for initial sync
             Column(
@@ -348,7 +322,6 @@ fun LocalMusicScreen(
                     .padding(32.dp),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                filterContent()
                 Spacer(modifier = Modifier.weight(1f))
                 CircularProgressIndicator()
                 Spacer(modifier = Modifier.padding(16.dp))
@@ -381,10 +354,6 @@ fun LocalMusicScreen(
                             state = lazyListState,
                             contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues(),
                         ) {
-                            item(key = "filter", contentType = CONTENT_TYPE_HEADER) {
-                                filterContent()
-                            }
-
                             item(key = "header", contentType = CONTENT_TYPE_HEADER) {
                                 headerContent()
                             }
@@ -430,14 +399,6 @@ fun LocalMusicScreen(
                             ),
                             contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues(),
                         ) {
-                            item(
-                                key = "filter",
-                                span = { GridItemSpan(maxLineSpan) },
-                                contentType = CONTENT_TYPE_HEADER,
-                            ) {
-                                filterContent()
-                            }
-
                             item(
                                 key = "header",
                                 span = { GridItemSpan(maxLineSpan) },

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalMusicScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalMusicScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.asPaddingValues
@@ -71,8 +72,10 @@ import com.metrolist.music.constants.ArtistSortDescendingKey
 import com.metrolist.music.constants.ArtistSortType
 import com.metrolist.music.constants.ArtistSortTypeKey
 import com.metrolist.music.constants.ArtistViewTypeKey
+import com.metrolist.music.constants.CONTENT_TYPE_ALBUM
 import com.metrolist.music.constants.CONTENT_TYPE_ARTIST
 import com.metrolist.music.constants.CONTENT_TYPE_HEADER
+import com.metrolist.music.constants.CONTENT_TYPE_SONG
 import com.metrolist.music.constants.GridItemSize
 import com.metrolist.music.constants.GridItemsSizeKey
 import com.metrolist.music.constants.GridThumbnailHeight
@@ -91,6 +94,7 @@ import com.metrolist.music.ui.component.SongListItem
 import com.metrolist.music.ui.component.SortHeader
 import com.metrolist.music.ui.component.AlbumListItem
 import com.metrolist.music.ui.component.AlbumGridItem
+import com.metrolist.music.ui.menu.AlbumMenu
 import com.metrolist.music.ui.menu.SongMenu
 import com.metrolist.music.utils.LocalMusicRepository
 import com.metrolist.music.utils.LocalSyncStatus
@@ -108,6 +112,7 @@ fun LocalMusicScreen(
     viewModel: LocalMusicViewModel = hiltViewModel(),
 ) {
     val menuState = LocalMenuState.current
+    val playerConnection = LocalPlayerConnection.current
     val haptic = LocalHapticFeedback.current
     val coroutineScope = rememberCoroutineScope()
     val database = LocalDatabase.current
@@ -124,19 +129,14 @@ fun LocalMusicScreen(
     val syncStatus by viewModel.syncStatus.collectAsState()
     val syncProgress by viewModel.syncProgress.collectAsState()
     val localArtists by viewModel.localArtists.collectAsState()
+    val allLocalAlbums by viewModel.allLocalAlbums.collectAsState()
+    val allLocalSongs by viewModel.allLocalSongs.collectAsState()
 
     Timber.d("LocalMusicScreen: COMPOSE - hasPermission=$hasPermission, syncStatus=$syncStatus, syncProgress=$syncProgress, artistCount=${localArtists.size}")
 
     var searchQuery by remember { mutableStateOf(TextFieldValue("")) }
     var isSearching by remember { mutableStateOf(false) }
     val searchFocusRequester = remember { FocusRequester() }
-
-    // Auto-focus search field when search is opened
-    LaunchedEffect(isSearching) {
-        if (isSearching) {
-            searchFocusRequester.requestFocus()
-        }
-    }
     var showPermissionDialog by remember { mutableStateOf(false) }
 
     val filteredArtists = remember(localArtists, searchQuery.text, sortType, sortDescending) {
@@ -151,6 +151,30 @@ fun LocalMusicScreen(
                     else -> artists
                 }.let { if (sortDescending) it.reversed() else it }
             }
+    }
+
+    val filteredAlbums = remember(allLocalAlbums, searchQuery.text) {
+        if (searchQuery.text.isEmpty()) emptyList()
+        else allLocalAlbums.filter { album ->
+            album.album.title.contains(searchQuery.text, ignoreCase = true)
+        }
+    }
+
+    val filteredSongs = remember(allLocalSongs, searchQuery.text) {
+        if (searchQuery.text.isEmpty()) emptyList()
+        else allLocalSongs.filter { song ->
+            song.song.title.contains(searchQuery.text, ignoreCase = true) ||
+            song.song.albumName?.contains(searchQuery.text, ignoreCase = true) == true
+        }
+    }
+
+    val isActiveSearch = isSearching && searchQuery.text.isNotEmpty()
+
+    // Auto-focus search field when search is opened
+    LaunchedEffect(isSearching) {
+        if (isSearching) {
+            searchFocusRequester.requestFocus()
+        }
     }
 
     val permissionLauncher = rememberLauncherForActivityResult(
@@ -228,35 +252,6 @@ fun LocalMusicScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp, vertical = 8.dp),
-                )
-            }
-
-            if (isSearching) {
-                OutlinedTextField(
-                    value = searchQuery,
-                    onValueChange = { searchQuery = it },
-                    placeholder = { Text(stringResource(R.string.search)) },
-                    leadingIcon = {
-                        Icon(
-                            painter = painterResource(R.drawable.search),
-                            contentDescription = null
-                        )
-                    },
-                    trailingIcon = {
-                        if (searchQuery.text.isNotEmpty()) {
-                            IconButton(onClick = { searchQuery = TextFieldValue("") }) {
-                                Icon(
-                                    painter = painterResource(R.drawable.close),
-                                    contentDescription = null
-                                )
-                            }
-                        }
-                    },
-                    singleLine = true,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 8.dp)
-                        .focusRequester(searchFocusRequester)
                 )
             }
 
@@ -350,55 +345,230 @@ fun LocalMusicScreen(
                 Spacer(modifier = Modifier.weight(1f))
             }
         } else {
-            PullToRefreshBox(
-                isRefreshing = syncStatus is LocalSyncStatus.Syncing,
-                onRefresh = {
-                    Timber.d("LocalMusicScreen: Pull-to-refresh triggered")
-                    coroutineScope.launch {
-                        viewModel.syncLocalMusic()
-                    }
-                },
+            val windowInsets = LocalPlayerAwareWindowInsets.current
+            val bottomPadding = windowInsets.asPaddingValues().calculateBottomPadding()
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(top = windowInsets.asPaddingValues().calculateTopPadding())
             ) {
-                when (viewType) {
+                // Search TextField outside lazy content to prevent recreation on view type change
+                if (isSearching) {
+                    OutlinedTextField(
+                        value = searchQuery,
+                        onValueChange = { searchQuery = it },
+                        placeholder = { Text(stringResource(R.string.search)) },
+                        leadingIcon = {
+                            Icon(
+                                painter = painterResource(R.drawable.search),
+                                contentDescription = null
+                            )
+                        },
+                        trailingIcon = {
+                            if (searchQuery.text.isNotEmpty()) {
+                                IconButton(onClick = { searchQuery = TextFieldValue("") }) {
+                                    Icon(
+                                        painter = painterResource(R.drawable.close),
+                                        contentDescription = null
+                                    )
+                                }
+                            }
+                        },
+                        singleLine = true,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 8.dp)
+                            .focusRequester(searchFocusRequester)
+                    )
+                }
+
+                PullToRefreshBox(
+                    isRefreshing = syncStatus is LocalSyncStatus.Syncing,
+                    onRefresh = {
+                        Timber.d("LocalMusicScreen: Pull-to-refresh triggered")
+                        coroutineScope.launch {
+                            viewModel.syncLocalMusic()
+                        }
+                    },
+                    modifier = Modifier.weight(1f)
+                ) {
+                    // Force list view when actively searching to show albums and songs
+                    val effectiveViewType = if (isActiveSearch) LibraryViewType.LIST else viewType
+                when (effectiveViewType) {
                     LibraryViewType.LIST ->
                         LazyColumn(
                             state = lazyListState,
-                            contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues(),
+                            contentPadding = PaddingValues(bottom = bottomPadding),
                         ) {
                             item(key = "header", contentType = CONTENT_TYPE_HEADER) {
                                 headerContent()
                             }
 
-                            if (filteredArtists.isEmpty() && syncStatus !is LocalSyncStatus.Syncing) {
-                                item(key = "empty_placeholder") {
-                                    EmptyPlaceholder(
-                                        icon = R.drawable.artist,
-                                        text = stringResource(R.string.no_local_artists),
+                            if (isActiveSearch) {
+                                // Search results mode
+                                if (filteredArtists.isEmpty() && filteredAlbums.isEmpty() && filteredSongs.isEmpty()) {
+                                    item(key = "no_results") {
+                                        EmptyPlaceholder(
+                                            icon = R.drawable.search,
+                                            text = stringResource(R.string.no_results_found),
+                                        )
+                                    }
+                                }
+
+                                if (filteredArtists.isNotEmpty()) {
+                                    item(key = "artists_header") {
+                                        Text(
+                                            text = stringResource(R.string.artists),
+                                            style = MaterialTheme.typography.titleMedium,
+                                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                                        )
+                                    }
+                                    items(
+                                        items = filteredArtists,
+                                        key = { "artist_${it.id}" },
+                                        contentType = { CONTENT_TYPE_ARTIST },
+                                    ) { artist ->
+                                        ArtistListItem(
+                                            artist = artist,
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .clickable {
+                                                    navController.navigate("local_artist/${artist.id}")
+                                                }
+                                                .animateItem()
+                                        )
+                                    }
+                                }
+
+                                if (filteredAlbums.isNotEmpty()) {
+                                    item(key = "albums_header") {
+                                        Text(
+                                            text = stringResource(R.string.albums),
+                                            style = MaterialTheme.typography.titleMedium,
+                                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                                        )
+                                    }
+                                    items(
+                                        items = filteredAlbums,
+                                        key = { "album_${it.id}" },
+                                        contentType = { CONTENT_TYPE_ALBUM },
+                                    ) { album ->
+                                        AlbumListItem(
+                                            album = album,
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .combinedClickable(
+                                                    onClick = {
+                                                        navController.navigate("local_album/${album.id}")
+                                                    },
+                                                    onLongClick = {
+                                                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                                        menuState.show {
+                                                            AlbumMenu(
+                                                                originalAlbum = album,
+                                                                navController = navController,
+                                                                onDismiss = menuState::dismiss
+                                                            )
+                                                        }
+                                                    }
+                                                )
+                                                .animateItem()
+                                        )
+                                    }
+                                }
+
+                                if (filteredSongs.isNotEmpty()) {
+                                    item(key = "songs_header") {
+                                        Text(
+                                            text = stringResource(R.string.songs),
+                                            style = MaterialTheme.typography.titleMedium,
+                                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                                        )
+                                    }
+                                    items(
+                                        items = filteredSongs,
+                                        key = { "song_${it.id}" },
+                                        contentType = { CONTENT_TYPE_SONG },
+                                    ) { song ->
+                                        SongListItem(
+                                            song = song,
+                                            trailingContent = {
+                                                IconButton(
+                                                    onClick = {
+                                                        menuState.show {
+                                                            SongMenu(
+                                                                originalSong = song,
+                                                                navController = navController,
+                                                                onDismiss = menuState::dismiss
+                                                            )
+                                                        }
+                                                    }
+                                                ) {
+                                                    Icon(
+                                                        painter = painterResource(R.drawable.more_vert),
+                                                        contentDescription = null
+                                                    )
+                                                }
+                                            },
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .combinedClickable(
+                                                    onClick = {
+                                                        playerConnection?.playQueue(
+                                                            ListQueue(
+                                                                title = song.song.title,
+                                                                items = listOf(song.toMediaItem())
+                                                            )
+                                                        )
+                                                    },
+                                                    onLongClick = {
+                                                        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                                        menuState.show {
+                                                            SongMenu(
+                                                                originalSong = song,
+                                                                navController = navController,
+                                                                onDismiss = menuState::dismiss
+                                                            )
+                                                        }
+                                                    }
+                                                )
+                                                .animateItem()
+                                        )
+                                    }
+                                }
+                            } else {
+                                // Normal artist list mode
+                                if (filteredArtists.isEmpty() && syncStatus !is LocalSyncStatus.Syncing) {
+                                    item(key = "empty_placeholder") {
+                                        EmptyPlaceholder(
+                                            icon = R.drawable.artist,
+                                            text = stringResource(R.string.no_local_artists),
+                                        )
+                                    }
+                                }
+
+                                items(
+                                    items = filteredArtists,
+                                    key = { it.id },
+                                    contentType = { CONTENT_TYPE_ARTIST },
+                                ) { artist ->
+                                    ArtistListItem(
+                                        artist = artist,
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .combinedClickable(
+                                                onClick = {
+                                                    Timber.d("LocalMusicScreen: Artist clicked - id=${artist.id}, name=${artist.artist.name}")
+                                                    navController.navigate("local_artist/${artist.id}")
+                                                },
+                                                onLongClick = {
+                                                    haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                                    Timber.d("LocalMusicScreen: Artist long-pressed - id=${artist.id}")
+                                                },
+                                            )
+                                            .animateItem()
                                     )
                                 }
-                            }
-
-                            items(
-                                items = filteredArtists,
-                                key = { it.id },
-                                contentType = { CONTENT_TYPE_ARTIST },
-                            ) { artist ->
-                                ArtistListItem(
-                                    artist = artist,
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .combinedClickable(
-                                            onClick = {
-                                                Timber.d("LocalMusicScreen: Artist clicked - id=${artist.id}, name=${artist.artist.name}")
-                                                navController.navigate("local_artist/${artist.id}")
-                                            },
-                                            onLongClick = {
-                                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                                                Timber.d("LocalMusicScreen: Artist long-pressed - id=${artist.id}")
-                                            },
-                                        )
-                                        .animateItem()
-                                )
                             }
                         }
 
@@ -408,7 +578,7 @@ fun LocalMusicScreen(
                             columns = GridCells.Adaptive(
                                 minSize = GridThumbnailHeight + if (gridItemSize == GridItemSize.BIG) 24.dp else (-24).dp,
                             ),
-                            contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues(),
+                            contentPadding = PaddingValues(bottom = bottomPadding),
                         ) {
                             item(
                                 key = "header",
@@ -452,6 +622,7 @@ fun LocalMusicScreen(
                             }
                         }
                 }
+            }
             }
         }
     }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalMusicScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LocalMusicScreen.kt
@@ -1,0 +1,501 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.ui.screens.library
+
+import android.Manifest
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import androidx.navigation.compose.currentBackStackEntryAsState
+import com.metrolist.music.LocalDatabase
+import com.metrolist.music.LocalPlayerAwareWindowInsets
+import com.metrolist.music.LocalPlayerConnection
+import com.metrolist.music.R
+import com.metrolist.music.constants.ArtistSortDescendingKey
+import com.metrolist.music.constants.ArtistSortType
+import com.metrolist.music.constants.ArtistSortTypeKey
+import com.metrolist.music.constants.ArtistViewTypeKey
+import com.metrolist.music.constants.CONTENT_TYPE_ARTIST
+import com.metrolist.music.constants.CONTENT_TYPE_HEADER
+import com.metrolist.music.constants.GridItemSize
+import com.metrolist.music.constants.GridItemsSizeKey
+import com.metrolist.music.constants.GridThumbnailHeight
+import com.metrolist.music.constants.LibraryViewType
+import com.metrolist.music.db.entities.Album
+import com.metrolist.music.db.entities.Artist
+import com.metrolist.music.db.entities.Song
+import com.metrolist.music.extensions.toMediaItem
+import com.metrolist.music.playback.queues.ListQueue
+import com.metrolist.music.ui.component.ArtistGridItem
+import com.metrolist.music.ui.component.ArtistListItem
+import com.metrolist.music.ui.component.DefaultDialog
+import com.metrolist.music.ui.component.EmptyPlaceholder
+import com.metrolist.music.ui.component.LocalMenuState
+import com.metrolist.music.ui.component.SongListItem
+import com.metrolist.music.ui.component.SortHeader
+import com.metrolist.music.ui.component.AlbumListItem
+import com.metrolist.music.ui.component.AlbumGridItem
+import com.metrolist.music.ui.menu.SongMenu
+import com.metrolist.music.utils.LocalMusicRepository
+import com.metrolist.music.utils.LocalSyncStatus
+import com.metrolist.music.utils.rememberEnumPreference
+import com.metrolist.music.utils.rememberPreference
+import com.metrolist.music.viewmodels.LocalMusicViewModel
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@Composable
+fun LocalMusicScreen(
+    navController: NavController,
+    scrollBehavior: TopAppBarScrollBehavior,
+    viewModel: LocalMusicViewModel = hiltViewModel(),
+) {
+    val menuState = LocalMenuState.current
+    val haptic = LocalHapticFeedback.current
+    val coroutineScope = rememberCoroutineScope()
+    val database = LocalDatabase.current
+
+    var viewType by rememberEnumPreference(ArtistViewTypeKey, LibraryViewType.GRID)
+    val (sortType, onSortTypeChange) = rememberEnumPreference(
+        ArtistSortTypeKey,
+        ArtistSortType.NAME
+    )
+    val (sortDescending, onSortDescendingChange) = rememberPreference(ArtistSortDescendingKey, false)
+    val gridItemSize by rememberEnumPreference(GridItemsSizeKey, GridItemSize.BIG)
+
+    val hasPermission by viewModel.hasPermission.collectAsState()
+    val syncStatus by viewModel.syncStatus.collectAsState()
+    val syncProgress by viewModel.syncProgress.collectAsState()
+    val localArtists by viewModel.localArtists.collectAsState()
+
+    Timber.d("LocalMusicScreen: COMPOSE - hasPermission=$hasPermission, syncStatus=$syncStatus, syncProgress=$syncProgress, artistCount=${localArtists.size}")
+
+    var searchQuery by remember { mutableStateOf(TextFieldValue("")) }
+    var isSearching by remember { mutableStateOf(false) }
+    var showPermissionDialog by remember { mutableStateOf(false) }
+
+    val filteredArtists = remember(localArtists, searchQuery.text, sortType, sortDescending) {
+        localArtists
+            .filter { artist ->
+                searchQuery.text.isEmpty() || artist.artist.name.contains(searchQuery.text, ignoreCase = true)
+            }
+            .let { artists ->
+                when (sortType) {
+                    ArtistSortType.NAME -> artists.sortedBy { it.artist.name.lowercase() }
+                    ArtistSortType.SONG_COUNT -> artists.sortedBy { it.songCount }
+                    else -> artists
+                }.let { if (sortDescending) it.reversed() else it }
+            }
+    }
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        Timber.d("LocalMusicScreen: Permission result callback - granted=$granted")
+        if (granted) {
+            Timber.d("LocalMusicScreen: Permission granted, updating state and launching sync")
+            viewModel.refreshPermissionState()
+            coroutineScope.launch {
+                viewModel.syncLocalMusic()
+            }
+        } else {
+            Timber.w("LocalMusicScreen: Permission DENIED by user")
+        }
+    }
+
+    LaunchedEffect(hasPermission) {
+        Timber.d("LocalMusicScreen: LaunchedEffect(hasPermission=$hasPermission)")
+        if (!hasPermission) {
+            Timber.d("LocalMusicScreen: Showing permission dialog")
+            showPermissionDialog = true
+        } else {
+            Timber.d("LocalMusicScreen: Permission already granted, no request needed")
+        }
+    }
+
+    if (showPermissionDialog) {
+        DefaultDialog(
+            onDismiss = { showPermissionDialog = false },
+            title = { Text(stringResource(R.string.local_music_permission_title)) },
+            buttons = {
+                TextButton(onClick = { showPermissionDialog = false }) {
+                    Text(stringResource(android.R.string.cancel))
+                }
+                TextButton(onClick = {
+                    showPermissionDialog = false
+                    val permission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                        Manifest.permission.READ_MEDIA_AUDIO
+                    } else {
+                        Manifest.permission.READ_EXTERNAL_STORAGE
+                    }
+                    Timber.d("LocalMusicScreen: Launching permission request for $permission")
+                    permissionLauncher.launch(permission)
+                }) {
+                    Text(stringResource(R.string.grant_permission))
+                }
+            }
+        ) {
+            Text(stringResource(R.string.local_music_permission_desc))
+        }
+    }
+
+    val filterContent = @Composable {
+        Row {
+            Spacer(Modifier.width(12.dp))
+            FilterChip(
+                label = { Text(stringResource(R.string.filter_local)) },
+                selected = true,
+                colors = FilterChipDefaults.filterChipColors(containerColor = MaterialTheme.colorScheme.surface),
+                onClick = { navController.navigateUp() },
+                shape = RoundedCornerShape(16.dp),
+                leadingIcon = {
+                    Icon(painter = painterResource(R.drawable.close), contentDescription = "")
+                },
+            )
+        }
+    }
+
+    val lazyListState = rememberLazyListState()
+    val lazyGridState = rememberLazyGridState()
+    val backStackEntry by navController.currentBackStackEntryAsState()
+    val scrollToTop =
+        backStackEntry?.savedStateHandle?.getStateFlow("scrollToTop", false)?.collectAsState()
+
+    LaunchedEffect(scrollToTop?.value) {
+        if (scrollToTop?.value == true) {
+            when (viewType) {
+                LibraryViewType.LIST -> lazyListState.animateScrollToItem(0)
+                LibraryViewType.GRID -> lazyGridState.animateScrollToItem(0)
+            }
+            backStackEntry?.savedStateHandle?.set("scrollToTop", false)
+        }
+    }
+
+    val headerContent = @Composable {
+        Column {
+            if (syncStatus is LocalSyncStatus.Syncing) {
+                LinearProgressIndicator(
+                    progress = { syncProgress },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                )
+            }
+
+            if (isSearching) {
+                OutlinedTextField(
+                    value = searchQuery,
+                    onValueChange = { searchQuery = it },
+                    placeholder = { Text(stringResource(R.string.search)) },
+                    leadingIcon = {
+                        Icon(
+                            painter = painterResource(R.drawable.search),
+                            contentDescription = null
+                        )
+                    },
+                    trailingIcon = {
+                        if (searchQuery.text.isNotEmpty()) {
+                            IconButton(onClick = { searchQuery = TextFieldValue("") }) {
+                                Icon(
+                                    painter = painterResource(R.drawable.close),
+                                    contentDescription = null
+                                )
+                            }
+                        }
+                    },
+                    singleLine = true,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                )
+            }
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(start = 16.dp),
+            ) {
+                SortHeader(
+                    sortType = sortType,
+                    sortDescending = sortDescending,
+                    onSortTypeChange = onSortTypeChange,
+                    onSortDescendingChange = onSortDescendingChange,
+                    sortTypeText = { sortType ->
+                        when (sortType) {
+                            ArtistSortType.CREATE_DATE -> R.string.sort_by_create_date
+                            ArtistSortType.NAME -> R.string.sort_by_name
+                            ArtistSortType.SONG_COUNT -> R.string.sort_by_song_count
+                            ArtistSortType.PLAY_TIME -> R.string.sort_by_play_time
+                        }
+                    },
+                )
+
+                Spacer(Modifier.weight(1f))
+
+                Text(
+                    text = pluralStringResource(
+                        R.plurals.n_artist,
+                        filteredArtists.size,
+                        filteredArtists.size
+                    ),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.secondary,
+                )
+
+                IconButton(
+                    onClick = { isSearching = !isSearching },
+                    modifier = Modifier.padding(horizontal = 4.dp),
+                ) {
+                    Icon(
+                        painter = painterResource(R.drawable.search),
+                        contentDescription = null,
+                    )
+                }
+
+                IconButton(
+                    onClick = { viewType = viewType.toggle() },
+                    modifier = Modifier.padding(end = 6.dp),
+                ) {
+                    Icon(
+                        painter = painterResource(
+                            when (viewType) {
+                                LibraryViewType.LIST -> R.drawable.list
+                                LibraryViewType.GRID -> R.drawable.grid_view
+                            },
+                        ),
+                        contentDescription = null,
+                    )
+                }
+            }
+        }
+    }
+
+    // Show full-screen loading during initial sync (no data yet)
+    val isInitialSync = hasPermission && syncStatus is LocalSyncStatus.Syncing && localArtists.isEmpty()
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        if (!hasPermission) {
+            // Just show filter chip, dialog handles permission request
+            Column(
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                filterContent()
+            }
+        } else if (isInitialSync) {
+            // Full-screen loading for initial sync
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(32.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                filterContent()
+                Spacer(modifier = Modifier.weight(1f))
+                CircularProgressIndicator()
+                Spacer(modifier = Modifier.padding(16.dp))
+                Text(
+                    text = stringResource(R.string.syncing_local_music),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(modifier = Modifier.padding(8.dp))
+                Text(
+                    text = "${(syncProgress * 100).toInt()}%",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                Spacer(modifier = Modifier.weight(1f))
+            }
+        } else {
+            PullToRefreshBox(
+                isRefreshing = syncStatus is LocalSyncStatus.Syncing,
+                onRefresh = {
+                    Timber.d("LocalMusicScreen: Pull-to-refresh triggered")
+                    coroutineScope.launch {
+                        viewModel.syncLocalMusic()
+                    }
+                },
+            ) {
+                when (viewType) {
+                    LibraryViewType.LIST ->
+                        LazyColumn(
+                            state = lazyListState,
+                            contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues(),
+                        ) {
+                            item(key = "filter", contentType = CONTENT_TYPE_HEADER) {
+                                filterContent()
+                            }
+
+                            item(key = "header", contentType = CONTENT_TYPE_HEADER) {
+                                headerContent()
+                            }
+
+                            if (filteredArtists.isEmpty() && syncStatus !is LocalSyncStatus.Syncing) {
+                                item(key = "empty_placeholder") {
+                                    EmptyPlaceholder(
+                                        icon = R.drawable.artist,
+                                        text = stringResource(R.string.no_local_artists),
+                                    )
+                                }
+                            }
+
+                            items(
+                                items = filteredArtists,
+                                key = { it.id },
+                                contentType = { CONTENT_TYPE_ARTIST },
+                            ) { artist ->
+                                ArtistListItem(
+                                    artist = artist,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .combinedClickable(
+                                            onClick = {
+                                                Timber.d("LocalMusicScreen: Artist clicked - id=${artist.id}, name=${artist.artist.name}")
+                                                navController.navigate("local_artist/${artist.id}")
+                                            },
+                                            onLongClick = {
+                                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                                Timber.d("LocalMusicScreen: Artist long-pressed - id=${artist.id}")
+                                            },
+                                        )
+                                        .animateItem()
+                                )
+                            }
+                        }
+
+                    LibraryViewType.GRID ->
+                        LazyVerticalGrid(
+                            state = lazyGridState,
+                            columns = GridCells.Adaptive(
+                                minSize = GridThumbnailHeight + if (gridItemSize == GridItemSize.BIG) 24.dp else (-24).dp,
+                            ),
+                            contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues(),
+                        ) {
+                            item(
+                                key = "filter",
+                                span = { GridItemSpan(maxLineSpan) },
+                                contentType = CONTENT_TYPE_HEADER,
+                            ) {
+                                filterContent()
+                            }
+
+                            item(
+                                key = "header",
+                                span = { GridItemSpan(maxLineSpan) },
+                                contentType = CONTENT_TYPE_HEADER,
+                            ) {
+                                headerContent()
+                            }
+
+                            if (filteredArtists.isEmpty() && syncStatus !is LocalSyncStatus.Syncing) {
+                                item(span = { GridItemSpan(maxLineSpan) }) {
+                                    EmptyPlaceholder(
+                                        icon = R.drawable.artist,
+                                        text = stringResource(R.string.no_local_artists),
+                                    )
+                                }
+                            }
+
+                            items(
+                                items = filteredArtists,
+                                key = { it.id },
+                                contentType = { CONTENT_TYPE_ARTIST },
+                            ) { artist ->
+                                ArtistGridItem(
+                                    artist = artist,
+                                    fillMaxWidth = true,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .combinedClickable(
+                                            onClick = {
+                                                Timber.d("LocalMusicScreen: Artist grid item clicked - id=${artist.id}, name=${artist.artist.name}")
+                                                navController.navigate("local_artist/${artist.id}")
+                                            },
+                                            onLongClick = {
+                                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                                Timber.d("LocalMusicScreen: Artist long-pressed - id=${artist.id}")
+                                            },
+                                        )
+                                        .animateItem()
+                                )
+                            }
+                        }
+                }
+            }
+        }
+    }
+
+    TopAppBar(
+        title = { Text(stringResource(R.string.local_music)) },
+        navigationIcon = {
+            IconButton(
+                onClick = navController::navigateUp,
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.arrow_back),
+                    contentDescription = null,
+                )
+            }
+        },
+        scrollBehavior = scrollBehavior,
+    )
+}

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AppearanceSettings.kt
@@ -567,6 +567,7 @@ fun AppearanceSettings(
                     LibraryFilter.ALBUMS -> stringResource(R.string.albums)
                     LibraryFilter.PLAYLISTS -> stringResource(R.string.playlists)
                     LibraryFilter.LIBRARY -> stringResource(R.string.filter_library)
+                    LibraryFilter.LOCAL -> stringResource(R.string.filter_local)
                 }
             }
         )
@@ -1285,6 +1286,7 @@ fun AppearanceSettings(
                                 LibraryFilter.ALBUMS -> stringResource(R.string.albums)
                                 LibraryFilter.PLAYLISTS -> stringResource(R.string.playlists)
                                 LibraryFilter.LIBRARY -> stringResource(R.string.filter_library)
+                                LibraryFilter.LOCAL -> stringResource(R.string.filter_local)
                             }
                         )
                     },

--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/ShowMediaInfo.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/ShowMediaInfo.kt
@@ -72,8 +72,14 @@ fun ShowMediaInfo(videoId: String) {
     val context = LocalContext.current
     val clipboardManager = LocalClipboard.current
 
+    // Check if this is a local song (ID starts with LOCAL_)
+    val isLocalSong = videoId.startsWith("LOCAL_")
+
     LaunchedEffect(Unit, videoId) {
-        info = YouTube.getMediaInfo(videoId).getOrNull()
+        // Only fetch from YouTube for non-local songs
+        if (!isLocalSong) {
+            info = YouTube.getMediaInfo(videoId).getOrNull()
+        }
     }
     LaunchedEffect(Unit, videoId) {
         database.song(videoId).collect {
@@ -126,7 +132,26 @@ fun ShowMediaInfo(videoId: String) {
                         stringResource(R.string.song_artists) to song?.artists?.joinToString { it.name },
                         stringResource(R.string.media_id) to song?.id
                     )
-                    val extendedList = baseList + if (currentFormat != null) {
+
+                    // Add local file specific info
+                    val localInfoList = if (isLocalSong) {
+                        listOf(
+                            stringResource(R.string.album) to song?.song?.albumName,
+                            stringResource(R.string.year) to song?.song?.year?.toString(),
+                            stringResource(R.string.duration) to song?.song?.duration?.let {
+                                val minutes = it / 60
+                                val seconds = it % 60
+                                String.format("%d:%02d", minutes, seconds)
+                            },
+                            stringResource(R.string.file_path) to song?.song?.downloadUri,
+                            stringResource(R.string.volume) to if (playerConnection != null)
+                                "${(playerConnection.player.volume * 100).toInt()}%" else null,
+                        )
+                    } else {
+                        emptyList()
+                    }
+
+                    val formatList = if (currentFormat != null && !isLocalSong) {
                         listOf(
                             "Itag" to currentFormat?.itag?.toString(),
                             stringResource(R.string.mime_type) to currentFormat?.mimeType,
@@ -147,6 +172,8 @@ fun ShowMediaInfo(videoId: String) {
                     } else {
                         emptyList()
                     }
+
+                    val extendedList = baseList + localInfoList + formatList
 
                     extendedList.forEach { (label, text) ->
                         val displayText = text ?: stringResource(R.string.unknown)
@@ -184,16 +211,19 @@ fun ShowMediaInfo(videoId: String) {
             }
         }
 
-        item(contentType = "TitleMediaInfo") {
-            Text(
-                text = stringResource(R.string.information),
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onBackground,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.fillMaxWidth()
-            )
+        // Only show YouTube information section for non-local songs
+        if (!isLocalSong) {
+            item(contentType = "TitleMediaInfo") {
+                Text(
+                    text = stringResource(R.string.information),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onBackground,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
         }
-        if (info != null) {
+        if (info != null && !isLocalSong) {
             if (song == null)
                 item(contentType = "MediaTitle") {
                     Column(
@@ -294,7 +324,8 @@ fun ShowMediaInfo(videoId: String) {
                     }
                 }
             }
-        } else {
+        } else if (!isLocalSong) {
+            // Only show loading shimmer for non-local songs
             item(contentType = "MediaInfoLoader") {
                 ShimmerHost {
                     Row(

--- a/app/src/main/kotlin/com/metrolist/music/utils/LocalMusicRepository.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/LocalMusicRepository.kt
@@ -94,9 +94,11 @@ class LocalMusicRepository @Inject constructor(
                 MediaStore.Audio.Media.DURATION,
                 MediaStore.Audio.Media.TRACK,
                 MediaStore.Audio.Media.YEAR,
+                MediaStore.Audio.Media.DATA,  // Full file path for folder browsing
             )
 
-            val selection = "${MediaStore.Audio.Media.IS_MUSIC} != 0"
+            // Include all audio files (m4a, webm, mp3, flac, etc.)
+            val selection = "(${MediaStore.Audio.Media.IS_MUSIC} != 0 OR ${MediaStore.Audio.Media.MIME_TYPE} LIKE 'audio/%')"
             val sortOrder = "${MediaStore.Audio.Media.TITLE} ASC"
 
             Timber.d("LocalMusic: syncLocalMusic() - Querying MediaStore.Audio.Media.EXTERNAL_CONTENT_URI")
@@ -119,6 +121,7 @@ class LocalMusicRepository @Inject constructor(
                 val durationCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DURATION)
                 val trackCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.TRACK)
                 val yearCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.YEAR)
+                val dataCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DATA)
 
                 val totalCount = cursor.count
                 var processedCount = 0
@@ -151,6 +154,8 @@ class LocalMusicRepository @Inject constructor(
                         val duration = cursor.getInt(durationCol) / 1000
                         val trackNumber = cursor.getInt(trackCol)
                         val year = cursor.getInt(yearCol).takeIf { it > 0 }
+                        val filePath = cursor.getString(dataCol)
+                        val folderPath = filePath?.substringBeforeLast('/')
 
                         val songId = "LOCAL_$mediaStoreId"
                         val localArtistId = artistCache.getOrPut(artistName.lowercase()) {
@@ -214,6 +219,7 @@ class LocalMusicRepository @Inject constructor(
                                 year = year,
                                 isLocal = true,
                                 downloadUri = contentUri,
+                                localPath = filePath,
                                 inLibrary = LocalDateTime.now()
                             )
                         )

--- a/app/src/main/kotlin/com/metrolist/music/utils/LocalMusicRepository.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/LocalMusicRepository.kt
@@ -1,0 +1,301 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.utils
+
+import android.Manifest
+import android.content.ContentUris
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.provider.MediaStore
+import androidx.core.content.ContextCompat
+import com.metrolist.music.db.MusicDatabase
+import com.metrolist.music.db.entities.AlbumArtistMap
+import com.metrolist.music.db.entities.AlbumEntity
+import com.metrolist.music.db.entities.ArtistEntity
+import com.metrolist.music.db.entities.SongAlbumMap
+import com.metrolist.music.db.entities.SongArtistMap
+import com.metrolist.music.db.entities.SongEntity
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.time.LocalDateTime
+import javax.inject.Inject
+import javax.inject.Singleton
+
+sealed class LocalSyncStatus {
+    data object Idle : LocalSyncStatus()
+    data object Syncing : LocalSyncStatus()
+    data object Completed : LocalSyncStatus()
+    data class Error(val message: String) : LocalSyncStatus()
+}
+
+@Singleton
+class LocalMusicRepository @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val database: MusicDatabase,
+) {
+    private val _syncStatus = MutableStateFlow<LocalSyncStatus>(LocalSyncStatus.Idle)
+    val syncStatus: StateFlow<LocalSyncStatus> = _syncStatus.asStateFlow()
+
+    private val _syncProgress = MutableStateFlow(0f)
+    val syncProgress: StateFlow<Float> = _syncProgress.asStateFlow()
+
+    fun hasPermission(): Boolean {
+        val permission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            Manifest.permission.READ_MEDIA_AUDIO
+        } else {
+            Manifest.permission.READ_EXTERNAL_STORAGE
+        }
+        val hasIt = ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED
+        Timber.d("LocalMusic: hasPermission() called - permission=$permission, granted=$hasIt, SDK=${Build.VERSION.SDK_INT}")
+        return hasIt
+    }
+
+    fun getRequiredPermission(): String {
+        val perm = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            Manifest.permission.READ_MEDIA_AUDIO
+        } else {
+            Manifest.permission.READ_EXTERNAL_STORAGE
+        }
+        Timber.d("LocalMusic: getRequiredPermission() = $perm")
+        return perm
+    }
+
+    suspend fun syncLocalMusic() = withContext(Dispatchers.IO) {
+        Timber.d("LocalMusic: syncLocalMusic() STARTED")
+        if (!hasPermission()) {
+            Timber.e("LocalMusic: syncLocalMusic() - Permission NOT granted, aborting")
+            _syncStatus.value = LocalSyncStatus.Error("Permission not granted")
+            return@withContext
+        }
+
+        Timber.d("LocalMusic: syncLocalMusic() - Permission granted, starting sync")
+        _syncStatus.value = LocalSyncStatus.Syncing
+        _syncProgress.value = 0f
+
+        try {
+            val contentResolver = context.contentResolver
+            Timber.d("LocalMusic: syncLocalMusic() - Got contentResolver: $contentResolver")
+
+            val projection = arrayOf(
+                MediaStore.Audio.Media._ID,
+                MediaStore.Audio.Media.TITLE,
+                MediaStore.Audio.Media.ARTIST,
+                MediaStore.Audio.Media.ALBUM,
+                MediaStore.Audio.Media.ALBUM_ID,
+                MediaStore.Audio.Media.DURATION,
+                MediaStore.Audio.Media.TRACK,
+                MediaStore.Audio.Media.YEAR,
+            )
+
+            val selection = "${MediaStore.Audio.Media.IS_MUSIC} != 0"
+            val sortOrder = "${MediaStore.Audio.Media.TITLE} ASC"
+
+            Timber.d("LocalMusic: syncLocalMusic() - Querying MediaStore.Audio.Media.EXTERNAL_CONTENT_URI")
+            Timber.d("LocalMusic: syncLocalMusic() - URI: ${MediaStore.Audio.Media.EXTERNAL_CONTENT_URI}")
+            Timber.d("LocalMusic: syncLocalMusic() - Selection: $selection")
+
+            contentResolver.query(
+                MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+                projection,
+                selection,
+                null,
+                sortOrder
+            )?.use { cursor ->
+                Timber.d("LocalMusic: syncLocalMusic() - Query returned cursor with ${cursor.count} rows")
+                val idCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media._ID)
+                val titleCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.TITLE)
+                val artistCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ARTIST)
+                val albumCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ALBUM)
+                val albumIdCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ALBUM_ID)
+                val durationCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DURATION)
+                val trackCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.TRACK)
+                val yearCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.YEAR)
+
+                val totalCount = cursor.count
+                var processedCount = 0
+                Timber.d("LocalMusic: syncLocalMusic() - Total songs to process: $totalCount")
+
+                val artistCache = mutableMapOf<String, String>()
+                val albumCache = mutableMapOf<Long, String>()
+                val artistThumbnailCache = mutableMapOf<String, String?>() // Track first album art per artist
+
+                // Collect all entities first, then batch insert in single transaction
+                val artistEntities = mutableListOf<ArtistEntity>()
+                val albumEntities = mutableListOf<AlbumEntity>()
+                val songEntities = mutableListOf<SongEntity>()
+                val songArtistMaps = mutableListOf<SongArtistMap>()
+                val songAlbumMaps = mutableListOf<SongAlbumMap>()
+                val albumArtistMaps = mutableListOf<AlbumArtistMap>()
+
+                while (cursor.moveToNext()) {
+                    try {
+                        val mediaStoreId = cursor.getLong(idCol)
+                        Timber.v("LocalMusic: Processing song mediaStoreId=$mediaStoreId")
+                        val title = cursor.getString(titleCol) ?: "Unknown"
+                        val artistName = cursor.getString(artistCol)?.takeIf {
+                            it.isNotBlank() && it != "<unknown>"
+                        } ?: "Unknown Artist"
+                        val albumName = cursor.getString(albumCol)?.takeIf {
+                            it.isNotBlank() && it != "<unknown>"
+                        } ?: "Unknown Album"
+                        val albumId = cursor.getLong(albumIdCol)
+                        val duration = cursor.getInt(durationCol) / 1000
+                        val trackNumber = cursor.getInt(trackCol)
+                        val year = cursor.getInt(yearCol).takeIf { it > 0 }
+
+                        val songId = "LOCAL_$mediaStoreId"
+                        val localArtistId = artistCache.getOrPut(artistName.lowercase()) {
+                            "LOCAL_ARTIST_${artistName.lowercase().hashCode()}"
+                        }
+                        val localAlbumId = albumCache.getOrPut(albumId) {
+                            "LOCAL_ALBUM_$albumId"
+                        }
+
+                        val contentUri = ContentUris.withAppendedId(
+                            MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+                            mediaStoreId
+                        ).toString()
+
+                        val albumArtUri = getAlbumArtUri(albumId)
+
+                        Timber.d("LocalMusic: Song details - id=$songId, title=$title, artist=$artistName, album=$albumName, duration=$duration, contentUri=$contentUri")
+
+                        // Track first album art for this artist
+                        if (!artistThumbnailCache.containsKey(localArtistId) && albumArtUri != null) {
+                            artistThumbnailCache[localArtistId] = albumArtUri
+                        }
+
+                        // Collect artist entity (deduped by cache)
+                        if (!artistCache.containsKey(artistName.lowercase() + "_added")) {
+                            artistEntities.add(
+                                ArtistEntity(
+                                    id = localArtistId,
+                                    name = artistName,
+                                    thumbnailUrl = albumArtUri, // Use first album art as thumbnail
+                                    isLocal = true
+                                )
+                            )
+                            artistCache[artistName.lowercase() + "_added"] = "true"
+                        }
+
+                        // Collect album entity (deduped by cache)
+                        if (!albumCache.containsKey(albumId + 1000000000L)) {
+                            albumEntities.add(
+                                AlbumEntity(
+                                    id = localAlbumId,
+                                    title = albumName,
+                                    year = year,
+                                    thumbnailUrl = albumArtUri,
+                                    songCount = 0,
+                                    duration = 0,
+                                    isLocal = true
+                                )
+                            )
+                            albumCache[albumId + 1000000000L] = "added"
+                        }
+
+                        songEntities.add(
+                            SongEntity(
+                                id = songId,
+                                title = title,
+                                duration = duration,
+                                thumbnailUrl = albumArtUri,
+                                albumId = localAlbumId,
+                                albumName = albumName,
+                                year = year,
+                                isLocal = true,
+                                downloadUri = contentUri,
+                                inLibrary = LocalDateTime.now()
+                            )
+                        )
+
+                        songArtistMaps.add(SongArtistMap(songId, localArtistId, 0))
+                        songAlbumMaps.add(SongAlbumMap(songId, localAlbumId, trackNumber))
+                        albumArtistMaps.add(AlbumArtistMap(localAlbumId, localArtistId, 0))
+
+                        processedCount++
+                        _syncProgress.value = processedCount.toFloat() / totalCount
+                        if (processedCount % 50 == 0) {
+                            Timber.d("LocalMusic: Sync progress - $processedCount / $totalCount songs collected")
+                        }
+                    } catch (e: Exception) {
+                        Timber.e(e, "LocalMusic: Error processing local song at index $processedCount")
+                    }
+                }
+
+                Timber.d("LocalMusic: Collected ${songEntities.size} songs, ${artistEntities.size} artists, ${albumEntities.size} albums - starting batch insert")
+
+                // Single transaction for all inserts - much faster and synchronous completion
+                database.transaction {
+                    Timber.d("LocalMusic: Batch inserting ${artistEntities.size} artists")
+                    artistEntities.forEach { upsert(it) }
+
+                    Timber.d("LocalMusic: Batch inserting ${albumEntities.size} albums")
+                    albumEntities.forEach { upsert(it) }
+
+                    Timber.d("LocalMusic: Batch inserting ${songEntities.size} songs")
+                    songEntities.forEach { upsert(it) }
+
+                    Timber.d("LocalMusic: Batch inserting ${songArtistMaps.size} song-artist maps")
+                    songArtistMaps.forEach { upsert(it) }
+
+                    Timber.d("LocalMusic: Batch inserting ${songAlbumMaps.size} song-album maps")
+                    songAlbumMaps.forEach { upsert(it) }
+
+                    Timber.d("LocalMusic: Batch inserting ${albumArtistMaps.size} album-artist maps")
+                    albumArtistMaps.distinctBy { it.albumId to it.artistId }.forEach { upsert(it) }
+                }
+
+                Timber.d("LocalMusic: Batch transaction submitted")
+                Timber.d("LocalMusic: Finished processing all $processedCount songs")
+            } ?: run {
+                Timber.e("LocalMusic: syncLocalMusic() - MediaStore query returned NULL cursor!")
+            }
+
+            updateAlbumStats()
+            _syncStatus.value = LocalSyncStatus.Completed
+            _syncProgress.value = 1f
+            Timber.d("LocalMusic: syncLocalMusic() COMPLETED SUCCESSFULLY")
+        } catch (e: Exception) {
+            Timber.e(e, "LocalMusic: syncLocalMusic() FAILED with exception: ${e.message}")
+            e.printStackTrace()
+            _syncStatus.value = LocalSyncStatus.Error(e.message ?: "Unknown error")
+        }
+    }
+
+    private fun getAlbumArtUri(albumId: Long): String? {
+        return try {
+            val uri = ContentUris.withAppendedId(
+                MediaStore.Audio.Albums.EXTERNAL_CONTENT_URI,
+                albumId
+            ).toString()
+            Timber.v("LocalMusic: getAlbumArtUri($albumId) = $uri")
+            uri
+        } catch (e: Exception) {
+            Timber.e(e, "LocalMusic: getAlbumArtUri($albumId) failed")
+            null
+        }
+    }
+
+    private suspend fun updateAlbumStats() = withContext(Dispatchers.IO) {
+        database.query {
+            // Update album song counts and durations via raw query would be complex,
+            // so we'll leave them as-is for now since they're not critical for display
+        }
+    }
+
+    fun resetSyncStatus() {
+        Timber.d("LocalMusic: resetSyncStatus() called")
+        _syncStatus.value = LocalSyncStatus.Idle
+        _syncProgress.value = 0f
+    }
+}

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/LocalMusicViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/LocalMusicViewModel.kt
@@ -99,9 +99,6 @@ class LocalArtistViewModel @Inject constructor(
         Timber.d("LocalArtistViewModel: INIT - artistId=$artistId")
     }
 
-    private val _isLoading = MutableStateFlow(true)
-    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
-
     val artist = database.artist(artistId)
         .stateIn(viewModelScope, SharingStarted.Lazily, null)
 
@@ -110,16 +107,6 @@ class LocalArtistViewModel @Inject constructor(
 
     val songs = database.localSongsByArtist(artistId)
         .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
-
-    init {
-        viewModelScope.launch {
-            // Wait for first emission from songs flow to mark loading complete
-            songs.collect {
-                _isLoading.value = false
-                return@collect
-            }
-        }
-    }
 }
 
 @HiltViewModel

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/LocalMusicViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/LocalMusicViewModel.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -51,6 +52,72 @@ class LocalMusicViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
 
     val allLocalAlbums = database.allLocalAlbums()
+        .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+    // Root-level folders (computed from paths)
+    val rootFolders: StateFlow<List<Pair<String, Int>>> = database.localSongPaths()
+        .map { paths ->
+            Timber.d("LocalMusicViewModel: Computing rootFolders from ${paths.size} song paths")
+
+            // Get all unique folder paths that directly contain songs
+            val folderCounts = paths.mapNotNull { path ->
+                path.substringBeforeLast('/')
+            }.groupingBy { it }.eachCount()
+
+            Timber.d("LocalMusicViewModel: Found ${folderCounts.size} unique folders")
+
+            // Find the common prefix (e.g., /storage/emulated/0)
+            val allFolders = folderCounts.keys.toList()
+            val commonPrefix = if (allFolders.isNotEmpty()) {
+                val firstParts = allFolders.first().split("/")
+                var prefix = ""
+                for (i in firstParts.indices) {
+                    val candidate = firstParts.take(i + 1).joinToString("/")
+                    if (allFolders.all { it.startsWith("$candidate/") || it == candidate }) {
+                        prefix = candidate
+                    } else {
+                        break
+                    }
+                }
+                prefix
+            } else ""
+
+            Timber.d("LocalMusicViewModel: Common prefix = '$commonPrefix'")
+
+            // Get immediate children of the common prefix as root folders
+            val rootFolders = allFolders.mapNotNull { folder ->
+                if (folder.startsWith("$commonPrefix/")) {
+                    val remaining = folder.removePrefix("$commonPrefix/")
+                    val firstChild = remaining.split("/").firstOrNull()
+                    if (firstChild != null) "$commonPrefix/$firstChild" else null
+                } else null
+            }.distinct()
+
+            Timber.d("LocalMusicViewModel: Found ${rootFolders.size} root folders")
+
+            // Count all songs under each root (including subfolders)
+            rootFolders.map { root ->
+                val totalSongs = folderCounts.entries
+                    .filter { it.key == root || it.key.startsWith("$root/") }
+                    .sumOf { it.value }
+                root to totalSongs
+            }.sortedBy { it.first.lowercase() }
+        }
+        .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+    fun getSongsInFolder(folderPath: String) = database.localSongsInFolder(folderPath)
+
+    fun getSubfolders(parentPath: String): StateFlow<List<String>> = database.localSongPaths()
+        .map { paths ->
+            paths.mapNotNull { path ->
+                val folder = path.substringBeforeLast('/')
+                if (folder.startsWith("$parentPath/") && folder != parentPath) {
+                    val remaining = folder.removePrefix("$parentPath/")
+                    val nextFolder = remaining.split("/").firstOrNull()
+                    if (nextFolder != null) "$parentPath/$nextFolder" else null
+                } else null
+            }.distinct().sorted()
+        }
         .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
 
     suspend fun syncLocalMusic() {
@@ -125,5 +192,41 @@ class LocalAlbumViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.Lazily, null)
 
     val songs = database.localSongsByAlbum(albumId)
+        .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+}
+
+@HiltViewModel
+class LocalFolderViewModel @Inject constructor(
+    private val database: MusicDatabase,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    val folderPath: String = savedStateHandle.get<String>("folderPath")?.let {
+        java.net.URLDecoder.decode(it, "UTF-8")
+    } ?: ""
+
+    init {
+        Timber.d("LocalFolderViewModel: INIT - folderPath=$folderPath")
+    }
+
+    // Songs directly in this folder
+    val songs = database.localSongsInFolder(folderPath)
+        .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+    // All songs including subfolders (for play all/shuffle)
+    val allSongs = database.localSongsInFolderRecursive(folderPath)
+        .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+    val subfolders: StateFlow<List<String>> = database.localSongPaths()
+        .map { paths ->
+            paths.mapNotNull { path ->
+                val folder = path.substringBeforeLast('/')
+                if (folder.startsWith("$folderPath/") && folder != folderPath) {
+                    val remaining = folder.removePrefix("$folderPath/")
+                    val nextFolder = remaining.split("/").firstOrNull()
+                    if (nextFolder != null) "$folderPath/$nextFolder" else null
+                } else null
+            }.distinct().sorted()
+        }
         .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
 }

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/LocalMusicViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/LocalMusicViewModel.kt
@@ -1,0 +1,129 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.viewmodels
+
+import android.content.Context
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.metrolist.music.db.MusicDatabase
+import com.metrolist.music.db.entities.Album
+import com.metrolist.music.db.entities.Artist
+import com.metrolist.music.db.entities.Song
+import com.metrolist.music.utils.LocalMusicRepository
+import com.metrolist.music.utils.LocalSyncStatus
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+
+@HiltViewModel
+class LocalMusicViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val database: MusicDatabase,
+    private val localMusicRepository: LocalMusicRepository,
+) : ViewModel() {
+
+    init {
+        Timber.d("LocalMusicViewModel: INIT - ViewModel created")
+    }
+
+    private val _hasPermission = MutableStateFlow(localMusicRepository.hasPermission())
+    val hasPermission: StateFlow<Boolean> = _hasPermission.asStateFlow()
+
+    val syncStatus: StateFlow<LocalSyncStatus> = localMusicRepository.syncStatus
+
+    val syncProgress: StateFlow<Float> = localMusicRepository.syncProgress
+
+    val localArtists = database.localArtists()
+        .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+    val allLocalSongs = database.allLocalSongs()
+        .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+    val allLocalAlbums = database.allLocalAlbums()
+        .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+    suspend fun syncLocalMusic() {
+        Timber.d("LocalMusicViewModel: syncLocalMusic() called")
+        // Update permission state before syncing
+        _hasPermission.value = localMusicRepository.hasPermission()
+        localMusicRepository.syncLocalMusic()
+        Timber.d("LocalMusicViewModel: syncLocalMusic() completed")
+    }
+
+    fun refreshPermissionState() {
+        val newState = localMusicRepository.hasPermission()
+        Timber.d("LocalMusicViewModel: refreshPermissionState() = $newState (was ${_hasPermission.value})")
+        _hasPermission.value = newState
+    }
+
+    fun checkPermission(): Boolean {
+        val result = localMusicRepository.hasPermission()
+        Timber.d("LocalMusicViewModel: checkPermission() = $result")
+        _hasPermission.value = result
+        return result
+    }
+
+    init {
+        Timber.d("LocalMusicViewModel: Secondary init block - checking permission")
+        if (localMusicRepository.hasPermission()) {
+            Timber.d("LocalMusicViewModel: Permission granted, auto-starting sync")
+            viewModelScope.launch {
+                localMusicRepository.syncLocalMusic()
+            }
+        } else {
+            Timber.d("LocalMusicViewModel: Permission NOT granted, skipping auto-sync")
+        }
+    }
+}
+
+@HiltViewModel
+class LocalArtistViewModel @Inject constructor(
+    private val database: MusicDatabase,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val artistId: String = savedStateHandle.get<String>("artistId")!!
+
+    init {
+        Timber.d("LocalArtistViewModel: INIT - artistId=$artistId")
+    }
+
+    val artist = database.artist(artistId)
+        .stateIn(viewModelScope, SharingStarted.Lazily, null)
+
+    val albums = database.localAlbumsByArtist(artistId)
+        .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+    val songs = database.localSongsByArtist(artistId)
+        .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+}
+
+@HiltViewModel
+class LocalAlbumViewModel @Inject constructor(
+    private val database: MusicDatabase,
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val albumId: String = savedStateHandle.get<String>("albumId")!!
+
+    init {
+        Timber.d("LocalAlbumViewModel: INIT - albumId=$albumId")
+    }
+
+    val album = database.album(albumId)
+        .stateIn(viewModelScope, SharingStarted.Lazily, null)
+
+    val songs = database.localSongsByAlbum(albumId)
+        .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+}

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/LocalMusicViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/LocalMusicViewModel.kt
@@ -99,6 +99,9 @@ class LocalArtistViewModel @Inject constructor(
         Timber.d("LocalArtistViewModel: INIT - artistId=$artistId")
     }
 
+    private val _isLoading = MutableStateFlow(true)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
     val artist = database.artist(artistId)
         .stateIn(viewModelScope, SharingStarted.Lazily, null)
 
@@ -107,6 +110,16 @@ class LocalArtistViewModel @Inject constructor(
 
     val songs = database.localSongsByArtist(artistId)
         .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+    init {
+        viewModelScope.launch {
+            // Wait for first emission from songs flow to mark loading complete
+            songs.collect {
+                _isLoading.value = false
+                return@collect
+            }
+        }
+    }
 }
 
 @HiltViewModel

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -723,4 +723,8 @@
     <string name="no_local_artists">No local music found</string>
     <string name="grant_permission">Grant permission</string>
     <string name="syncing_local_music">Scanning local music library…</string>
+    <string name="file_path">File path</string>
+    <string name="album">Album</string>
+    <string name="year">Year</string>
+    <string name="duration">Duration</string>
 </resources>

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -722,6 +722,8 @@
     <string name="local_music_permission_needed">Permission needed to access local music files</string>
     <string name="local_playback_blocked_listen_together">Local files cannot be played during Listen Together</string>
     <string name="no_local_artists">No local music found</string>
+    <string name="no_local_folders">No folders found</string>
+    <string name="folders">Folders</string>
     <string name="grant_permission">Grant permission</string>
     <string name="syncing_local_music">Scanning local music library…</string>
     <string name="file_path">File path</string>

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -720,6 +720,7 @@
     <string name="local_music_permission_title">Access local music</string>
     <string name="local_music_permission_desc">Metrolist needs permission to read audio files from your device to display your local music library.</string>
     <string name="local_music_permission_needed">Permission needed to access local music files</string>
+    <string name="local_playback_blocked_listen_together">Local files cannot be played during Listen Together</string>
     <string name="no_local_artists">No local music found</string>
     <string name="grant_permission">Grant permission</string>
     <string name="syncing_local_music">Scanning local music library…</string>

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -713,4 +713,14 @@
     <string name="discord_activity_name_description">Custom name for the activity (leave empty for default)</string>
     <string name="discord_advanced_mode">Advanced mode</string>
     <string name="discord_advanced_mode_description">Show additional customization options for Rich Presence</string>
+
+    <!-- Local Music -->
+    <string name="local_music">Local Music</string>
+    <string name="filter_local">Local</string>
+    <string name="local_music_permission_title">Access local music</string>
+    <string name="local_music_permission_desc">Metrolist needs permission to read audio files from your device to display your local music library.</string>
+    <string name="local_music_permission_needed">Permission needed to access local music files</string>
+    <string name="no_local_artists">No local music found</string>
+    <string name="grant_permission">Grant permission</string>
+    <string name="syncing_local_music">Scanning local music library…</string>
 </resources>


### PR DESCRIPTION
## Problem
Users cannot browse or play local audio files (mp3, m4a, flac, ogg, etc.) stored on their device. The app only supports streaming from YouTube Music.

## Cause
The app lacked integration with Android's MediaStore to scan and index local audio files, and had no UI for browsing local music.

## Solution
- Added LOCAL tab in Library to browse local artists → albums → songs
- Integrated with MediaStore to scan device for audio files
- Reused existing `SongEntity.isLocal` and `downloadUri` fields for playback
- Added permission handling for READ_MEDIA_AUDIO (Android 13+) / READ_EXTERNAL_STORAGE
- Adapted menus to hide YouTube-specific options for local songs (download, share, radio, refetch)
- Added long-press menu support for local albums
- Local songs can be mixed with online songs in playlists
- Added search within local music library

## Testing
**Important: Back up your database before testing.** This build adds local music entries to the database. Reverting to the official release after testing would require clearing app data.

- Granted audio permission when prompted
- Browsed local artists, albums, songs
- Played local songs (single, queue, shuffle)
- Long-pressed albums/songs for context menu
- Added local songs to playlists alongside online songs
- Verified online music playback still works normally