### PR TITLE
fix(db): prevent auto-deletion of favorited albums on YouTube fetch failure

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
@@ -856,12 +856,14 @@ class SyncUtils @Inject constructor(
                     val remoteIds = remoteAlbums.map { it.id }.toSet()
                     val localAlbums = database.albumsLikedByNameAsc().first()
 
-                    localAlbums.filterNot { it.id in remoteIds }.forEach { album ->
-                        try {
-                            database.update(album.album.localToggleLike())
-                            delay(DB_OPERATION_DELAY_MS)
-                        } catch (e: Exception) {
-                            Timber.e(e, "Failed to update album: ${album.id}")
+                    if (remoteIds.isNotEmpty()) {
+                        localAlbums.filterNot { it.id in remoteIds }.forEach { album ->
+                            try {
+                                database.update(album.album.localToggleLike())
+                                delay(DB_OPERATION_DELAY_MS)
+                            } catch (e: Exception) {
+                                Timber.e(e, "Failed to update album: ${album.id}")
+                            }
                         }
                     }
 

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/LibraryViewModels.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/LibraryViewModels.kt
@@ -257,11 +257,6 @@ constructor(
                                 }
                             }.onFailure {
                                 reportException(it)
-                                if (it.message?.contains("NOT_FOUND") == true) {
-                                    database.query {
-                                        delete(album.album)
-                                    }
-                                }
                             }
                     }
             }
@@ -427,11 +422,6 @@ constructor(
                                 }
                             }.onFailure {
                                 reportException(it)
-                                if (it.message?.contains("NOT_FOUND") == true) {
-                                    database.query {
-                                        delete(album.album)
-                                    }
-                                }
                             }
                     }
             }


### PR DESCRIPTION
## Problem
Favorited albums can permanently disappear from the Library. The album list shows empty while artists and songs are unaffected. Re-adding albums from YouTube creates new entries, but the original album data (play history, etc.) is permanently lost.

## Cause
Two structural bugs work together to cause data loss:

1. **Auto-deletion on fetch failure** — Both `LibraryAlbumsViewModel` and `LibraryMixViewModel` have `init` blocks that iterate albums with `songCount == 0` and call `YouTube.album()`. If the API returns `NOT_FOUND`, the album entity is **permanently deleted** from the database via `database.query { delete(album.album) }`. Albums with `songCount == 0` (incomplete sync data) trigger this code path every time the ViewModel is created.

2. **Sync wipes local favorites on empty remote response** — `executeSyncLikedAlbums()` in `SyncUtils.kt` unconditionally un-favorites (`bookmarkedAt = null`) every locally liked album not present in the YouTube API response. If the `FEmusic_liked_albums` endpoint returns an empty list (due to API changes, rate limiting, or transient errors), **all** locally favorited albums are silently un-favorited.

## Solution
### 1. LibraryViewModels.kt — Remove destructive auto-deletion
Removed the `onFailure { if (NOT_FOUND) delete(album) }` branch in both `LibraryAlbumsViewModel` and `LibraryMixViewModel`. On fetch failure, only the exception is reported; the album entity is never deleted.

### 2. SyncUtils.kt — Guard against empty sync responses
Added `if (remoteIds.isNotEmpty())` guard around the un-favorite loop. If the YouTube API returns an empty liked-albums list, local favorites are left intact instead of being wiped.

## Testing
- Build: `./gradlew :app:assembleFossDebug` — success
- No new code paths introduced; only destructive or overly-aggressive paths removed or guarded
- Changes are strictly behavioral improvements with zero regression risk in normal operation

## Related Issues
- Closes #2463
- Related to #2909

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a potential issue where all liked albums could be unintentionally removed during album library sync in certain scenarios
* Improved error handling for album operations—the app no longer automatically removes albums from your library when certain sync-related errors occur

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MetrolistGroup/Metrolist/pull/3732)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->