### PR TITLE
fix(playlists): batch multi-select adds into one playlist edit request

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialog.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialog.kt
@@ -81,6 +81,7 @@ fun AddToPlaylistDialog(
     isVisible: Boolean,
     allowSyncing: Boolean = true,
     initialTextFieldValue: String? = null,
+    multiSelectParams: String? = null,
     onGetSong: suspend (Playlist) -> List<String>, // list of song ids. Songs should be inserted to database in this function.
     onGetSongIds: (suspend () -> List<String>)? = null,
     onDismiss: () -> Unit,
@@ -123,15 +124,34 @@ fun AddToPlaylistDialog(
     }
 
     suspend fun addSongsAndSync(targetPlaylist: Playlist, ids: List<String>) {
-        database.addSongsToPlaylist(targetPlaylist, ids.map { it to null }, prepend = true)
-        targetPlaylist.playlist.browseId?.let { plist ->
-            ids.forEach { songId ->
-                syncUtils.registerPendingAdd(plist, songId)
-                try {
-                    YouTube.addToPlaylist(plist, songId)
-                } finally {
-                    syncUtils.unregisterPendingAdd(plist, songId)
-                }
+        val localIds = ids.distinct()
+        database.addSongsToPlaylist(targetPlaylist, localIds.map { it to null }, prepend = true)
+        val browseId = targetPlaylist.playlist.browseId ?: return
+        val remoteIds =
+            if (localIds.size > 1) {
+                YouTube.getMultiSelectCommand(localIds, multiSelectParams)
+                    .getOrNull()
+                    ?.multiSelectCommand
+                    ?.addToPlaylistEndpoint
+                    ?.videoIds
+                    .orEmpty()
+                    .ifEmpty { localIds }
+            } else {
+                localIds
+            }
+
+        remoteIds.forEach { songId ->
+            syncUtils.registerPendingAdd(browseId, songId)
+        }
+        try {
+            if (remoteIds.size == 1) {
+                YouTube.addToPlaylist(browseId, remoteIds.first())
+            } else {
+                YouTube.addToPlaylist(browseId, remoteIds)
+            }
+        } finally {
+            remoteIds.forEach { songId ->
+                syncUtils.unregisterPendingAdd(browseId, songId)
             }
         }
     }
@@ -291,26 +311,29 @@ fun AddToPlaylistDialog(
                     animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
                     label = "playlistBg"
                 )
-                PlaylistListItem(
-                    playlist = playlist,
-                    modifier = Modifier
+                    PlaylistListItem(
+                        playlist = playlist,
+                        modifier = Modifier
                     .padding(horizontal = 8.dp, vertical = 2.dp)
                     .clip(RoundedCornerShape(16.dp))
                     .background(rowBg)
                     .clickable {
                         selectedPlaylist = playlist
                         coroutineScope.launch(Dispatchers.IO) {
-                            if (songIds == null) {
-                                songIds = onGetSong(playlist)
-                            } else {
-                                onGetSong(playlist)
-                            }
-                            duplicates = database.playlistDuplicates(playlist.id, songIds!!)
+                            val resolvedSongIds =
+                                if (songIds.isNullOrEmpty()) {
+                                    onGetSong(playlist).also { resolved ->
+                                        songIds = resolved
+                                    }
+                                } else {
+                                    songIds!!
+                                }
+                            duplicates = database.playlistDuplicates(playlist.id, resolvedSongIds)
                             if (duplicates.isNotEmpty()) {
                                 showDuplicateDialog = true
                             } else {
                                 onDismiss()
-                                addSongsAndSync(playlist, songIds!!)
+                                addSongsAndSync(playlist, resolvedSongIds)
                             }
                         }
                     }

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialog.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialog.kt
@@ -128,7 +128,7 @@ fun AddToPlaylistDialog(
         database.addSongsToPlaylist(targetPlaylist, localIds.map { it to null }, prepend = true)
         val browseId = targetPlaylist.playlist.browseId ?: return
         val remoteIds =
-            if (localIds.size > 1) {
+            if (localIds.size > 1 && multiSelectParams != null) {
                 YouTube.getMultiSelectCommand(localIds, multiSelectParams)
                     .getOrNull()
                     ?.multiSelectCommand

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialog.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialog.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import com.metrolist.innertube.YouTube
 import com.metrolist.innertube.utils.parseCookieString
 import com.metrolist.music.LocalDatabase
 import com.metrolist.music.R
@@ -50,7 +49,6 @@ import com.metrolist.music.utils.rememberEnumPreference
 import com.metrolist.music.utils.rememberPreference
 import com.metrolist.music.viewmodels.PlaylistsViewModel
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import androidx.compose.foundation.background
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.graphics.Color
@@ -74,7 +72,6 @@ import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.material3.FilterChip
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.material3.FilterChipDefaults
-import com.metrolist.music.LocalSyncUtils
 
 @Composable
 fun AddToPlaylistDialog(
@@ -121,39 +118,6 @@ fun AddToPlaylistDialog(
     }
     var playlistsContainingSong by remember {
         mutableStateOf<Set<String>>(emptySet())
-    }
-
-    suspend fun addSongsAndSync(targetPlaylist: Playlist, ids: List<String>) {
-        val localIds = ids.distinct()
-        database.addSongsToPlaylist(targetPlaylist, localIds.map { it to null }, prepend = true)
-        val browseId = targetPlaylist.playlist.browseId ?: return
-        val remoteIds =
-            if (localIds.size > 1 && multiSelectParams != null) {
-                YouTube.getMultiSelectCommand(localIds, multiSelectParams)
-                    .getOrNull()
-                    ?.multiSelectCommand
-                    ?.addToPlaylistEndpoint
-                    ?.videoIds
-                    .orEmpty()
-                    .ifEmpty { localIds }
-            } else {
-                localIds
-            }
-
-        remoteIds.forEach { songId ->
-            syncUtils.registerPendingAdd(browseId, songId)
-        }
-        try {
-            if (remoteIds.size == 1) {
-                YouTube.addToPlaylist(browseId, remoteIds.first())
-            } else {
-                YouTube.addToPlaylist(browseId, remoteIds)
-            }
-        } finally {
-            remoteIds.forEach { songId ->
-                syncUtils.unregisterPendingAdd(browseId, songId)
-            }
-        }
     }
 
     LaunchedEffect(isVisible, playlists.isEmpty()) {
@@ -333,7 +297,7 @@ fun AddToPlaylistDialog(
                                 showDuplicateDialog = true
                             } else {
                                 onDismiss()
-                                addSongsAndSync(playlist, resolvedSongIds)
+                                viewModel.addSongsAndSync(playlist, resolvedSongIds, multiSelectParams)
                             }
                         }
                     }
@@ -359,12 +323,11 @@ fun AddToPlaylistDialog(
                         onClick = {
                             showDuplicateDialog = false
                             onDismiss()
-                            coroutineScope.launch(Dispatchers.IO) {
-                                addSongsAndSync(
-                                    selectedPlaylist!!,
-                                    songIds!!.filter { !duplicates.contains(it) }
-                                )
-                            }
+                            viewModel.addSongsAndSync(
+                                selectedPlaylist!!,
+                                songIds!!.filter { !duplicates.contains(it) },
+                                multiSelectParams,
+                            )
                         }
                     ) {
                         Text(stringResource(R.string.skip_duplicates))
@@ -374,9 +337,7 @@ fun AddToPlaylistDialog(
                         onClick = {
                             showDuplicateDialog = false
                             onDismiss()
-                            coroutineScope.launch(Dispatchers.IO) {
-                                addSongsAndSync(selectedPlaylist!!, songIds!!)
-                            }
+                            viewModel.addSongsAndSync(selectedPlaylist!!, songIds!!, multiSelectParams)
                         }
                     ) {
                         Text(stringResource(R.string.add_anyway))

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialog.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialog.kt
@@ -49,6 +49,7 @@ import com.metrolist.music.utils.rememberEnumPreference
 import com.metrolist.music.utils.rememberPreference
 import com.metrolist.music.viewmodels.PlaylistsViewModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import androidx.compose.foundation.background
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.graphics.Color
@@ -85,7 +86,6 @@ fun AddToPlaylistDialog(
     viewModel: PlaylistsViewModel = hiltViewModel()
 ) {
     val database = LocalDatabase.current
-    val syncUtils = LocalSyncUtils.current
     val coroutineScope = rememberCoroutineScope()
     val (sortType, onSortTypeChange) = rememberEnumPreference(
         AddToPlaylistSortTypeKey,

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/AlbumMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/AlbumMenu.kt
@@ -174,14 +174,7 @@ fun AlbumMenu(
 
     AddToPlaylistDialog(
         isVisible = showChoosePlaylistDialog,
-        onGetSong = { playlist ->
-            coroutineScope.launch(Dispatchers.IO) {
-                playlist.playlist.browseId?.let { playlistId ->
-                    album.album.playlistId?.let { addPlaylistId ->
-                        YouTube.addPlaylistToPlaylist(playlistId, addPlaylistId)
-                    }
-                }
-            }
+        onGetSong = {
             songs.map { it.id }
         },
         onGetSongIds = { songs.map { it.id } },

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/PlayerMenu.kt
@@ -167,12 +167,9 @@ fun PlayerMenu(
 
     AddToPlaylistDialog(
         isVisible = showChoosePlaylistDialog,
-        onGetSong = { playlist ->
+        onGetSong = {
             database.withTransaction {
                 insert(mediaMetadata)
-            }
-            coroutineScope.launch(Dispatchers.IO) {
-                playlist.playlist.browseId?.let { YouTube.addToPlaylist(it, mediaMetadata.id) }
             }
             listOf(mediaMetadata.id)
         },

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/QueueMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/QueueMenu.kt
@@ -117,12 +117,9 @@ fun QueueMenu(
 
     AddToPlaylistDialog(
         isVisible = showChoosePlaylistDialog,
-        onGetSong = { playlist ->
+        onGetSong = {
             database.withTransaction {
                 insert(mediaMetadata)
-            }
-            coroutineScope.launch(Dispatchers.IO) {
-                playlist.playlist.browseId?.let { YouTube.addToPlaylist(it, mediaMetadata.id) }
             }
             listOf(mediaMetadata.id)
         },

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/SelectionSongsMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/SelectionSongsMenu.kt
@@ -139,14 +139,7 @@ fun SelectionSongMenu(
 
     AddToPlaylistDialog(
         isVisible = showChoosePlaylistDialog,
-        onGetSong = { playlist ->
-            coroutineScope.launch(Dispatchers.IO) {
-                songSelection.forEach { song ->
-                    playlist.playlist.browseId?.let { browseId ->
-                        YouTube.addToPlaylist(browseId, song.id)
-                    }
-                }
-            }
+        onGetSong = {
             songSelection.map { it.id }
         },
         onGetSongIds = { songSelection.map { it.id } },

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/SongMenu.kt
@@ -237,11 +237,9 @@ fun SongMenu(
 
     AddToPlaylistDialog(
         isVisible = showChoosePlaylistDialog,
-        onGetSong = { playlist ->
-            coroutineScope.launch(Dispatchers.IO) {
-                playlist.playlist.browseId?.let { browseId ->
-                    YouTube.addToPlaylist(browseId, song.id)
-                }
+        onGetSong = {
+            database.withTransaction {
+                insert(song.toMediaMetadata())
             }
             listOf(song.id)
         },

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeAlbumMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeAlbumMenu.kt
@@ -153,14 +153,7 @@ fun YouTubeAlbumMenu(
 
     AddToPlaylistDialog(
         isVisible = showChoosePlaylistDialog,
-        onGetSong = { playlist ->
-            coroutineScope.launch(Dispatchers.IO) {
-                playlist.playlist.browseId?.let { playlistId ->
-                    album?.album?.playlistId?.let { addPlaylistId ->
-                        YouTube.addPlaylistToPlaylist(playlistId, addPlaylistId)
-                    }
-                }
-            }
+        onGetSong = {
             album?.songs?.map { it.id }.orEmpty()
         },
         onGetSongIds = { album?.songs?.map { it.id }.orEmpty() },

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubePlaylistMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubePlaylistMenu.kt
@@ -126,12 +126,12 @@ fun YouTubePlaylistMenu(
 
     AddToPlaylistDialog(
         isVisible = showChoosePlaylistDialog,
-        onGetSong = { targetPlaylist ->
+        onGetSong = {
             val allSongs =
                 songs
                     .ifEmpty {
                         YouTube
-                            .playlist(targetPlaylist.id)
+                            .playlist(playlist.id)
                             .completed()
                             .getOrNull()
                             ?.songs
@@ -141,11 +141,6 @@ fun YouTubePlaylistMenu(
                     }
             database.withTransaction {
                 allSongs.forEach(::insert)
-            }
-            coroutineScope.launch(Dispatchers.IO) {
-                targetPlaylist.playlist.browseId?.let { playlistId ->
-                    YouTube.addPlaylistToPlaylist(playlistId, targetPlaylist.id)
-                }
             }
             allSongs.map { it.id }
         },

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeSelectionSongMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeSelectionSongMenu.kt
@@ -26,7 +26,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -122,52 +121,16 @@ fun YouTubeSelectionSongMenu(
         }
     }
 
-    AddToPlaylistDialogOnline(
+    val selectedSongs = songSelection.map { it.toMediaMetadata() }
+
+    AddToPlaylistDialog(
         isVisible = showChoosePlaylistDialog,
-        songs =
-            remember {
-                songSelection
-                    .map { song ->
-                        // Convert SongItem to Song entity
-                        val metadata = song.toMediaMetadata()
-                        com.metrolist.music.db.entities.Song(
-                            song =
-                                com.metrolist.music.db.entities.SongEntity(
-                                    id = metadata.id,
-                                    title = metadata.title,
-                                    duration = metadata.duration,
-                                    thumbnailUrl = metadata.thumbnailUrl,
-                                    albumId = metadata.album?.id,
-                                    albumName = metadata.album?.title,
-                                    liked = metadata.liked,
-                                    totalPlayTime = 0,
-                                    inLibrary = metadata.inLibrary,
-                                    isLocal = false,
-                                    libraryAddToken = metadata.libraryAddToken,
-                                    libraryRemoveToken = metadata.libraryRemoveToken,
-                                ),
-                            artists =
-                                metadata.artists.map { artist ->
-                                    com.metrolist.music.db.entities.ArtistEntity(
-                                        id = artist.id ?: "",
-                                        name = artist.name,
-                                    )
-                                },
-                            album =
-                                metadata.album?.let { album ->
-                                    com.metrolist.music.db.entities.AlbumEntity(
-                                        id = album.id,
-                                        title = album.title,
-                                        thumbnailUrl = metadata.thumbnailUrl, // Use song's thumbnail as album thumbnail
-                                        songCount = 0,
-                                        duration = 0,
-                                    )
-                                },
-                        )
-                    }.toMutableStateList()
-            },
-        onProgressStart = { },
-        onPercentageChange = { },
+        onGetSong = {
+            database.withTransaction {
+                selectedSongs.forEach(::insert)
+            }
+            selectedSongs.map { it.id }
+        },
         onDismiss = {
             showChoosePlaylistDialog = false
         },

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeSongMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeSongMenu.kt
@@ -123,14 +123,9 @@ fun YouTubeSongMenu(
 
     AddToPlaylistDialog(
         isVisible = showChoosePlaylistDialog,
-        onGetSong = { playlist ->
+        onGetSong = {
             database.withTransaction {
                 insert(song.toMediaMetadata())
-            }
-            coroutineScope.launch(Dispatchers.IO) {
-                playlist.playlist.browseId?.let { browseId ->
-                    YouTube.addToPlaylist(browseId, song.id)
-                }
             }
             listOf(song.id)
         },

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/MiniPlayer.kt
@@ -179,6 +179,7 @@ private fun NewMiniPlayer(
     onClick: () -> Unit = {},
 ) {
     val playerConnection = LocalPlayerConnection.current ?: return
+    val database = LocalDatabase.current
     val menuState = LocalMenuState.current
 
     // Theme settings - these rarely change
@@ -486,7 +487,12 @@ private fun NewMiniPlayer(
                             menuState.show {
                                 AddToPlaylistDialog(
                                     isVisible = true,
-                                    onGetSong = { listOf(metadata.id) },
+                                    onGetSong = {
+                                        database.withTransaction {
+                                            insert(metadata)
+                                        }
+                                        listOf(metadata.id)
+                                    },
                                     onDismiss = menuState::dismiss,
                                 )
                             }

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/PlaylistsViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/PlaylistsViewModel.kt
@@ -14,12 +14,16 @@ import com.metrolist.music.constants.AddToPlaylistSortDescendingKey
 import com.metrolist.music.constants.AddToPlaylistSortTypeKey
 import com.metrolist.music.constants.PlaylistSortType
 import com.metrolist.music.db.MusicDatabase
+import com.metrolist.music.db.entities.Playlist
 import com.metrolist.music.extensions.toEnum
+import com.metrolist.innertube.YouTube
 import com.metrolist.music.utils.SyncUtils
 import com.metrolist.music.utils.dataStore
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
@@ -32,7 +36,7 @@ class PlaylistsViewModel
 @Inject
 constructor(
     @ApplicationContext context: Context,
-    database: MusicDatabase,
+    private val database: MusicDatabase,
     private val syncUtils: SyncUtils,
 ) : ViewModel() {
     val allPlaylists =
@@ -48,5 +52,44 @@ constructor(
     // Suspend function that waits for sync to complete
     suspend fun sync() {
         syncUtils.syncSavedPlaylists()
+    }
+
+    fun addSongsAndSync(
+        targetPlaylist: Playlist,
+        ids: List<String>,
+        multiSelectParams: String? = null,
+    ) {
+        viewModelScope.launch(Dispatchers.IO) {
+            val localIds = ids.distinct()
+            database.addSongsToPlaylist(targetPlaylist, localIds.map { it to null }, prepend = true)
+            val browseId = targetPlaylist.playlist.browseId ?: return@launch
+            val remoteIds =
+                if (localIds.size > 1 && multiSelectParams != null) {
+                    YouTube.getMultiSelectCommand(localIds, multiSelectParams)
+                        .getOrNull()
+                        ?.multiSelectCommand
+                        ?.addToPlaylistEndpoint
+                        ?.videoIds
+                        .orEmpty()
+                        .ifEmpty { localIds }
+                } else {
+                    localIds
+                }
+
+            remoteIds.forEach { songId ->
+                syncUtils.registerPendingAdd(browseId, songId)
+            }
+            try {
+                if (remoteIds.size == 1) {
+                    YouTube.addToPlaylist(browseId, remoteIds.first())
+                } else {
+                    YouTube.addToPlaylist(browseId, remoteIds)
+                }
+            } finally {
+                remoteIds.forEach { songId ->
+                    syncUtils.unregisterPendingAdd(browseId, songId)
+                }
+            }
+        }
     }
 }

--- a/innertube/src/main/kotlin/com/metrolist/innertube/InnerTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/InnerTube.kt
@@ -508,6 +508,42 @@ class InnerTube {
         }
     }
 
+    suspend fun addToPlaylist(
+        client: YouTubeClient,
+        playlistId: String,
+        videoIds: List<String>,
+    ) = withRetry {
+        httpClient.post("browse/edit_playlist") {
+            ytClient(client, setLogin = true)
+            setBody(
+                EditPlaylistBody(
+                    context = client.toContext(locale, visitorData, dataSyncId),
+                    playlistId = playlistId.removePrefix("VL"),
+                    actions = videoIds.map {
+                        Action.AddVideoAction(addedVideoId = it)
+                    }
+                )
+            )
+        }
+    }
+
+    suspend fun getMultiSelectCommand(
+        client: YouTubeClient,
+        selectedItems: List<String>,
+        multiSelectParams: String? = null,
+    ) = withRetry {
+        httpClient.post("get_multi_select_command") {
+            ytClient(client, setLogin = true)
+            setBody(
+                GetMultiSelectCommandBody(
+                    context = client.toContext(locale, visitorData, dataSyncId),
+                    selectedItems = selectedItems,
+                    multiSelectParams = multiSelectParams,
+                )
+            )
+        }
+    }
+
     suspend fun addPlaylistToPlaylist(
         client: YouTubeClient,
         playlistId: String,

--- a/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
@@ -36,7 +36,9 @@ import com.metrolist.innertube.models.response.BrowseResponse
 import com.metrolist.innertube.models.response.CreatePlaylistResponse
 import com.metrolist.innertube.models.response.EditPlaylistResponse
 import com.metrolist.innertube.models.response.FeedbackResponse
+import com.metrolist.innertube.models.response.GetMultiSelectCommandResponse
 import com.metrolist.innertube.models.response.GetQueueResponse
+import com.metrolist.innertube.models.response.GetMultiSelectCommandResponse
 import com.metrolist.innertube.models.response.GetSearchSuggestionsResponse
 import com.metrolist.innertube.models.response.GetTranscriptResponse
 import com.metrolist.innertube.models.response.ImageUploadResponse
@@ -2587,6 +2589,21 @@ object YouTube {
         videoId: String,
     ) = runCatching {
         innerTube.addToPlaylist(WEB_REMIX, playlistId, videoId)
+    }
+
+    suspend fun addToPlaylist(
+        playlistId: String,
+        videoIds: List<String>,
+    ) = runCatching {
+        innerTube.addToPlaylist(WEB_REMIX, playlistId, videoIds)
+    }
+
+    suspend fun getMultiSelectCommand(
+        selectedItems: List<String>,
+        multiSelectParams: String? = null,
+    ) = runCatching {
+        val response = innerTube.getMultiSelectCommand(WEB_REMIX, selectedItems, multiSelectParams).body<GetMultiSelectCommandResponse>()
+        response
     }
 
     suspend fun addPlaylistToPlaylist(

--- a/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
@@ -38,7 +38,6 @@ import com.metrolist.innertube.models.response.EditPlaylistResponse
 import com.metrolist.innertube.models.response.FeedbackResponse
 import com.metrolist.innertube.models.response.GetMultiSelectCommandResponse
 import com.metrolist.innertube.models.response.GetQueueResponse
-import com.metrolist.innertube.models.response.GetMultiSelectCommandResponse
 import com.metrolist.innertube.models.response.GetSearchSuggestionsResponse
 import com.metrolist.innertube.models.response.GetTranscriptResponse
 import com.metrolist.innertube.models.response.ImageUploadResponse

--- a/innertube/src/main/kotlin/com/metrolist/innertube/models/body/EditPlaylistBody.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/models/body/EditPlaylistBody.kt
@@ -15,7 +15,8 @@ sealed class Action {
     @Serializable
     data class AddVideoAction(
         val action: String = "ACTION_ADD_VIDEO",
-        val addedVideoId: String
+        val addedVideoId: String,
+        val dedupeOption: String = "DEDUPE_OPTION_CHECK"
     ) : Action()
 
     @Serializable

--- a/innertube/src/main/kotlin/com/metrolist/innertube/models/body/GetMultiSelectCommandBody.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/models/body/GetMultiSelectCommandBody.kt
@@ -1,0 +1,11 @@
+package com.metrolist.innertube.models.body
+
+import com.metrolist.innertube.models.Context
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GetMultiSelectCommandBody(
+    val context: Context,
+    val selectedItems: List<String>,
+    val multiSelectParams: String? = null,
+)

--- a/innertube/src/main/kotlin/com/metrolist/innertube/models/response/GetMultiSelectCommandResponse.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/models/response/GetMultiSelectCommandResponse.kt
@@ -1,0 +1,18 @@
+package com.metrolist.innertube.models.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GetMultiSelectCommandResponse(
+    val multiSelectCommand: MultiSelectCommand? = null,
+) {
+    @Serializable
+    data class MultiSelectCommand(
+        val addToPlaylistEndpoint: AddToPlaylistEndpoint? = null,
+    ) {
+        @Serializable
+        data class AddToPlaylistEndpoint(
+            val videoIds: List<String> = emptyList(),
+        )
+    }
+}


### PR DESCRIPTION
## Problem
Multi-select add-to-playlist was slow and unreliable for large selections. The add work was tied too closely to the UI flow, and the app was issuing one request per song instead of using a single bulk playlist edit.

## Cause
The playlist add flow was spread across multiple menu entry points and depended on the dialog/UI staying alive while each individual add request completed. For online selections, the flow also re-resolved songs unnecessarily instead of using the direct add path.

## Solution
- Added support for YouTube Music's multi-select edit command in the InnerTube layer
- Switched playlist add handling to batch selected songs into a single edit request
- Updated the shared add-to-playlist flow to use the batch path consistently
- Simplified online selection handling so selected songs go through the direct add flow instead of a per-song search/re-resolve step

## Testing
Manually verified that multi-select add-to-playlist completes correctly and is much faster for large selections.

## Related Issues
- Closes #2484
- Closes #3167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-select support for adding multiple songs to playlists at once.
  * Batch add-and-sync flow to add many items in one operation.

* **Bug Fixes**
  * Improved duplicate detection and "skip duplicates" behavior.
  * More reliable ID resolution with fallbacks and robust pending-add tracking.
  * Ensures local insertion of added items so playlist additions persist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->