### PR TITLE
Enhance experimental lyrics : fix devnagari rendering glitch

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/LyricsLine.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/LyricsLine.kt
@@ -91,6 +91,27 @@ private fun String.containsRtl(): Boolean {
     return false
 }
 
+/**
+ * Splits a string into Unicode grapheme clusters using BreakIterator.
+ * This correctly handles Devanagari, Bengali, Arabic, Hangul, emoji, etc.
+ * where a single visible glyph is composed of multiple code points (e.g. base
+ * consonant + matra + anusvara = one cluster, not three separate chars).
+ */
+private fun String.toGraphemeClusters(): List<String> {
+    if (isEmpty()) return emptyList()
+    val result = mutableListOf<String>()
+    val it = java.text.BreakIterator.getCharacterInstance()
+    it.setText(this)
+    var start = it.first()
+    var end = it.next()
+    while (end != java.text.BreakIterator.DONE) {
+        result.add(substring(start, end))
+        start = end
+        end = it.next()
+    }
+    return result
+}
+
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun LyricsLine(
@@ -377,13 +398,34 @@ private fun WordLevelLyrics(
         }.let { data -> data.map { it.first } to data.map { it.second } }
     }
 
-    val charToWordData = remember(mainText, effectiveWords, isBackground) {
-        val wordIdxMap = IntArray(mainText.length) { -1 }
-        val charInWordMap = IntArray(mainText.length) { 0 }
-        val wordLenMap = IntArray(mainText.length) { 1 }
+    // Break mainText into grapheme clusters so that multi-codepoint glyphs
+    // (Devanagari/Bengali matras, Arabic ligatures, emoji, etc.) are treated
+    // as single units throughout the animation pipeline.
+    val graphemeClusters = remember(mainText) { mainText.toGraphemeClusters() }
+    val clusterCount = graphemeClusters.size
+    // For each cluster index, the String offset (Char index) of its first character in mainText.
+    // Required because TextLayoutResult.getBoundingBox/getLineForOffset take
+    // String offsets (UTF-16/Char indices), not cluster indices.
+    val clusterCharOffsets = remember(mainText) {
+        IntArray(clusterCount).also { offsets ->
+            var charOffset = 0
+            graphemeClusters.forEachIndexed { i, cluster ->
+                offsets[i] = charOffset
+                charOffset += cluster.length
+            }
+        }
+    }
+
+    // wordIdxMap / charInWordMap / wordLenMap are now sized and indexed by
+    // CLUSTER INDEX (not codepoint index) so that each visual glyph unit is
+    // mapped to exactly one word slot.
+    val charToWordData = remember(mainText, effectiveWords, isBackground, graphemeClusters, clusterCharOffsets) {
+        val wordIdxMap = IntArray(clusterCount) { -1 }
+        val charInWordMap = IntArray(clusterCount) { 0 }
+        val wordLenMap = IntArray(clusterCount) { 1 }
         var currentPos = 0
         effectiveWords.forEachIndexed { wordIdx, word ->
-            val rawWordText = word.text.let { 
+            val rawWordText = word.text.let {
                 if (isBackground) {
                     var t = it
                     if (wordIdx == 0) t = t.removePrefix("(")
@@ -393,19 +435,31 @@ private fun WordLevelLyrics(
             }
             val indexInMain = mainText.indexOf(rawWordText, currentPos)
             if (indexInMain != -1) {
-                for (i in 0 until rawWordText.length) {
-                    val pos = indexInMain + i
-                    wordIdxMap[pos] = wordIdx
-                    charInWordMap[pos] = i
-                    wordLenMap[pos] = rawWordText.length
+                val wordEndInMain = indexInMain + rawWordText.length
+                // Collect all cluster indices whose String offset falls within
+                // this word's String range.
+                val wordClusterIndices = mutableListOf<Int>()
+                clusterCharOffsets.forEachIndexed { clIdx, charOff ->
+                    if (charOff >= indexInMain && charOff < wordEndInMain) {
+                        wordClusterIndices.add(clIdx)
+                    }
                 }
-                if (indexInMain + rawWordText.length < mainText.length && mainText[indexInMain + rawWordText.length] == ' ') {
-                    val pos = indexInMain + rawWordText.length
-                    wordIdxMap[pos] = wordIdx
-                    charInWordMap[pos] = rawWordText.length
-                    wordLenMap[pos] = rawWordText.length + 1
+                val wordClusterLen = wordClusterIndices.size
+                wordClusterIndices.forEachIndexed { posInWord, clIdx ->
+                    wordIdxMap[clIdx] = wordIdx
+                    charInWordMap[clIdx] = posInWord
+                    wordLenMap[clIdx] = wordClusterLen
                 }
-                currentPos = indexInMain + rawWordText.length
+                // Assign trailing space cluster (if any) to this word.
+                if (wordEndInMain < mainText.length && mainText[wordEndInMain] == ' ') {
+                    val spaceClIdx = clusterCharOffsets.indexOfFirst { it == wordEndInMain }
+                    if (spaceClIdx != -1) {
+                        wordIdxMap[spaceClIdx] = wordIdx
+                        charInWordMap[spaceClIdx] = wordClusterLen
+                        wordLenMap[spaceClIdx] = wordClusterLen + 1
+                    }
+                }
+                currentPos = wordEndInMain
             }
         }
         Triple(wordIdxMap, charInWordMap, wordLenMap)
@@ -442,8 +496,10 @@ private fun WordLevelLyrics(
             )
         }
         
+        // Each layout corresponds to one grapheme cluster (the visual unit),
+        // not one codepoint - fixes Devanagari/Bengali matra fragmentation.
         val letterLayouts = remember(mainText, lyricStyle) {
-            mainText.map { textMeasurer.measure(it.toString(), lyricStyle) }
+            graphemeClusters.map { cluster -> textMeasurer.measure(cluster, lyricStyle) }
         }
         
         val isRtlText = remember(mainText) { mainText.containsRtl() }
@@ -481,9 +537,10 @@ private fun WordLevelLyrics(
                         var bottom = Float.MIN_VALUE
                         var found = false
 
-                        for (i in mainText.indices) {
+                        for (i in 0 until clusterCount) {
                             if (wordIdxMap[i] == wIdx) {
-                                val bounds = layoutResult.getBoundingBox(i)
+                                val cpOffset = clusterCharOffsets[i]
+                                val bounds = layoutResult.getBoundingBox(cpOffset)
                                 left = minOf(left, bounds.left)
                                 right = maxOf(right, bounds.right)
                                 top = minOf(top, bounds.top)
@@ -533,9 +590,11 @@ private fun WordLevelLyrics(
                 val lineCurrentPushes = FloatArray(layoutResult.lineCount)
                 val lineTotalPushes = FloatArray(layoutResult.lineCount)
                 
-                // Pre-calculate total pushes per line to handle alignment correctly
-                for (i in mainText.indices) {
-                    val lineIdx = layoutResult.getLineForOffset(i)
+                // Pre-calculate total pushes per line to handle alignment correctly.
+                // Iterate over cluster indices so each visual glyph unit is one slot.
+                for (i in 0 until clusterCount) {
+                    val charOffset = clusterCharOffsets[i]
+                    val lineIdx = layoutResult.getLineForOffset(charOffset)
                     val wordIdx = wordIdxMap[i]
                     val originalWordIdx = if (wordIdx != -1) effectiveToOriginalIdx[wordIdx] else -1
                     
@@ -581,13 +640,16 @@ private fun WordLevelLyrics(
                     } else 0f
 
                     val charScaleX = 1f + (wobble * 0.025f) + crescendoDeltaX + (nudgeScale * 0.3f)
-                    val charBounds = layoutResult.getBoundingBox(i)
+                    val charBounds = layoutResult.getBoundingBox(charOffset)
                     lineTotalPushes[lineIdx] += charBounds.width * (charScaleX - 1f)
                 }
 
-                for (i in mainText.indices) {
-                    val lineIdx = layoutResult.getLineForOffset(i)
-                    val charBounds = layoutResult.getBoundingBox(i)
+                // Main drawing loop: iterate over cluster indices so each visual
+                // glyph (including multi-codepoint Devanagari clusters) is one unit.
+                for (i in 0 until clusterCount) {
+                    val charOffset = clusterCharOffsets[i]
+                    val lineIdx = layoutResult.getLineForOffset(charOffset)
+                    val charBounds = layoutResult.getBoundingBox(charOffset)
                     val wordIdx = wordIdxMap[i]
                     val originalWordIdx = if (wordIdx != -1) effectiveToOriginalIdx[wordIdx] else -1
                     

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/LyricsLine.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/LyricsLine.kt
@@ -424,6 +424,7 @@ private fun WordLevelLyrics(
         val charInWordMap = IntArray(clusterCount) { 0 }
         val wordLenMap = IntArray(clusterCount) { 1 }
         var currentPos = 0
+        var clCursor = 0
         effectiveWords.forEachIndexed { wordIdx, word ->
             val rawWordText = word.text.let {
                 if (isBackground) {
@@ -436,13 +437,16 @@ private fun WordLevelLyrics(
             val indexInMain = mainText.indexOf(rawWordText, currentPos)
             if (indexInMain != -1) {
                 val wordEndInMain = indexInMain + rawWordText.length
-                // Collect all cluster indices whose String offset falls within
-                // this word's String range.
+                // Advance clCursor to the first cluster at or after indexInMain
+                while (clCursor < clusterCount && clusterCharOffsets[clCursor] < indexInMain) {
+                    clCursor++
+                }
+                val firstClIdx = clCursor
+                // Collect all clusters in the word range [indexInMain, wordEndInMain)
                 val wordClusterIndices = mutableListOf<Int>()
-                clusterCharOffsets.forEachIndexed { clIdx, charOff ->
-                    if (charOff >= indexInMain && charOff < wordEndInMain) {
-                        wordClusterIndices.add(clIdx)
-                    }
+                while (clCursor < clusterCount && clusterCharOffsets[clCursor] < wordEndInMain) {
+                    wordClusterIndices.add(clCursor)
+                    clCursor++
                 }
                 val wordClusterLen = wordClusterIndices.size
                 wordClusterIndices.forEachIndexed { posInWord, clIdx ->
@@ -450,14 +454,14 @@ private fun WordLevelLyrics(
                     charInWordMap[clIdx] = posInWord
                     wordLenMap[clIdx] = wordClusterLen
                 }
-                // Assign trailing space cluster (if any) to this word.
-                if (wordEndInMain < mainText.length && mainText[wordEndInMain] == ' ') {
-                    val spaceClIdx = clusterCharOffsets.indexOfFirst { it == wordEndInMain }
-                    if (spaceClIdx != -1) {
-                        wordIdxMap[spaceClIdx] = wordIdx
-                        charInWordMap[spaceClIdx] = wordClusterLen
-                        wordLenMap[spaceClIdx] = wordClusterLen + 1
-                    }
+                // Check the cluster at clCursor for a trailing space
+                if (clCursor < clusterCount && clusterCharOffsets[clCursor] == wordEndInMain && 
+                    wordEndInMain < mainText.length && mainText[wordEndInMain] == ' ') {
+                    val spaceClIdx = clCursor
+                    wordIdxMap[spaceClIdx] = wordIdx
+                    charInWordMap[spaceClIdx] = wordClusterLen
+                    wordLenMap[spaceClIdx] = wordClusterLen + 1
+                    clCursor++
                 }
                 currentPos = wordEndInMain
             }
@@ -497,7 +501,7 @@ private fun WordLevelLyrics(
         }
         
         // Each layout corresponds to one grapheme cluster (the visual unit),
-        // not one codepoint - fixes Devanagari/Bengali matra fragmentation.
+        // not one codepoint-fixes Devanagari/Bengali matra fragmentation.
         val letterLayouts = remember(mainText, lyricStyle) {
             graphemeClusters.map { cluster -> textMeasurer.measure(cluster, lyricStyle) }
         }
@@ -539,8 +543,8 @@ private fun WordLevelLyrics(
 
                         for (i in 0 until clusterCount) {
                             if (wordIdxMap[i] == wIdx) {
-                                val cpOffset = clusterCharOffsets[i]
-                                val bounds = layoutResult.getBoundingBox(cpOffset)
+                                val charOffset = clusterCharOffsets[i]
+                                val bounds = layoutResult.getBoundingBox(charOffset)
                                 left = minOf(left, bounds.left)
                                 right = maxOf(right, bounds.right)
                                 top = minOf(top, bounds.top)

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/LyricsLine.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/LyricsLine.kt
@@ -501,7 +501,7 @@ private fun WordLevelLyrics(
         }
         
         // Each layout corresponds to one grapheme cluster (the visual unit),
-        // not one codepoint-fixes Devanagari/Bengali matra fragmentation.
+        // not one codepoint. Fixes Devanagari/Bengali matra fragmentation.
         val letterLayouts = remember(mainText, lyricStyle) {
             graphemeClusters.map { cluster -> textMeasurer.measure(cluster, lyricStyle) }
         }


### PR DESCRIPTION
## Problem
Devanagari and other Indic script lyrics render with broken and fragmented glyphs in the expressive word-level lyrics view. Vowel matras and combining marks detach from their base consonants during animation, causing visual corruption.

## Cause
The animation pipeline iterated over codepoint indices (for i in mainText.indices), treating each Char as an independent unit. Indic glyphs like में are 3 codepoints but 1 visible cluster, so each combining mark got its own bounding box, scale transform, and draw call, tearing them apart visually.

## Solution
- Added String.toGraphemeClusters() using java.text.BreakIterator.getCharacterInstance() to correctly segment text into visual grapheme units
- Rebuilt charToWordData to be indexed by cluster count instead of codepoint count
- Added clusterCharOffsets to map cluster indices back to String/Char offsets required by TextLayoutResult methods
- Changed letterLayouts to measure one full cluster string per entry instead of one Char
- Replaced pre-calc and main drawing loops to iterate over cluster indices (0 until clusterCount)
- Updated RTL word-bounds scan to use cluster indices and clusterCharOffsets for correct glyph offset lookups
- Renamed clusterCodePointOffsets to clusterCharOffsets with clarified comments stating String offsets are UTF-16/Char indices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lyrics rendering and animation so complex characters, emoji, and multi-script text (e.g., Devanagari, Bengali, Arabic) render as single visual units. Alignment, clipping, highlighting, wobble and glow effects now apply correctly across LTR and RTL text, eliminating visual fragmentation and misaligned bounding boxes during playback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->