### PR TITLE
fix(artists): properly handle artist conjunctions in YouTube Music API responses

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/App.kt
+++ b/app/src/main/kotlin/com/metrolist/music/App.kt
@@ -97,16 +97,6 @@ class App :
 
         ArtistConjunctions.conjunctions = listOf(
             R.string.and,
-            R.string.e,
-            R.string.ed,
-            R.string.y,
-            R.string.et,
-            R.string.und,
-            R.string.en,
-            R.string.och,
-            R.string.og,
-            R.string.ja,
-            R.string.ve,
         ).mapNotNull { id ->
             runCatching { getString(id) }.getOrNull()
         }

--- a/app/src/main/kotlin/com/metrolist/music/App.kt
+++ b/app/src/main/kotlin/com/metrolist/music/App.kt
@@ -22,6 +22,7 @@ import coil3.request.CachePolicy
 import coil3.request.allowHardware
 import coil3.request.crossfade
 import com.metrolist.innertube.YouTube
+import com.metrolist.innertube.models.ArtistConjunctions
 import com.metrolist.innertube.models.YouTubeLocale
 import com.metrolist.kugou.KuGou
 import com.metrolist.lastfm.LastFM
@@ -93,6 +94,22 @@ class App :
         val settings = dataStore.data.first()
         val locale = Locale.getDefault()
         val languageTag = locale.language
+
+        ArtistConjunctions.conjunctions = listOf(
+            R.string.and,
+            R.string.e,
+            R.string.ed,
+            R.string.y,
+            R.string.et,
+            R.string.und,
+            R.string.en,
+            R.string.och,
+            R.string.og,
+            R.string.ja,
+            R.string.ve,
+        ).mapNotNull { id ->
+            runCatching { getString(id) }.getOrNull()
+        }
 
         YouTube.locale =
             YouTubeLocale(

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/ArtistItemsViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/ArtistItemsViewModel.kt
@@ -47,13 +47,14 @@ constructor(
                         browseId = browseId,
                         params = params,
                     ),
-                ).onSuccess { artistItemsPage ->
+                )                .onSuccess { artistItemsPage ->
+                    val resolvedItems = YouTube.resolveArtistIds(artistItemsPage.items)
                     val hideExplicit = context.dataStore.get(HideExplicitKey, false)
                     val hideVideoSongs = context.dataStore.get(HideVideoSongsKey, false)
                     title.value = artistItemsPage.title
                     itemsPage.value =
                         ItemsPage(
-                            items = artistItemsPage.items
+                            items = resolvedItems
                                 .distinctBy { it.id }
                                 .filterExplicit(hideExplicit)
                                 .filterVideoSongs(hideVideoSongs),
@@ -72,12 +73,13 @@ constructor(
             YouTube
                 .artistItemsContinuation(continuation)
                 .onSuccess { artistItemsContinuationPage ->
+                    val resolvedItems = YouTube.resolveArtistIds(artistItemsContinuationPage.items)
                     val hideExplicit = context.dataStore.get(HideExplicitKey, false)
                     val hideVideoSongs = context.dataStore.get(HideVideoSongsKey, false)
                     itemsPage.update {
                         ItemsPage(
                             items =
-                            (oldItemsPage.items + artistItemsContinuationPage.items)
+                            (oldItemsPage.items + resolvedItems)
                                 .distinctBy { it.id }
                                 .filterExplicit(hideExplicit)
                                 .filterVideoSongs(hideVideoSongs),

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/ArtistViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/ArtistViewModel.kt
@@ -110,15 +110,19 @@ class ArtistViewModel @Inject constructor(
             val hideYoutubeShorts = context.dataStore.get(HideYoutubeShortsKey, false)
             YouTube.artist(artistId)
                 .onSuccess { page ->
-                    val filteredSections = page.sections
+                    val resolvedSections = page.sections.map { section ->
+                        section.copy(items = YouTube.resolveArtistIds(section.items))
+                    }
+                    val resolvedPage = page.copy(sections = resolvedSections)
+                    val filteredSections = resolvedPage.sections
                         .map { section ->
                             section.copy(items = section.items.filterExplicit(hideExplicit).filterVideoSongs(hideVideoSongs).filterYoutubeShorts(hideYoutubeShorts))
                         }
                         .filter { section -> section.items.isNotEmpty() }
 
-                    artistPage = page.copy(sections = filteredSections)
+                    artistPage = resolvedPage.copy(sections = filteredSections)
                     // Store API subscription state
-                    _apiSubscribed.value = page.isSubscribed
+                    _apiSubscribed.value = resolvedPage.isSubscribed
                 }.onFailure {
                     reportException(it)
                 }

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/OnlineSearchViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/OnlineSearchViewModel.kt
@@ -50,16 +50,20 @@ constructor(
 
     private suspend fun loadSummaryPage() {
         if (summaryPage == null) {
-            YouTube
-                .searchSummary(query)
-                .onSuccess {
-                    val hideExplicit = context.dataStore.get(HideExplicitKey, false)
-                    val hideVideoSongs = context.dataStore.get(HideVideoSongsKey, false)
-                    val hideYoutubeShorts = context.dataStore.get(HideYoutubeShortsKey, false)
-                    summaryPage =
-                        it.filterExplicit(hideExplicit)
-                          .filterVideoSongs(hideVideoSongs)
-                          .filterYoutubeShorts(hideYoutubeShorts)
+                    YouTube
+                        .searchSummary(query)
+                        .onSuccess { page ->
+                            val resolvedSummaries = page.summaries.map { summary ->
+                                summary.copy(items = YouTube.resolveArtistIds(summary.items))
+                            }
+                            val resolvedPage = page.copy(summaries = resolvedSummaries)
+                            val hideExplicit = context.dataStore.get(HideExplicitKey, false)
+                            val hideVideoSongs = context.dataStore.get(HideVideoSongsKey, false)
+                            val hideYoutubeShorts = context.dataStore.get(HideYoutubeShortsKey, false)
+                            summaryPage =
+                                resolvedPage.filterExplicit(hideExplicit)
+                                  .filterVideoSongs(hideVideoSongs)
+                                  .filterYoutubeShorts(hideYoutubeShorts)
                 }.onFailure {
                     reportException(it)
                 }
@@ -93,12 +97,13 @@ constructor(
                         YouTube
                             .search(query, filter)
                             .onSuccess { result ->
+                                val resolvedItems = YouTube.resolveArtistIds(result.items)
                                 val hideExplicit = context.dataStore.get(HideExplicitKey, false)
                                 val hideVideoSongs = context.dataStore.get(HideVideoSongsKey, false)
                                 val hideYoutubeShorts = context.dataStore.get(HideYoutubeShortsKey, false)
                                 viewStateMap[filter.value] =
                                     ItemsPage(
-                                        result.items
+                                        resolvedItems
                                             .distinctBy { it.id }
                                             .filterExplicit(hideExplicit)
                                             .filterVideoSongs(hideVideoSongs)
@@ -122,10 +127,11 @@ constructor(
             val continuation = viewState.continuation ?: return@launch
             val searchResult =
                 YouTube.searchContinuation(continuation).getOrNull() ?: return@launch
+            val resolvedItems = YouTube.resolveArtistIds(searchResult.items)
             val hideExplicit = context.dataStore.get(HideExplicitKey, false)
             val hideVideoSongs = context.dataStore.get(HideVideoSongsKey, false)
             val hideYoutubeShorts = context.dataStore.get(HideYoutubeShortsKey, false)
-            val newItems = searchResult.items
+            val newItems = resolvedItems
                 .filterExplicit(hideExplicit)
                 .filterVideoSongs(hideVideoSongs)
                 .filterYoutubeShorts(hideYoutubeShorts)

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -28,18 +28,7 @@
     <string name="sync_disabled">Sync disabled</string>
     <string name="allows_for_sync_witch_youtube">NOTE: This option enables syncing with YouTube Music and CANNOT be changed later</string>
 
-    <!-- Artist conjunctions used to split multiple artists in YouTube Music responses -->
     <string name="and">and</string>
-    <string name="e">e</string>
-    <string name="ed">ed</string>
-    <string name="y">y</string>
-    <string name="et">et</string>
-    <string name="und">und</string>
-    <string name="en">en</string>
-    <string name="och">och</string>
-    <string name="og">og</string>
-    <string name="ja">ja</string>
-    <string name="ve">ve</string>
     <string name="generating_image">Generating image…</string>
     <string name="please_wait">Please wait</string>
     <string name="cancel">Cancel</string>

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -28,8 +28,18 @@
     <string name="sync_disabled">Sync disabled</string>
     <string name="allows_for_sync_witch_youtube">NOTE: This option enables syncing with YouTube Music and CANNOT be changed later</string>
 
-    <!-- Artist conjunction patterns for internationalized parsing -->
-    <string name="conjunction_and">and</string>
+    <!-- Artist conjunctions used to split multiple artists in YouTube Music responses -->
+    <string name="and">and</string>
+    <string name="e">e</string>
+    <string name="ed">ed</string>
+    <string name="y">y</string>
+    <string name="et">et</string>
+    <string name="und">und</string>
+    <string name="en">en</string>
+    <string name="och">och</string>
+    <string name="og">og</string>
+    <string name="ja">ja</string>
+    <string name="ve">ve</string>
     <string name="generating_image">Generating image…</string>
     <string name="please_wait">Please wait</string>
     <string name="cancel">Cancel</string>

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -27,6 +27,9 @@
     <string name="sync_playlist">Sync playlist</string>
     <string name="sync_disabled">Sync disabled</string>
     <string name="allows_for_sync_witch_youtube">NOTE: This option enables syncing with YouTube Music and CANNOT be changed later</string>
+
+    <!-- Artist conjunction patterns for internationalized parsing -->
+    <string name="conjunction_and">and</string>
     <string name="generating_image">Generating image…</string>
     <string name="please_wait">Please wait</string>
     <string name="cancel">Cancel</string>

--- a/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
@@ -3213,4 +3213,40 @@ object YouTube {
      * Maximum file size for upload (300MB)
      */
     const val MAX_UPLOAD_SIZE = 314572800L
+
+    suspend fun resolveArtistIds(items: List<YTItem>): List<YTItem> {
+        val missingNames = mutableSetOf<String>()
+        for (item in items) {
+            when (item) {
+                is SongItem -> item.artists.filter { it.id == null }.forEach { missingNames.add(it.name) }
+                is AlbumItem -> item.artists?.filter { it.id == null }?.forEach { missingNames.add(it.name) }
+                is PlaylistItem -> item.author?.let { if (it.id == null) missingNames.add(it.name) }
+                is EpisodeItem -> item.author?.let { if (it.id == null) missingNames.add(it.name) }
+                is PodcastItem -> item.author?.let { if (it.id == null) missingNames.add(it.name) }
+                else -> {}
+            }
+        }
+
+        if (missingNames.isEmpty()) return items
+
+        val resolved = mutableMapOf<String, String>()
+        for (name in missingNames) {
+            val searchResult = search(name, SearchFilter.FILTER_ARTIST).getOrNull()
+            val artistId = searchResult?.items?.firstOrNull { it is ArtistItem }
+                ?.let { (it as ArtistItem).id }
+            if (artistId != null) resolved[name] = artistId
+        }
+
+        fun Artist.resolve() = if (id == null) resolved[name]?.let { copy(id = it) } ?: this else this
+        return items.map { item ->
+            when (item) {
+                is SongItem -> item.copy(artists = item.artists.map { it.resolve() })
+                is AlbumItem -> item.copy(artists = item.artists?.map { it.resolve() })
+                is PlaylistItem -> item.copy(author = item.author?.resolve())
+                is EpisodeItem -> item.copy(author = item.author?.resolve())
+                is PodcastItem -> item.copy(author = item.author?.resolve())
+                else -> item
+            }
+        }
+    }
 }

--- a/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
@@ -3232,8 +3232,12 @@ object YouTube {
         val resolved = mutableMapOf<String, String>()
         for (name in missingNames) {
             val searchResult = search(name, SearchFilter.FILTER_ARTIST).getOrNull()
-            val artistId = searchResult?.items?.firstOrNull { it is ArtistItem }
-                ?.let { (it as ArtistItem).id }
+            val normalizedName = name.trim()
+            val artistId = searchResult?.items
+                ?.filterIsInstance<ArtistItem>()
+                ?.firstOrNull { candidate ->
+                    candidate.title.trim().equals(normalizedName, ignoreCase = true)
+                }?.id
             if (artistId != null) resolved[name] = artistId
         }
 

--- a/innertube/src/main/kotlin/com/metrolist/innertube/models/Runs.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/models/Runs.kt
@@ -30,9 +30,10 @@ fun List<Run>.splitBySeparator(): List<List<Run>> {
 
 fun List<Run>.splitArtistsByConjunction(): List<Run> {
     val result = mutableListOf<Run>()
+    val pattern = ArtistConjunctions.conjunctions.joinToString("|") { Regex.escape(it) }
+    val conjunctionPattern = Regex(" $pattern |, | & ")
     forEach { run ->
         val text = run.text
-        val conjunctionPattern = Regex(" & |, | \\band\\b")
         if (text.contains(conjunctionPattern)) {
             val parts = text.split(conjunctionPattern)
             parts.forEachIndexed { index, part ->
@@ -45,6 +46,10 @@ fun List<Run>.splitArtistsByConjunction(): List<Run> {
         }
     }
     return result
+}
+
+object ArtistConjunctions {
+    var conjunctions: List<String> = listOf("and")
 }
 
 fun List<List<Run>>.clean(): List<List<Run>> =

--- a/innertube/src/main/kotlin/com/metrolist/innertube/models/Runs.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/models/Runs.kt
@@ -28,6 +28,30 @@ fun List<Run>.splitBySeparator(): List<List<Run>> {
     return res
 }
 
+/**
+ * Splits artist runs by conjunction separators (&, ,) to properly handle
+ * cases where multiple artists are displayed as "Artist1 & Artist2" or "Artist1, Artist2"
+ */
+fun List<Run>.splitArtistsByConjunction(): List<Run> {
+    val result = mutableListOf<Run>()
+    forEach { run ->
+        val text = run.text
+        // Check if this run contains conjunction patterns
+        if (text.contains(" & ") || text.contains(", ")) {
+            // Split by both patterns and preserve navigationEndpoint if present
+            val parts = text.split(Regex(" & |, "))
+            parts.forEachIndexed { index, part ->
+                if (part.isNotBlank()) {
+                    result.add(Run(part.trim(), if (index == 0) run.navigationEndpoint else null))
+                }
+            }
+        } else {
+            result.add(run)
+        }
+    }
+    return result
+}
+
 fun List<List<Run>>.clean(): List<List<Run>> =
     if (getOrNull(0)?.getOrNull(0)?.navigationEndpoint != null ||
         (getOrNull(0)?.getOrNull(0)?.text?.contains(regex = Regex("[&,]"))) != false

--- a/innertube/src/main/kotlin/com/metrolist/innertube/models/Runs.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/models/Runs.kt
@@ -32,8 +32,8 @@ fun List<Run>.splitArtistsByConjunction(): List<Run> {
     val result = mutableListOf<Run>()
     val words = ArtistConjunctions.conjunctions
     val conjunctionPattern = Regex(
-        if (words.isNotEmpty()) " (${words.joinToString("|") { Regex.escape(it) }}) |, | & "
-        else ", | & "
+        if (words.isNotEmpty()) " (${words.joinToString("|") { Regex.escape(it) }}) | & "
+        else " & "
     )
     forEach { run ->
         val text = run.text
@@ -41,7 +41,7 @@ fun List<Run>.splitArtistsByConjunction(): List<Run> {
             val parts = text.split(conjunctionPattern)
             parts.forEachIndexed { index, part ->
                 if (part.isNotBlank()) {
-                    result.add(Run(part.trim(), if (index == 0) run.navigationEndpoint else null))
+                    result.add(Run(part.trim(), run.navigationEndpoint))
                 }
             }
         } else {
@@ -55,14 +55,15 @@ object ArtistConjunctions {
     var conjunctions: List<String> = listOf("and")
 }
 
-fun List<List<Run>>.clean(): List<List<Run>> =
-    if (getOrNull(0)?.getOrNull(0)?.navigationEndpoint != null ||
-        (getOrNull(0)?.getOrNull(0)?.text?.contains(regex = Regex("[&,]"))) != false
-    ) {
-        this
-    } else {
-        this.drop(1)
-    }
+fun List<List<Run>>.clean(): List<List<Run>> {
+    val firstGroup = getOrNull(0) ?: return this
+    val hasArtistSignals = firstGroup.any { it.navigationEndpoint != null } ||
+        firstGroup.any { it.text.contains(" & ") } ||
+        ArtistConjunctions.conjunctions.any { conj ->
+            firstGroup.any { it.text.trim().equals(conj, ignoreCase = true) }
+        }
+    return if (hasArtistSignals) this else drop(1)
+}
 
 fun List<Run>.oddElements() =
     filterIndexed { index, _ ->

--- a/innertube/src/main/kotlin/com/metrolist/innertube/models/Runs.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/models/Runs.kt
@@ -32,7 +32,7 @@ fun List<Run>.splitArtistsByConjunction(): List<Run> {
     val result = mutableListOf<Run>()
     forEach { run ->
         val text = run.text
-        val conjunctionPattern = Regex(" & |, | \\band\\b| \\be\\b| \\by\\b| \\bet\\b| \\und\\b| \\bи\\b| \\bと\\b| \\b와\\b")
+        val conjunctionPattern = Regex(" & |, | \\band\\b")
         if (text.contains(conjunctionPattern)) {
             val parts = text.split(conjunctionPattern)
             parts.forEachIndexed { index, part ->

--- a/innertube/src/main/kotlin/com/metrolist/innertube/models/Runs.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/models/Runs.kt
@@ -30,8 +30,11 @@ fun List<Run>.splitBySeparator(): List<List<Run>> {
 
 fun List<Run>.splitArtistsByConjunction(): List<Run> {
     val result = mutableListOf<Run>()
-    val pattern = ArtistConjunctions.conjunctions.joinToString("|") { Regex.escape(it) }
-    val conjunctionPattern = Regex(" $pattern |, | & ")
+    val words = ArtistConjunctions.conjunctions
+    val conjunctionPattern = Regex(
+        if (words.isNotEmpty()) " (${words.joinToString("|") { Regex.escape(it) }}) |, | & "
+        else ", | & "
+    )
     forEach { run ->
         val text = run.text
         if (text.contains(conjunctionPattern)) {

--- a/innertube/src/main/kotlin/com/metrolist/innertube/models/Runs.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/models/Runs.kt
@@ -28,18 +28,13 @@ fun List<Run>.splitBySeparator(): List<List<Run>> {
     return res
 }
 
-/**
- * Splits artist runs by conjunction separators (&, ,) to properly handle
- * cases where multiple artists are displayed as "Artist1 & Artist2" or "Artist1, Artist2"
- */
 fun List<Run>.splitArtistsByConjunction(): List<Run> {
     val result = mutableListOf<Run>()
     forEach { run ->
         val text = run.text
-        // Check if this run contains conjunction patterns
-        if (text.contains(" & ") || text.contains(", ")) {
-            // Split by both patterns and preserve navigationEndpoint if present
-            val parts = text.split(Regex(" & |, "))
+        val conjunctionPattern = Regex(" & |, | \\band\\b| \\be\\b| \\by\\b| \\bet\\b| \\und\\b| \\bи\\b| \\bと\\b| \\b와\\b")
+        if (text.contains(conjunctionPattern)) {
+            val parts = text.split(conjunctionPattern)
             parts.forEachIndexed { index, part ->
                 if (part.isNotBlank()) {
                     result.add(Run(part.trim(), if (index == 0) run.navigationEndpoint else null))

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/ArtistItemsPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/ArtistItemsPage.kt
@@ -19,7 +19,6 @@ data class ArtistItemsPage(
 ) {
     companion object {
         fun fromMusicResponsiveListItemRenderer(renderer: MusicResponsiveListItemRenderer): SongItem? {
-            // Split the secondary line by bullet separator to separate artists from other metadata (like views)
             val artistRuns = renderer.flexColumns
                 .getOrNull(1)
                 ?.musicResponsiveListItemFlexColumnRenderer
@@ -92,9 +91,7 @@ data class ArtistItemsPage(
                 // Video
                 renderer.isSong -> {
                     val subtitleRuns = renderer.subtitle?.runs ?: return null
-                    // Split any runs that contain conjunctions (&, ,) to properly extract individual artists
                     val expandedRuns = subtitleRuns.splitArtistsByConjunction()
-                    // Filter out separator runs (like "&", ",") to get only artist runs
                     val artistRuns = expandedRuns.filter { 
                         it.text.isNotBlank() && it.text != "&" && it.text != "," 
                     }
@@ -110,9 +107,7 @@ data class ArtistItemsPage(
                                 id = it.navigationEndpoint?.browseEndpoint?.browseId
                             )
                         }.ifEmpty {
-                            artistRuns.firstOrNull()?.let { 
-                                listOf(Artist(name = it.text.trim(), id = null)) 
-                            } ?: emptyList()
+                            artistRuns.map { Artist(name = it.text.trim(), id = null) }
                         },
                         album = null,
                         duration = null,

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/ArtistItemsPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/ArtistItemsPage.kt
@@ -9,6 +9,7 @@ import com.metrolist.innertube.models.PlaylistItem
 import com.metrolist.innertube.models.SongItem
 import com.metrolist.innertube.models.YTItem
 import com.metrolist.innertube.models.oddElements
+import com.metrolist.innertube.models.splitArtistsByConjunction
 import com.metrolist.innertube.models.splitBySeparator
 import com.metrolist.innertube.utils.parseTime
 
@@ -20,20 +21,21 @@ data class ArtistItemsPage(
     companion object {
         fun fromMusicResponsiveListItemRenderer(renderer: MusicResponsiveListItemRenderer): SongItem? {
             // Split the secondary line by bullet separator to separate artists from other metadata (like views)
-            val secondaryLineRuns = renderer.flexColumns
+            val artistRuns = renderer.flexColumns
                 .getOrNull(1)
                 ?.musicResponsiveListItemFlexColumnRenderer
                 ?.text
                 ?.runs
                 ?.splitBySeparator()
-
-            // Extract artists from the first segment after splitting
-            val artists = secondaryLineRuns?.firstOrNull()?.oddElements()?.map {
-                Artist(
-                    name = it.text,
-                    id = it.navigationEndpoint?.browseEndpoint?.browseId
-                )
-            }
+                ?.getOrNull(0)
+                ?.splitArtistsByConjunction()
+                ?.filter { it.text.isNotBlank() && it.text != "&" && it.text != "," }
+                ?.map { run ->
+                    Artist(
+                        name = run.text.trim(),
+                        id = run.navigationEndpoint?.browseEndpoint?.browseId
+                    )
+                }
 
             // Extract album from last flexColumn (like SimpMusic does)
             val album = renderer.flexColumns.lastOrNull()
@@ -55,7 +57,7 @@ data class ArtistItemsPage(
                 title = renderer.flexColumns.firstOrNull()
                     ?.musicResponsiveListItemFlexColumnRenderer?.text
                     ?.runs?.firstOrNull()?.text ?: return null,
-                artists = artists ?: return null,
+                artists = artistRuns ?: return null,
                 album = album,
                 duration = renderer.fixedColumns?.firstOrNull()
                     ?.musicResponsiveListItemFlexColumnRenderer?.text
@@ -89,21 +91,37 @@ data class ArtistItemsPage(
                     } != null
                 )
                 // Video
-                renderer.isSong -> SongItem(
-                    id = renderer.navigationEndpoint.watchEndpoint?.videoId ?: return null,
-                    title = renderer.title.runs?.firstOrNull()?.text ?: return null,
-                    artists = renderer.subtitle?.runs?.splitBySeparator()?.firstOrNull()?.oddElements()?.map {
-                        Artist(
-                            name = it.text,
-                            id = it.navigationEndpoint?.browseEndpoint?.browseId
-                        )
-                    } ?: return null,
-                    album = null,
-                    duration = null,
-                    musicVideoType = renderer.musicVideoType,
-                    thumbnail = renderer.thumbnailRenderer.musicThumbnailRenderer?.getThumbnailUrl() ?: return null,
-                    endpoint = renderer.navigationEndpoint.watchEndpoint
-                )
+                renderer.isSong -> {
+                    val subtitleRuns = renderer.subtitle?.runs ?: return null
+                    // Split any runs that contain conjunctions (&, ,) to properly extract individual artists
+                    val expandedRuns = subtitleRuns.splitArtistsByConjunction()
+                    // Filter out separator runs (like "&", ",") to get only artist runs
+                    val artistRuns = expandedRuns.filter { 
+                        it.text.isNotBlank() && it.text != "&" && it.text != "," 
+                    }
+                    SongItem(
+                        id = renderer.navigationEndpoint.watchEndpoint?.videoId ?: return null,
+                        title = renderer.title.runs?.firstOrNull()?.text ?: return null,
+                        artists = artistRuns.filter { 
+                            it.navigationEndpoint?.browseEndpoint?.browseId?.startsWith("UC") == true ||
+                            it.navigationEndpoint?.browseEndpoint != null
+                        }.map {
+                            Artist(
+                                name = it.text.trim(),
+                                id = it.navigationEndpoint?.browseEndpoint?.browseId
+                            )
+                        }.ifEmpty {
+                            artistRuns.firstOrNull()?.let { 
+                                listOf(Artist(name = it.text.trim(), id = null)) 
+                            } ?: emptyList()
+                        },
+                        album = null,
+                        duration = null,
+                        musicVideoType = renderer.musicVideoType,
+                        thumbnail = renderer.thumbnailRenderer.musicThumbnailRenderer?.getThumbnailUrl() ?: return null,
+                        endpoint = renderer.navigationEndpoint.watchEndpoint
+                    )
+                }
                 renderer.isPlaylist -> PlaylistItem(
                     id = renderer.navigationEndpoint.browseEndpoint?.browseId?.removePrefix("VL") ?: return null,
                     title = renderer.title.runs?.firstOrNull()?.text ?: return null,

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/ArtistItemsPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/ArtistItemsPage.kt
@@ -8,7 +8,6 @@ import com.metrolist.innertube.models.MusicTwoRowItemRenderer
 import com.metrolist.innertube.models.PlaylistItem
 import com.metrolist.innertube.models.SongItem
 import com.metrolist.innertube.models.YTItem
-import com.metrolist.innertube.models.oddElements
 import com.metrolist.innertube.models.splitArtistsByConjunction
 import com.metrolist.innertube.models.splitBySeparator
 import com.metrolist.innertube.utils.parseTime

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/ArtistPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/ArtistPage.kt
@@ -72,7 +72,6 @@ data class ArtistPage(
         }
 
         private fun fromMusicResponsiveListItemRenderer(renderer: MusicResponsiveListItemRenderer): SongItem? {
-            // Split the secondary line by bullet separator to separate artists from other metadata (like views)
             val artistRuns = renderer.flexColumns
                 .getOrNull(1)
                 ?.musicResponsiveListItemFlexColumnRenderer
@@ -89,7 +88,6 @@ data class ArtistPage(
                     )
                 }
 
-            // Extract album from last flexColumn (like SimpMusic)
             val album = renderer.flexColumns.lastOrNull()
                 ?.musicResponsiveListItemFlexColumnRenderer?.text?.runs
                 ?.firstOrNull()?.let {
@@ -101,7 +99,6 @@ data class ArtistPage(
                     } else null
                 }
 
-            // Extract library tokens using the new method that properly handles multiple toggle items
             val libraryTokens = PageHelper.extractLibraryTokensFromMenuItems(renderer.menu?.menuRenderer?.items)
 
             return SongItem(

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/ArtistPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/ArtistPage.kt
@@ -19,7 +19,6 @@ import com.metrolist.innertube.models.WatchEndpoint
 import com.metrolist.innertube.models.YTItem
 import com.metrolist.innertube.models.filterExplicit
 import com.metrolist.innertube.models.getItems
-import com.metrolist.innertube.models.oddElements
 import com.metrolist.innertube.models.splitArtistsByConjunction
 import com.metrolist.innertube.models.splitBySeparator
 

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/ArtistPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/ArtistPage.kt
@@ -124,9 +124,7 @@ data class ArtistPage(
             return when {
                 renderer.isSong -> {
                     val subtitleRuns = renderer.subtitle?.runs ?: return null
-                    // Split any runs that contain conjunctions (&, ,) to properly extract individual artists
                     val expandedRuns = subtitleRuns.splitArtistsByConjunction()
-                    // Filter out separator runs (like "&", ",") to get only artist runs
                     val artistRuns = expandedRuns.filter { 
                         it.text.isNotBlank() && it.text != "&" && it.text != "," 
                     }
@@ -142,9 +140,7 @@ data class ArtistPage(
                                 id = it.navigationEndpoint?.browseEndpoint?.browseId
                             )
                         }.ifEmpty {
-                            artistRuns.firstOrNull()?.let { 
-                                listOf(Artist(name = it.text.trim(), id = null)) 
-                            } ?: emptyList()
+                            artistRuns.map { Artist(name = it.text.trim(), id = null) }
                         },
                         album = null,
                         duration = null,

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/ArtistPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/ArtistPage.kt
@@ -20,6 +20,7 @@ import com.metrolist.innertube.models.YTItem
 import com.metrolist.innertube.models.filterExplicit
 import com.metrolist.innertube.models.getItems
 import com.metrolist.innertube.models.oddElements
+import com.metrolist.innertube.models.splitArtistsByConjunction
 import com.metrolist.innertube.models.splitBySeparator
 
 data class ArtistSection(
@@ -72,20 +73,21 @@ data class ArtistPage(
 
         private fun fromMusicResponsiveListItemRenderer(renderer: MusicResponsiveListItemRenderer): SongItem? {
             // Split the secondary line by bullet separator to separate artists from other metadata (like views)
-            val secondaryLineRuns = renderer.flexColumns
+            val artistRuns = renderer.flexColumns
                 .getOrNull(1)
                 ?.musicResponsiveListItemFlexColumnRenderer
                 ?.text
                 ?.runs
                 ?.splitBySeparator()
-
-            // Extract artists from the first segment after splitting
-            val artists = secondaryLineRuns?.firstOrNull()?.oddElements()?.map {
-                Artist(
-                    name = it.text,
-                    id = it.navigationEndpoint?.browseEndpoint?.browseId
-                )
-            }
+                ?.getOrNull(0)
+                ?.splitArtistsByConjunction()
+                ?.filter { it.text.isNotBlank() && it.text != "&" && it.text != "," }
+                ?.map { run ->
+                    Artist(
+                        name = run.text.trim(),
+                        id = run.navigationEndpoint?.browseEndpoint?.browseId
+                    )
+                }
 
             // Extract album from last flexColumn (like SimpMusic)
             val album = renderer.flexColumns.lastOrNull()
@@ -107,7 +109,7 @@ data class ArtistPage(
                 title = renderer.flexColumns.firstOrNull()
                     ?.musicResponsiveListItemFlexColumnRenderer?.text?.runs?.firstOrNull()
                     ?.text ?: return null,
-                artists = artists ?: return null,
+                artists = artistRuns ?: return null,
                 album = album,
                 duration = null,
                 musicVideoType = renderer.musicVideoType,
@@ -125,21 +127,27 @@ data class ArtistPage(
         private fun fromMusicTwoRowItemRenderer(renderer: MusicTwoRowItemRenderer): YTItem? {
             return when {
                 renderer.isSong -> {
-                    val subtitleRuns = renderer.subtitle?.runs?.oddElements() ?: return null
+                    val subtitleRuns = renderer.subtitle?.runs ?: return null
+                    // Split any runs that contain conjunctions (&, ,) to properly extract individual artists
+                    val expandedRuns = subtitleRuns.splitArtistsByConjunction()
+                    // Filter out separator runs (like "&", ",") to get only artist runs
+                    val artistRuns = expandedRuns.filter { 
+                        it.text.isNotBlank() && it.text != "&" && it.text != "," 
+                    }
                     SongItem(
                         id = renderer.navigationEndpoint.watchEndpoint?.videoId ?: return null,
                         title = renderer.title.runs?.firstOrNull()?.text ?: return null,
-                        artists = subtitleRuns.filter { 
+                        artists = artistRuns.filter { 
                             it.navigationEndpoint?.browseEndpoint?.browseId?.startsWith("UC") == true ||
                             it.navigationEndpoint?.browseEndpoint != null
                         }.map {
                             Artist(
-                                name = it.text,
+                                name = it.text.trim(),
                                 id = it.navigationEndpoint?.browseEndpoint?.browseId
                             )
                         }.ifEmpty {
-                            subtitleRuns.firstOrNull()?.let { 
-                                listOf(Artist(name = it.text, id = null)) 
+                            artistRuns.firstOrNull()?.let { 
+                                listOf(Artist(name = it.text.trim(), id = null)) 
                             } ?: emptyList()
                         },
                         album = null,

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/SearchSuggestionPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/SearchSuggestionPage.kt
@@ -12,6 +12,7 @@ import com.metrolist.innertube.models.SongItem
 import com.metrolist.innertube.models.YTItem
 import com.metrolist.innertube.models.clean
 import com.metrolist.innertube.models.oddElements
+import com.metrolist.innertube.models.splitArtistsByConjunction
 import com.metrolist.innertube.models.splitBySeparator
 import com.metrolist.innertube.utils.parseTime
 
@@ -159,6 +160,11 @@ object SearchSuggestionPage {
                         ?.runs
                         ?.splitBySeparator()
                         ?.clean()
+                // Split artist runs by conjunction to handle "Artist1 & Artist2" cases
+                val artistRuns = secondaryLine
+                    ?.firstOrNull()
+                    ?.splitArtistsByConjunction()
+                    ?.filter { it.text.isNotBlank() && it.text != "&" && it.text != "," }
                 SongItem(
                     id = renderer.playlistItemData?.videoId ?: return null,
                     title =
@@ -170,15 +176,12 @@ object SearchSuggestionPage {
                             ?.firstOrNull()
                             ?.text ?: return null,
                     artists =
-                        secondaryLine
-                            ?.firstOrNull()
-                            ?.oddElements()
-                            ?.map {
-                                Artist(
-                                    name = it.text,
-                                    id = it.navigationEndpoint?.browseEndpoint?.browseId,
-                                )
-                            } ?: return null,
+                        artistRuns?.map { run ->
+                            Artist(
+                                name = run.text.trim(),
+                                id = run.navigationEndpoint?.browseEndpoint?.browseId,
+                            )
+                        } ?: return null,
                     album =
                         renderer.flexColumns
                             .getOrNull(

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/SearchSummaryPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/SearchSummaryPage.kt
@@ -19,6 +19,7 @@ import com.metrolist.innertube.models.filterExplicit
 import com.metrolist.innertube.models.filterVideoSongs
 import com.metrolist.innertube.models.filterYoutubeShorts
 import com.metrolist.innertube.models.oddElements
+import com.metrolist.innertube.models.splitArtistsByConjunction
 import com.metrolist.innertube.models.splitBySeparator
 import com.metrolist.innertube.utils.parseTime
 
@@ -324,6 +325,10 @@ data class SearchSummaryPage(
                             ?: emptyList()
                     val listRun = (secondaryLine + thirdLine).clean()
 
+                    // Split artist runs by conjunction to handle "Artist1 & Artist2" cases
+                    val artistRuns = listRun.getOrNull(0)?.splitArtistsByConjunction()
+                        ?.filter { it.text.isNotBlank() && it.text != "&" && it.text != "," }
+
                     SongItem(
                         id = renderer.playlistItemData?.videoId ?: return null,
                         title =
@@ -334,10 +339,10 @@ data class SearchSummaryPage(
                                 ?.runs
                                 ?.firstOrNull()
                                 ?.text ?: return null,
-                        artists = listRun.getOrNull(0)?.oddElements()?.map {
+                        artists = artistRuns?.map { run ->
                             Artist(
-                                name = it.text,
-                                id = it.navigationEndpoint?.browseEndpoint?.browseId
+                                name = run.text.trim(),
+                                id = run.navigationEndpoint?.browseEndpoint?.browseId
                             )
                         } ?: return null,
                         album = listRun.getOrNull(1)?.firstOrNull()?.takeIf { it.navigationEndpoint?.browseEndpoint != null }?.let {


### PR DESCRIPTION
## Problem

Songs appear under wrong artist pages because the YouTube Music API returns multiple artists joined by conjunctions (e.g., "Artist1 & Artist2", "Artist1 y Artist2", "Artist1 e Artist2") as a single run. The app was treating these as a single artist, causing songs to appear only under one artist instead of all relevant ones.

## Cause

The artist parsing logic in `ArtistPage.kt`, `ArtistItemsPage.kt`, `SearchSummaryPage.kt`, and `SearchSuggestionPage.kt` did not split artist runs by conjunction patterns. When artists like "ditonellapiaga e tonypitony" were returned, the app created one artist "ditonellapiaga e tonypitony" instead of two separate artists.

## Solution

- **`Runs.kt`** — Added `splitArtistsByConjunction()` that splits runs on localized conjunction words (space-padded) and ` & `. Comma (`,`) is NOT used as separator to avoid breaking names like "Tyler, The Creator". NavigationEndpoint is shared to all split parts so no artist loses its ID. Updated `clean()` to retain groups with localized conjunction patterns.
- **`Runs.kt`** — `ArtistConjunctions` singleton holds configurable word list, defaulting to `listOf("and")`.
- **`App.kt`** — Loads conjunctions from `metrolist_strings.xml` via locale-aware resources. The default file keeps only `"and"`; localized conjunctions (`e`, `y`, `et`, `und`, etc.) are added in their respective language files.
- **Page parsers** — Applied `splitArtistsByConjunction()` in `ArtistPage.kt`, `ArtistItemsPage.kt`, `SearchSummaryPage.kt`, `SearchSuggestionPage.kt`. Two-row fallback now preserves **all** split artists with null IDs instead of collapsing to `firstOrNull()`.
- **`YouTube.kt`** — Added `resolveArtistIds()` that searches for missing artist IDs and assigns them only on exact name match.

## Key fixes

1. `, ` removed from separator pattern — prevents splitting "Tyler, The Creator"
2. `navigationEndpoint` shared to all split parts — no null IDs after split
3. `clean()` checks ALL runs in first group (not just first) — localized conjunctions not dropped
4. Two-row fallback uses `artistRuns.map` instead of `firstOrNull()` — no artist lost
5. `resolveArtistIds` uses exact name match — prevents wrong artist IDs
6. Default `metrolist_strings.xml` keeps only `"and"` — other conjunctions go in locale files

## Testing

- Builds successfully with `./gradlew :app:assembleFossDebug`
- innertube module compiles with `./gradlew :innertube:compileDebugKotlin`
- Need manual testing on device with various conjunction patterns