### PR TITLE
feat(audio): reorder quality options to [auto, low, high, very_high]

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
@@ -109,10 +109,10 @@ val LastUpdateCheckTimeKey = longPreferencesKey("lastUpdateCheckTime")
 val AudioQualityKey = stringPreferencesKey("audioQuality")
 
 enum class AudioQuality {
-    AUTO,
-    HIGH,
     LOW,
+    HIGH,
     VERY_HIGH,
+    AUTO,
 }
 
 val AudioOffload = booleanPreferencesKey("enableOffload")

--- a/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
@@ -109,10 +109,10 @@ val LastUpdateCheckTimeKey = longPreferencesKey("lastUpdateCheckTime")
 val AudioQualityKey = stringPreferencesKey("audioQuality")
 
 enum class AudioQuality {
+    AUTO,
     LOW,
     HIGH,
     VERY_HIGH,
-    AUTO,
 }
 
 val AudioOffload = booleanPreferencesKey("enableOffload")


### PR DESCRIPTION
## Problem

The audio quality options in settings are ordered incorrectly for user understanding.

## Cause

The enum ordering was [AUTO, HIGH, LOW, VERY_HIGH] which doesn't follow a logical progression from low to high.

## Solution

Reorder audio quality enum to [LOW, HIGH, VERY_HIGH, AUTO]

## Testing

Verified build compiles successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Adjusted the internal ordering of audio quality options; this is a non-functional reorder with no user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->