### PR TITLE
fix(ui): handle back gesture in expanded player

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
@@ -5,6 +5,7 @@
 
 package com.metrolist.music.ui.player
 
+import androidx.activity.compose.BackHandler
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
@@ -290,6 +291,11 @@ fun BottomSheetPlayer(
             }
         }
     }
+
+    BackHandler(enabled = state.isExpanded) {
+        state.collapseSoft()
+    }
+
     val onBackgroundColor =
         when (playerBackground) {
             PlayerBackgroundStyle.DEFAULT -> MaterialTheme.colorScheme.secondary


### PR DESCRIPTION
## Problem
The back gesture (swipe from the side of the screen) doesn't work when the player is in its expanded/full-screen state. Users expecting to navigate back to the mini-player by swiping from the side get no response.

## Cause
The BottomSheetPlayer component doesn't have a BackHandler to intercept the back gesture when expanded. While there's a BackHandler inside the BottomSheet component that handles the collapsed state, there's no equivalent handling in the Player screen for when the player is expanded.

## Solution
- Added BackHandler to BottomSheetPlayer in Player.kt
- The handler is enabled only when the player is expanded (state.isExpanded)
- When triggered, it calls state.collapseSoft() to collapse the player back to mini-player state
- This ensures the system back gesture properly collapses the expanded player

## Testing
The fix adds proper back gesture handling to the expanded player screen. The BackHandler will only be active when the player is expanded, ensuring the gesture properly collapses the player to mini-player state.

## Related Issues
- Closes #3391

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved back button behavior in the expanded player: pressing back now collapses the player instead of exiting the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->