### PR TITLE
feat(voice): handle MEDIA_PLAY_FROM_SEARCH intents for voice assistants

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
@@ -8,6 +8,7 @@ package com.metrolist.music
 import android.Manifest
 import android.annotation.SuppressLint
 import android.app.PendingIntent
+import android.app.SearchManager
 import android.content.ComponentName
 import android.content.Intent
 import android.content.ServiceConnection
@@ -15,6 +16,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
+import android.provider.MediaStore
 import android.view.View
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
@@ -122,6 +124,9 @@ import coil3.request.allowHardware
 import coil3.request.crossfade
 import coil3.toBitmap
 import com.metrolist.innertube.YouTube
+import com.metrolist.innertube.models.AlbumItem
+import com.metrolist.innertube.models.ArtistItem
+import com.metrolist.innertube.models.PlaylistItem
 import com.metrolist.innertube.models.SongItem
 import com.metrolist.innertube.models.WatchEndpoint
 import com.metrolist.music.constants.AppBarHeight
@@ -211,6 +216,7 @@ class MainActivity : ComponentActivity() {
     companion object {
         private const val ACTION_SEARCH = "com.metrolist.music.action.SEARCH"
         private const val ACTION_LIBRARY = "com.metrolist.music.action.LIBRARY"
+        private const val VOICE_SEARCH_TAG = "VoiceSearch"
         const val ACTION_RECOGNITION = "com.metrolist.music.action.RECOGNITION"
         const val EXTRA_AUTO_START_RECOGNITION = "auto_start_recognition"
     }
@@ -308,6 +314,7 @@ class MainActivity : ComponentActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         if (::navController.isInitialized) {
+            handleVoiceSearchIntent(intent, navController)
             handleDeepLinkIntent(intent, navController)
         } else {
             pendingIntent = intent
@@ -783,10 +790,12 @@ class MainActivity : ComponentActivity() {
 
                 LaunchedEffect(Unit) {
                     if (pendingIntent != null) {
+                        handleVoiceSearchIntent(pendingIntent!!, navController)
                         handleRecognitionIntent(pendingIntent!!, navController)
                         handleDeepLinkIntent(pendingIntent!!, navController)
                         pendingIntent = null
                     } else {
+                        handleVoiceSearchIntent(intent, navController)
                         handleRecognitionIntent(intent, navController)
                         handleDeepLinkIntent(intent, navController)
                     }
@@ -795,6 +804,7 @@ class MainActivity : ComponentActivity() {
                 DisposableEffect(Unit) {
                     val listener =
                         Consumer<Intent> { intent ->
+                            handleVoiceSearchIntent(intent, navController)
                             handleRecognitionIntent(intent, navController)
                             handleDeepLinkIntent(intent, navController)
                         }
@@ -1251,6 +1261,228 @@ class MainActivity : ComponentActivity() {
         intent.removeExtra(EXTRA_AUTO_START_RECOGNITION)
         navController.navigate(if (autoStart) "recognition?autoStart=true" else "recognition") {
             launchSingleTop = true
+        }
+    }
+
+    private fun handleVoiceSearchIntent(
+        intent: Intent,
+        navController: NavHostController,
+    ) {
+        if (intent.action != MediaStore.INTENT_ACTION_MEDIA_PLAY_FROM_SEARCH) return
+
+        intent.action = null
+
+        val query = intent.getStringExtra(SearchManager.QUERY).orEmpty().trim()
+        val mediaFocus = intent.getStringExtra(MediaStore.EXTRA_MEDIA_FOCUS).orEmpty().trim()
+        val mediaArtist = intent.getStringExtra(MediaStore.EXTRA_MEDIA_ARTIST).orEmpty().trim()
+        val mediaAlbum = intent.getStringExtra(MediaStore.EXTRA_MEDIA_ALBUM).orEmpty().trim()
+        val mediaTitle = intent.getStringExtra(MediaStore.EXTRA_MEDIA_TITLE).orEmpty().trim()
+        val normalizedFocus = mediaFocus.lowercase(Locale.US)
+
+        Timber.tag(VOICE_SEARCH_TAG).d(
+            "Voice search intent received. focus=%s query=%s artist=%s album=%s title=%s route=%s",
+            mediaFocus,
+            query,
+            mediaArtist,
+            mediaAlbum,
+            mediaTitle,
+            navController.currentBackStackEntry?.destination?.route,
+        )
+
+        lifecycleScope.launch(Dispatchers.IO) {
+            try {
+                if (query.isBlank()) {
+                    val connection = playerConnection
+                    val hasQueue =
+                        connection != null &&
+                            runCatching { connection.player.mediaItemCount > 0 }
+                                .getOrElse { false }
+
+                    if (!hasQueue) {
+                        Timber.tag(VOICE_SEARCH_TAG).d("Blank query ignored because queue is empty")
+                        return@launch
+                    }
+
+                    connection.player.shuffleModeEnabled = true
+                    connection.play()
+                    Timber.tag(VOICE_SEARCH_TAG).d("Blank query handled by shuffling current queue")
+                    return@launch
+                }
+
+                when {
+                    normalizedFocus == MediaStore.Audio.Media.ENTRY_CONTENT_TYPE.lowercase(Locale.US) ||
+                        normalizedFocus.contains("track") ||
+                        normalizedFocus.contains("song") ||
+                        normalizedFocus.contains("media") -> {
+                            val trackQuery =
+                                listOf(mediaArtist, mediaTitle)
+                                    .filter { it.isNotBlank() }
+                                    .joinToString(" ")
+                                    .ifBlank { query }
+                            Timber.tag(VOICE_SEARCH_TAG).d("Track focus resolved query=%s", trackQuery)
+                            playSong(trackQuery)
+                        }
+
+                    normalizedFocus == MediaStore.Audio.Artists.ENTRY_CONTENT_TYPE.lowercase(Locale.US) ||
+                        normalizedFocus.contains("artist") -> {
+                            val artistName = mediaArtist.ifBlank { query }
+                            Timber.tag(VOICE_SEARCH_TAG).d("Artist focus query=%s", artistName)
+                            val artistItem =
+                                YouTube
+                                    .search(artistName, YouTube.SearchFilter.FILTER_ARTIST)
+                                    .getOrThrow()
+                                    .items
+                                    .filterIsInstance<ArtistItem>()
+                                    .firstOrNull()
+
+                            if (artistItem == null) {
+                                Timber.tag(VOICE_SEARCH_TAG).d("No artist match, falling back to song search")
+                                playSong(artistName)
+                                return@launch
+                            }
+
+                            val endpoint =
+                                YouTube
+                                    .artist(artistItem.id)
+                                    .getOrThrow()
+                                    .artist
+                                    .let { it.shuffleEndpoint ?: it.radioEndpoint ?: it.playEndpoint }
+
+                            if (endpoint != null) {
+                                withContext(Dispatchers.Main) {
+                                    playerConnection?.playQueue(YouTubeQueue(endpoint))
+                                }
+                                Timber.tag(VOICE_SEARCH_TAG).d("Queued artist endpoint for %s", artistItem.title)
+                            } else {
+                                Timber.tag(VOICE_SEARCH_TAG).d("Artist endpoint missing, falling back to song search")
+                                playSong(artistName)
+                            }
+                        }
+
+                    normalizedFocus == MediaStore.Audio.Albums.ENTRY_CONTENT_TYPE.lowercase(Locale.US) ||
+                        normalizedFocus.contains("album") -> {
+                            val albumQuery = mediaAlbum.ifBlank { query }
+                            Timber.tag(VOICE_SEARCH_TAG).d("Album focus query=%s", albumQuery)
+                            val albumItem =
+                                YouTube
+                                    .search(albumQuery, YouTube.SearchFilter.FILTER_ALBUM)
+                                    .getOrThrow()
+                                    .items
+                                    .filterIsInstance<AlbumItem>()
+                                    .firstOrNull()
+
+                            if (albumItem != null) {
+                                withContext(Dispatchers.Main) {
+                                    playerConnection?.playQueue(
+                                        YouTubeQueue(
+                                            WatchEndpoint(playlistId = albumItem.playlistId),
+                                        ),
+                                    )
+                                }
+                                Timber.tag(VOICE_SEARCH_TAG).d("Queued album endpoint for %s", albumItem.title)
+                            } else {
+                                Timber.tag(VOICE_SEARCH_TAG).d("No album match, falling back to song search")
+                                playSong(albumQuery)
+                            }
+                        }
+
+                    normalizedFocus == MediaStore.Audio.Playlists.ENTRY_CONTENT_TYPE.lowercase(Locale.US) ||
+                        normalizedFocus.contains("playlist") -> {
+                            val playlistQuery = mediaTitle.ifBlank { query }
+                            Timber.tag(VOICE_SEARCH_TAG).d("Playlist focus query=%s", playlistQuery)
+                            val playlistItem = searchPlaylist(playlistQuery)
+
+                            if (playlistItem != null) {
+                                withContext(Dispatchers.Main) {
+                                    playerConnection?.playQueue(
+                                        YouTubeQueue(
+                                            WatchEndpoint(playlistId = playlistItem.id),
+                                        ),
+                                    )
+                                }
+                                Timber.tag(VOICE_SEARCH_TAG).d("Queued playlist endpoint for %s", playlistItem.title)
+                            } else {
+                                Timber.tag(VOICE_SEARCH_TAG).d("No playlist match, falling back to song search")
+                                playSong(playlistQuery)
+                            }
+                        }
+
+                    else -> {
+                        Timber.tag(VOICE_SEARCH_TAG).d("Generic focus, falling back to song search query=%s", query)
+                        playSong(query)
+                    }
+                }
+            } catch (e: Exception) {
+                Timber.tag(VOICE_SEARCH_TAG).e(e, "Failed to handle voice search intent")
+                reportException(e)
+            }
+        }
+    }
+
+    private suspend fun playSong(query: String) {
+        val normalizedQuery = query.trim()
+        if (normalizedQuery.isBlank()) return
+
+        try {
+            val song =
+                withContext(Dispatchers.IO) {
+                    YouTube
+                        .search(normalizedQuery, YouTube.SearchFilter.FILTER_SONG)
+                        .getOrThrow()
+                        .items
+                        .filterIsInstance<SongItem>()
+                        .firstOrNull()
+                }
+
+            if (song == null) {
+                Timber.tag(VOICE_SEARCH_TAG).d("No song found for query=%s", normalizedQuery)
+                return
+            }
+
+            withContext(Dispatchers.Main) {
+                playerConnection?.playQueue(
+                    YouTubeQueue(
+                        WatchEndpoint(videoId = song.id),
+                        song.toMediaMetadata(),
+                    ),
+                )
+            }
+            Timber.tag(VOICE_SEARCH_TAG).d("Queued song for query=%s id=%s", normalizedQuery, song.id)
+        } catch (e: Exception) {
+            Timber.tag(VOICE_SEARCH_TAG).e(e, "Failed to play song query=%s", normalizedQuery)
+            reportException(e)
+        }
+    }
+
+    private suspend fun searchPlaylist(query: String): PlaylistItem? {
+        val normalizedQuery = query.trim()
+        if (normalizedQuery.isBlank()) return null
+
+        return withContext(Dispatchers.IO) {
+            val featuredPlaylist =
+                YouTube
+                    .search(normalizedQuery, YouTube.SearchFilter.FILTER_FEATURED_PLAYLIST)
+                    .onFailure {
+                        Timber.tag(VOICE_SEARCH_TAG).e(it, "Featured playlist search failed for query=%s", normalizedQuery)
+                        reportException(it)
+                    }.getOrNull()
+                    ?.items
+                    ?.filterIsInstance<PlaylistItem>()
+                    ?.firstOrNull()
+
+            if (featuredPlaylist != null) {
+                return@withContext featuredPlaylist
+            }
+
+            YouTube
+                .search(normalizedQuery, YouTube.SearchFilter.FILTER_COMMUNITY_PLAYLIST)
+                .onFailure {
+                    Timber.tag(VOICE_SEARCH_TAG).e(it, "Community playlist search failed for query=%s", normalizedQuery)
+                    reportException(it)
+                }.getOrNull()
+                ?.items
+                ?.filterIsInstance<PlaylistItem>()
+                ?.firstOrNull()
         }
     }
 

--- a/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
@@ -1277,15 +1277,17 @@ class MainActivity : ComponentActivity() {
         val mediaArtist = intent.getStringExtra(MediaStore.EXTRA_MEDIA_ARTIST).orEmpty().trim()
         val mediaAlbum = intent.getStringExtra(MediaStore.EXTRA_MEDIA_ALBUM).orEmpty().trim()
         val mediaTitle = intent.getStringExtra(MediaStore.EXTRA_MEDIA_TITLE).orEmpty().trim()
+        val mediaPlaylist = intent.getStringExtra("android.intent.extra.playlist").orEmpty().trim()
         val normalizedFocus = mediaFocus.lowercase(Locale.US)
 
         Timber.tag(VOICE_SEARCH_TAG).d(
-            "Voice search intent received. focus=%s query=%s artist=%s album=%s title=%s route=%s",
+            "Voice search intent received. focus=%s query=%s artist=%s album=%s title=%s playlist=%s route=%s",
             mediaFocus,
             query,
             mediaArtist,
             mediaAlbum,
             mediaTitle,
+            mediaPlaylist,
             navController.currentBackStackEntry?.destination?.route,
         )
 
@@ -1388,7 +1390,7 @@ class MainActivity : ComponentActivity() {
 
                     normalizedFocus == MediaStore.Audio.Playlists.ENTRY_CONTENT_TYPE.lowercase(Locale.US) ||
                         normalizedFocus.contains("playlist") -> {
-                            val playlistQuery = mediaTitle.ifBlank { query }
+                            val playlistQuery = mediaPlaylist.ifBlank { mediaTitle.ifBlank { query } }
                             Timber.tag(VOICE_SEARCH_TAG).d("Playlist focus query=%s", playlistQuery)
                             val playlistItem = searchPlaylist(playlistQuery)
 

--- a/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
@@ -207,7 +207,9 @@ import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.net.URLDecoder
 import java.net.URLEncoder
+import java.util.ArrayDeque
 import java.util.Locale
+import java.util.concurrent.ConcurrentLinkedDeque
 import javax.inject.Inject
 
 @Suppress("DEPRECATION", "ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE")
@@ -234,7 +236,9 @@ class MainActivity : ComponentActivity() {
     lateinit var listenTogetherManager: com.metrolist.music.listentogether.ListenTogetherManager
 
     private lateinit var navController: NavHostController
-    private var pendingIntent: Intent? = null
+    private val pendingIntents = ArrayDeque<Intent>()
+    private val deferredIntents = ConcurrentLinkedDeque<Intent>()
+    private var isOnNewIntentListenerRegistered = false
     private var latestVersionName by mutableStateOf(BuildConfig.VERSION_NAME)
 
     private var playerConnection by mutableStateOf<PlayerConnection?>(null)
@@ -313,11 +317,13 @@ class MainActivity : ComponentActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
+        if (isOnNewIntentListenerRegistered) return
+
         if (::navController.isInitialized) {
-            handleVoiceSearchIntent(intent, navController)
-            handleDeepLinkIntent(intent, navController)
+            enqueueOrHandleIntent(intent, navController)
+            drainDeferredIntents(navController)
         } else {
-            pendingIntent = intent
+            pendingIntents.addLast(Intent(intent))
         }
     }
 
@@ -546,7 +552,7 @@ class MainActivity : ComponentActivity() {
                 val bottomInset = with(density) { windowsInsets.getBottom(density).toDp() }
                 val bottomInsetDp = WindowInsets.systemBars.asPaddingValues().calculateBottomPadding()
 
-                val navController = rememberNavController()
+                val navController = rememberNavController().also { this@MainActivity.navController = it }
 
                 LaunchedEffect(Unit) {
                     val lastSeenVersion = dataStore.data.first()[LastSeenVersionKey] ?: ""
@@ -789,28 +795,34 @@ class MainActivity : ComponentActivity() {
                 val snackbarHostState = remember { SnackbarHostState() }
 
                 LaunchedEffect(Unit) {
-                    if (pendingIntent != null) {
-                        handleVoiceSearchIntent(pendingIntent!!, navController)
-                        handleRecognitionIntent(pendingIntent!!, navController)
-                        handleDeepLinkIntent(pendingIntent!!, navController)
-                        pendingIntent = null
+                    if (pendingIntents.isNotEmpty()) {
+                        while (pendingIntents.isNotEmpty()) {
+                            enqueueOrHandleIntent(pendingIntents.removeFirst(), navController)
+                        }
                     } else {
-                        handleVoiceSearchIntent(intent, navController)
-                        handleRecognitionIntent(intent, navController)
-                        handleDeepLinkIntent(intent, navController)
+                        enqueueOrHandleIntent(intent, navController)
                     }
+
+                    drainDeferredIntents(navController)
+                }
+
+                LaunchedEffect(playerConnection) {
+                    drainDeferredIntents(navController)
                 }
 
                 DisposableEffect(Unit) {
                     val listener =
                         Consumer<Intent> { intent ->
-                            handleVoiceSearchIntent(intent, navController)
-                            handleRecognitionIntent(intent, navController)
-                            handleDeepLinkIntent(intent, navController)
+                            enqueueOrHandleIntent(intent, navController)
+                            drainDeferredIntents(navController)
                         }
 
+                    isOnNewIntentListenerRegistered = true
                     addOnNewIntentListener(listener)
-                    onDispose { removeOnNewIntentListener(listener) }
+                    onDispose {
+                        isOnNewIntentListenerRegistered = false
+                        removeOnNewIntentListener(listener)
+                    }
                 }
 
                 val currentTitleRes =
@@ -1247,6 +1259,62 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    private fun enqueueOrHandleIntent(
+        intent: Intent,
+        navController: NavHostController,
+    ) {
+        val intentToHandle = Intent(intent)
+        if (shouldDeferIntentUntilPlayerReady(intentToHandle)) {
+            deferredIntents.addLast(intentToHandle)
+            return
+        }
+
+        dispatchIntent(intentToHandle, navController)
+    }
+
+    private fun drainDeferredIntents(navController: NavHostController) {
+        if (deferredIntents.isEmpty()) return
+        if (playerConnection == null) return
+
+        val intentsToHandle = mutableListOf<Intent>()
+        while (true) {
+            val deferredIntent = deferredIntents.pollFirst() ?: break
+            intentsToHandle.add(deferredIntent)
+        }
+
+        intentsToHandle.forEach { dispatchIntent(it, navController) }
+    }
+
+    private fun dispatchIntent(
+        intent: Intent,
+        navController: NavHostController,
+    ) {
+        if (handleVoiceSearchIntent(intent, navController)) return
+        if (handleRecognitionIntent(intent, navController)) return
+        handleDeepLinkIntent(intent, navController)
+    }
+
+    private fun shouldDeferIntentUntilPlayerReady(intent: Intent): Boolean {
+        if (playerConnection != null) return false
+        if (intent.action == MediaStore.INTENT_ACTION_MEDIA_PLAY_FROM_SEARCH) return true
+
+        val uri = intent.data ?: intent.extras?.getString(Intent.EXTRA_TEXT)?.toUri() ?: return false
+        val path = uri.pathSegments.firstOrNull()
+        if (path in setOf("listen", "playlist", "browse", "channel", "c", "search")) {
+            return false
+        }
+
+        val hasVideo =
+            when {
+                path == "watch" -> !uri.getQueryParameter("v").isNullOrBlank()
+                uri.host == "youtu.be" -> !uri.pathSegments.firstOrNull().isNullOrBlank()
+                else -> false
+            }
+        val hasPlaylist = !uri.getQueryParameter("list").isNullOrBlank()
+
+        return hasVideo || hasPlaylist
+    }
+
     /**
      * Handles the ACTION_RECOGNITION intent sent from the Music Recognizer Widget.
      * Always navigates to the recognition screen to show the result.
@@ -1254,21 +1322,22 @@ class MainActivity : ComponentActivity() {
     private fun handleRecognitionIntent(
         intent: Intent,
         navController: NavHostController,
-    ) {
-        if (intent.action != ACTION_RECOGNITION) return
+    ): Boolean {
+        if (intent.action != ACTION_RECOGNITION) return false
         val autoStart = intent.getBooleanExtra(EXTRA_AUTO_START_RECOGNITION, false)
         intent.action = null
         intent.removeExtra(EXTRA_AUTO_START_RECOGNITION)
         navController.navigate(if (autoStart) "recognition?autoStart=true" else "recognition") {
             launchSingleTop = true
         }
+        return true
     }
 
     private fun handleVoiceSearchIntent(
         intent: Intent,
         navController: NavHostController,
-    ) {
-        if (intent.action != MediaStore.INTENT_ACTION_MEDIA_PLAY_FROM_SEARCH) return
+    ): Boolean {
+        if (intent.action != MediaStore.INTENT_ACTION_MEDIA_PLAY_FROM_SEARCH) return false
 
         intent.action = null
 
@@ -1279,6 +1348,11 @@ class MainActivity : ComponentActivity() {
         val mediaTitle = intent.getStringExtra(MediaStore.EXTRA_MEDIA_TITLE).orEmpty().trim()
         val mediaPlaylist = intent.getStringExtra("android.intent.extra.playlist").orEmpty().trim()
         val normalizedFocus = mediaFocus.lowercase(Locale.US)
+        val hasStructuredMediaExtras =
+            mediaArtist.isNotBlank() ||
+                mediaAlbum.isNotBlank() ||
+                mediaTitle.isNotBlank() ||
+                mediaPlaylist.isNotBlank()
 
         Timber.tag(VOICE_SEARCH_TAG).d(
             "Voice search intent received. focus=%s query=%s artist=%s album=%s title=%s playlist=%s route=%s",
@@ -1293,7 +1367,7 @@ class MainActivity : ComponentActivity() {
 
         lifecycleScope.launch(Dispatchers.IO) {
             try {
-                if (query.isBlank()) {
+                if (query.isBlank() && !hasStructuredMediaExtras) {
                     val connection = playerConnection
                     if (connection == null) {
                         Timber.tag(VOICE_SEARCH_TAG).d("Blank query ignored because queue is empty")
@@ -1427,6 +1501,8 @@ class MainActivity : ComponentActivity() {
                 reportException(e)
             }
         }
+
+        return true
     }
 
     private suspend fun playSong(query: String) {

--- a/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
@@ -1295,18 +1295,26 @@ class MainActivity : ComponentActivity() {
             try {
                 if (query.isBlank()) {
                     val connection = playerConnection
+                    if (connection == null) {
+                        Timber.tag(VOICE_SEARCH_TAG).d("Blank query ignored because queue is empty")
+                        return@launch
+                    }
+
                     val hasQueue =
-                        connection != null &&
+                        withContext(Dispatchers.Main) {
                             runCatching { connection.player.mediaItemCount > 0 }
                                 .getOrElse { false }
+                        }
 
                     if (!hasQueue) {
                         Timber.tag(VOICE_SEARCH_TAG).d("Blank query ignored because queue is empty")
                         return@launch
                     }
 
-                    connection.player.shuffleModeEnabled = true
-                    connection.play()
+                    withContext(Dispatchers.Main) {
+                        connection.player.shuffleModeEnabled = true
+                        connection.play()
+                    }
                     Timber.tag(VOICE_SEARCH_TAG).d("Blank query handled by shuffling current queue")
                     return@launch
                 }


### PR DESCRIPTION
## Problem
Voice assistants (Google Assistant, Bixby, etc.) cannot start playback in Metrolist. Users expect to say "Play song on Metrolist" and have the app respond, but the app doesn't handle the MEDIA_PLAY_FROM_SEARCH intent that assistants dispatch.

## Cause
The AndroidManifest.xml declares support for android.media.action.MEDIA_PLAY_FROM_SEARCH in MainActivity's intent-filters, but MainActivity never actually handled these intents. The existing handleDeepLinkIntent() returns early when intent.data is null, and voice search intents arrive without intent.data — they carry search query in extras instead.

## Solution
- Added handleVoiceSearchIntent(intent, navController) in MainActivity.kt that processes MEDIA_PLAY_FROM_SEARCH intents
- Parses extras: SearchManager.QUERY, MediaStore.EXTRA_MEDIA_FOCUS, EXTRA_MEDIA_ARTIST, EXTRA_MEDIA_ALBUM, EXTRA_MEDIA_TITLE
- Dispatches based on focus type:
  - Track/song: searches YouTube with FILTER_SONG, queues first SongItem
  - Artist: searches with FILTER_ARTIST, calls YouTube.artist(id) to fetch shuffle/radio/play endpoints, queues the endpoint
  - Album: searches with FILTER_ALBUM, queues album's playlistId via WatchEndpoint
  - Playlist: searches featured/community playlists, queues playlistId
  - Blank query: shuffles current queue if non-empty
- Network calls run on Dispatchers.IO; player calls on Dispatchers.Main
- Added Timber logging (tag=VoiceSearch) and reportException() for diagnostics
- Wired handler in onNewIntent, LaunchedEffect, and DisposableEffect listeners

## Testing
- Built successfully: ./gradlew :app:assembleFossDebug
- Validated via adb to emulate voice intents:
  - Generic query: adb shell am start -a android.media.action.MEDIA_PLAY_FROM_SEARCH -n com.metrolist.music.debug/com.metrolist.music.MainActivity --es query Kayra → queued song
  - Artist focus: --es android.intent.extra.artist Kayra --es android.intent.extra.focus vnd.android.cursor.item/artist → queued artist endpoint
  - Album focus: --es android.intent.extra.album Abbey_Road --es android.intent.extra.focus vnd.android.cursor.item/album → queued album endpoint
  - Playlist focus: --es android.intent.extra.title ChillVibes --es android.intent.extra.focus vnd.android.cursor.item/playlist → queued playlist
  - Blank query: --es android.intent.extra.focus vnd.android.cursor.item/audio → shuffled queue
- Verified logs show correct routing (VoiceSearch tag) and queueing
- I couldn't test with an assistant and ngl I am about to break my phone because assistant is an AI and instead of assisting its just making my job harder like its not hard enough. Would be really great if someone can test it.

## Related Issues

- Closes #3237 #1331 
- Related to #3237 #1331 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Voice search to discover and play songs, artists, albums, and playlists, usable at launch and during playback
  * Blank voice queries now shuffle the current play queue
  * Better support for featured and community playlists via voice search

* **Improvements**
  * Voice intents are queued until playback is ready and routed reliably to avoid duplicate handling
  * Enhanced diagnostics and error handling for voice-driven playback resolution
<!-- end of auto-generated comment: release notes by coderabbit.ai -->