### PR TITLE
fix(innertube): handle musicShelfRenderer and musicShelfContinuation in playlistContinuation

### DIFF
--- a/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
@@ -1066,12 +1066,18 @@ object YouTube {
                 response.continuationContents
                     ?.sectionListContinuation
                     ?.contents
-                    ?.mapNotNull { content: SectionListRenderer.Content -> content.musicPlaylistShelfRenderer?.contents }
+                    ?.mapNotNull { content: SectionListRenderer.Content ->
+                        content.musicPlaylistShelfRenderer?.contents
+                            ?: content.musicShelfRenderer?.contents
+                    }
                     ?.flatten()
                     ?: emptyList()
 
             val shelfContents: List<MusicShelfRenderer.Content> =
                 response.continuationContents?.musicPlaylistShelfContinuation?.contents ?: emptyList()
+
+            val musicShelfContinuationContents: List<MusicShelfRenderer.Content> =
+                response.continuationContents?.musicShelfContinuation?.contents ?: emptyList()
 
             val appendedContents: List<MusicShelfRenderer.Content> =
                 response.onResponseReceivedActions
@@ -1080,7 +1086,7 @@ object YouTube {
                     ?.continuationItems
                     .orEmpty()
 
-            val allContents = mainContents + shelfContents + appendedContents
+            val allContents = mainContents + shelfContents + musicShelfContinuationContents + appendedContents
 
             val songs =
                 allContents


### PR DESCRIPTION
## Problem

Playlists with more than 100 songs do not display all songs — only the initial batch (~100) is shown when viewing the playlist online or after sync. The song count on the homepage shows the correct total, but scrolling only reveals 100 songs.

## Cause

The `playlistContinuation()` function in `YouTube.kt` was not extracting songs from two response formats that YouTube Music API can return for paginated continuation requests:

1. **`musicShelfRenderer` inside `sectionListContinuation.contents`** — only `musicPlaylistShelfRenderer` was checked
2. **`continuationContents.musicShelfContinuation.contents`** — was completely ignored

When the API returned continuation songs in these formats, `playlistContinuation()` returned an empty `songs` list, causing the pagination loop (`completed()` / `startProactiveBackgroundLoading()`) to terminate immediately with `nextContinuation = null`. Only the first batch of ~100 songs from the initial `YouTube.playlist()` call were ever loaded.

## Solution

- Added fallback to `content.musicShelfRenderer?.contents` when extracting songs from `sectionListContinuation.contents`
- Added new extraction from `continuationContents?.musicShelfContinuation?.contents`
- Added `musicShelfContinuationContents` to the combined `allContents` list

All three song sources (`mainContents`, `shelfContents`, `musicShelfContinuationContents`, `appendedContents`) are now checked, ensuring continuation responses are parsed correctly regardless of the format YouTube Music API uses.

## Testing

- Build verified with `./gradlew :app:assembleFossDebug` — BUILD SUCCESSFUL
- The fix follows existing patterns and is entirely null-safe

## Related Issues

- Closes #1845
- Related to #2909

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playlist content handling to ensure all items are properly retrieved and displayed across different playlist configurations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MetrolistGroup/Metrolist/pull/3715)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->