### PR TITLE
feat(widget): implement playlists home screen widget

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -288,6 +288,21 @@
                 android:resource="@xml/music_widget_info" />
         </receiver>
 
+
+        <!-- Playlist Widget -->
+        <receiver
+            android:name=".widget.PlaylistWidgetReceiver"
+            android:exported="true"
+            android:label="@string/widget_playlists">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/playlist_widget_info" />
+        </receiver>
+
         <!-- Turntable Widget -->
         <receiver
             android:name=".widget.TurntableWidgetReceiver"

--- a/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
@@ -194,6 +194,7 @@ import com.metrolist.music.utils.rememberPreference
 import com.metrolist.music.utils.reportException
 import com.metrolist.music.utils.setAppLocale
 import com.metrolist.music.viewmodels.HomeViewModel
+import com.metrolist.music.widget.PlaylistWidgetReceiver
 import com.valentinilk.shimmer.LocalShimmerTheme
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
@@ -217,7 +218,10 @@ class MainActivity : ComponentActivity() {
         private const val ACTION_SEARCH = "com.metrolist.music.action.SEARCH"
         private const val ACTION_LIBRARY = "com.metrolist.music.action.LIBRARY"
         const val ACTION_RECOGNITION = "com.metrolist.music.action.RECOGNITION"
+        const val ACTION_OPEN_WIDGET_TARGET = "com.metrolist.music.action.OPEN_WIDGET_TARGET"
         const val EXTRA_AUTO_START_RECOGNITION = "auto_start_recognition"
+        const val EXTRA_WIDGET_TARGET_TYPE = "widget_target_type"
+        const val EXTRA_WIDGET_TARGET_ID = "widget_target_id"
     }
 
     @Inject
@@ -368,6 +372,7 @@ class MainActivity : ComponentActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         if (::navController.isInitialized) {
+            handleWidgetTargetIntent(intent, navController)
             handleDeepLinkIntent(intent, navController)
         } else {
             pendingIntent = intent
@@ -884,10 +889,12 @@ class MainActivity : ComponentActivity() {
 
                 LaunchedEffect(Unit) {
                     if (pendingIntent != null) {
+                        handleWidgetTargetIntent(pendingIntent!!, navController)
                         handleRecognitionIntent(pendingIntent!!, navController)
                         handleDeepLinkIntent(pendingIntent!!, navController)
                         pendingIntent = null
                     } else {
+                        handleWidgetTargetIntent(intent, navController)
                         handleRecognitionIntent(intent, navController)
                         handleDeepLinkIntent(intent, navController)
                     }
@@ -896,6 +903,7 @@ class MainActivity : ComponentActivity() {
                 DisposableEffect(Unit) {
                     val listener =
                         Consumer<Intent> { intent ->
+                            handleWidgetTargetIntent(intent, navController)
                             handleRecognitionIntent(intent, navController)
                             handleDeepLinkIntent(intent, navController)
                         }
@@ -1381,6 +1389,50 @@ class MainActivity : ComponentActivity() {
         navController.navigate(if (autoStart) "recognition?autoStart=true" else "recognition") {
             launchSingleTop = true
         }
+    }
+
+    private sealed class WidgetTargetRoute(val route: String) {
+        data class LocalPlaylist(val id: String) : WidgetTargetRoute("local_playlist/$id")
+        data class OnlinePlaylist(val id: String) : WidgetTargetRoute("online_playlist/$id")
+        data object LikedSongs : WidgetTargetRoute("auto_playlist/liked")
+        data object DownloadedSongs : WidgetTargetRoute("auto_playlist/downloaded")
+        data class TopSongs(val limit: String) : WidgetTargetRoute("top_playlist/$limit")
+    }
+
+    private fun handleWidgetTargetIntent(
+        intent: Intent,
+        navController: NavHostController,
+    ) {
+        if (intent.action != ACTION_OPEN_WIDGET_TARGET) return
+
+        val targetType = intent.getStringExtra(EXTRA_WIDGET_TARGET_TYPE)
+        val targetId = intent.getStringExtra(EXTRA_WIDGET_TARGET_ID)
+        intent.action = null
+        intent.removeExtra(EXTRA_WIDGET_TARGET_TYPE)
+        intent.removeExtra(EXTRA_WIDGET_TARGET_ID)
+
+        val normalizedTargetId = targetId?.takeIf { it.isNotBlank() }
+
+        val targetRoute = when (targetType) {
+            PlaylistWidgetReceiver.TARGET_TYPE_LOCAL ->
+                normalizedTargetId?.let { WidgetTargetRoute.LocalPlaylist(it) }
+
+            PlaylistWidgetReceiver.TARGET_TYPE_ONLINE ->
+                normalizedTargetId?.let { WidgetTargetRoute.OnlinePlaylist(it) }
+
+            PlaylistWidgetReceiver.TARGET_TYPE_LIKED ->
+                WidgetTargetRoute.LikedSongs
+
+            PlaylistWidgetReceiver.TARGET_TYPE_DOWNLOADED ->
+                WidgetTargetRoute.DownloadedSongs
+
+            PlaylistWidgetReceiver.TARGET_TYPE_TOP ->
+                WidgetTargetRoute.TopSongs(normalizedTargetId ?: "50")
+
+            else -> null
+        } ?: return
+
+        navController.navigate(targetRoute.route)
     }
 
     private fun handleDeepLinkIntent(

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -179,6 +179,7 @@ import com.metrolist.music.playback.queues.EmptyQueue
 import com.metrolist.music.playback.queues.ListQueue
 import com.metrolist.music.playback.queues.Queue
 import com.metrolist.music.playback.queues.YouTubeQueue
+import com.metrolist.music.playback.queues.YouTubePlaylistQueue
 import com.metrolist.music.playback.queues.filterExplicit
 import com.metrolist.music.playback.queues.filterVideoSongs
 import com.metrolist.music.constants.LoudnessLevel
@@ -194,6 +195,7 @@ import com.metrolist.music.utils.get
 import com.metrolist.music.utils.reportException
 import com.metrolist.music.widget.MetrolistWidgetManager
 import com.metrolist.music.widget.MusicWidgetReceiver
+import com.metrolist.music.widget.PlaylistWidgetReceiver
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CancellationException
 import kotlin.coroutines.coroutineContext
@@ -3707,12 +3709,124 @@ class MusicService :
                 updateWidgetUI(player.isPlaying)
             }
 
-            MusicWidgetReceiver.ACTION_UPDATE_WIDGET -> {
+            MusicWidgetReceiver.ACTION_UPDATE_WIDGET,
+            PlaylistWidgetReceiver.ACTION_UPDATE_WIDGET -> {
                 updateWidgetUI(player.isPlaying)
+            }
+
+            PlaylistWidgetReceiver.ACTION_PLAY_TARGET -> {
+                handlePlaylistWidgetPlay(intent)
             }
         }
 
         return super.onStartCommand(intent, flags, startId)
+    }
+
+
+    private fun handlePlaylistWidgetPlay(intent: Intent) {
+        scope.launch {
+            try {
+                val queue = withContext(Dispatchers.IO) {
+                    buildPlaylistWidgetQueue(intent)
+                }
+                // Fall back to opening the target in app when it cannot be played directly
+                if (queue == null) {
+                    openPlaylistWidgetTarget(intent)
+                    return@launch
+                }
+                playQueue(queue, playWhenReady = true)
+                updateWidgetUI(true)
+            } catch (t: Throwable) {
+                Timber.tag(TAG).e(t, "Failed to start playlist widget target")
+                openPlaylistWidgetTarget(intent)
+            }
+        }
+    }
+
+    private fun openPlaylistWidgetTarget(source: Intent) {
+        val activityIntent = Intent(this, MainActivity::class.java).apply {
+            action = MainActivity.ACTION_OPEN_WIDGET_TARGET
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
+            putExtra(
+                MainActivity.EXTRA_WIDGET_TARGET_TYPE,
+                source.getStringExtra(PlaylistWidgetReceiver.EXTRA_TARGET_TYPE),
+            )
+            putExtra(
+                MainActivity.EXTRA_WIDGET_TARGET_ID,
+                source.getStringExtra(PlaylistWidgetReceiver.EXTRA_TARGET_ID),
+            )
+        }
+        try {
+            startActivity(activityIntent)
+        } catch (t: Throwable) {
+            Timber.tag(TAG).e(t, "Failed to open playlist widget target")
+        }
+    }
+
+    private suspend fun buildPlaylistWidgetQueue(intent: Intent): Queue? {
+        val targetType = intent.getStringExtra(PlaylistWidgetReceiver.EXTRA_TARGET_TYPE) ?: return null
+        val targetId = intent.getStringExtra(PlaylistWidgetReceiver.EXTRA_TARGET_ID).orEmpty()
+        val targetTitle = intent.getStringExtra(PlaylistWidgetReceiver.EXTRA_TARGET_TITLE)
+
+        return when (targetType) {
+            PlaylistWidgetReceiver.TARGET_TYPE_LOCAL -> {
+                if (targetId.isBlank()) return null
+                val songs = database.playlistSongs(targetId).first()
+                if (songs.isEmpty()) return null
+                val playlistName = database.playlist(targetId).first()?.playlist?.name ?: targetTitle
+                ListQueue(
+                    title = playlistName,
+                    items = songs.map { it.song.toMediaItem() },
+                )
+            }
+
+            PlaylistWidgetReceiver.TARGET_TYPE_ONLINE -> {
+                if (targetId.isBlank()) return null
+                val cachedPlaylist = database.playlistByBrowseId(targetId).first()
+                val cachedSongs = cachedPlaylist?.let { database.playlistSongs(it.playlist.id).first() }.orEmpty()
+                if (cachedSongs.isNotEmpty()) {
+                    ListQueue(
+                        title = cachedPlaylist?.playlist?.name ?: targetTitle,
+                        items = cachedSongs.map { it.song.toMediaItem() },
+                    )
+                } else {
+                    YouTubePlaylistQueue(
+                        playlistId = targetId,
+                        playlistTitle = targetTitle,
+                    )
+                }
+            }
+
+            PlaylistWidgetReceiver.TARGET_TYPE_LIKED -> {
+                val songs = database.likedSongsByCreateDateAsc().first()
+                if (songs.isEmpty()) return null
+                ListQueue(
+                    title = getString(R.string.liked_songs),
+                    items = songs.map { it.toMediaItem() },
+                )
+            }
+
+            PlaylistWidgetReceiver.TARGET_TYPE_DOWNLOADED -> {
+                val songs = database.downloadedSongsByCreateDateAsc().first()
+                if (songs.isEmpty()) return null
+                ListQueue(
+                    title = getString(R.string.downloaded_songs),
+                    items = songs.map { it.toMediaItem() },
+                )
+            }
+
+            PlaylistWidgetReceiver.TARGET_TYPE_TOP -> {
+                val limit = targetId.toIntOrNull() ?: 50
+                val songs = database.mostPlayedSongs(0L, limit = limit).first()
+                if (songs.isEmpty()) return null
+                ListQueue(
+                    title = getString(R.string.my_top),
+                    items = songs.map { it.toMediaItem() },
+                )
+            }
+
+            else -> null
+        }
     }
 
     private fun handleAlarmTrigger(intent: Intent) {

--- a/app/src/main/kotlin/com/metrolist/music/widget/MetrolistWidgetManager.kt
+++ b/app/src/main/kotlin/com/metrolist/music/widget/MetrolistWidgetManager.kt
@@ -35,7 +35,8 @@ import javax.inject.Singleton
 @Singleton
 class MetrolistWidgetManager @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val database: MusicDatabase
+    private val database: MusicDatabase,
+    private val playlistWidgetManager: PlaylistWidgetManager,
 ) {
     private val imageLoader by lazy {
         ImageLoader.Builder(context)
@@ -108,6 +109,16 @@ class MetrolistWidgetManager @Inject constructor(
                 appWidgetManager.updateAppWidget(widgetId, turntableViews)
             }
         }
+
+        playlistWidgetManager.updateWidgets(
+            title = title,
+            artist = artist,
+            artworkUri = artworkUri,
+            isPlaying = isPlaying,
+            isLiked = isLiked,
+            duration = duration,
+            currentPosition = currentPosition,
+        )
     }
 
     private fun createRemoteViewsForSize(

--- a/app/src/main/kotlin/com/metrolist/music/widget/PlaylistWidgetManager.kt
+++ b/app/src/main/kotlin/com/metrolist/music/widget/PlaylistWidgetManager.kt
@@ -1,0 +1,733 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.widget
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.BitmapShader
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.RectF
+import android.graphics.Shader
+import android.os.Bundle
+import android.view.View
+import android.widget.RemoteViews
+import coil3.imageLoader
+import coil3.request.ImageRequest
+import coil3.request.allowHardware
+import coil3.request.crossfade
+import coil3.toBitmap
+import com.metrolist.music.MainActivity
+import com.metrolist.music.R
+import com.metrolist.music.db.MusicDatabase
+import com.metrolist.music.db.entities.Playlist
+import com.metrolist.music.di.ApplicationScope
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.debounce
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class PlaylistWidgetManager @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val database: MusicDatabase,
+    @ApplicationScope private val applicationScope: CoroutineScope,
+) {
+    private val imageLoader
+        get() = context.imageLoader
+    @Volatile
+    private var cachedArtworkUri: String? = null
+    @Volatile
+    private var cachedAlbumArt: Bitmap? = null
+    @Volatile
+    private var cachedRoundedAlbumArt: Bitmap? = null
+    @Volatile
+    private var cachedRoundedSource: Bitmap? = null
+    private val fallbackArtworkCache = ConcurrentHashMap<FallbackArtworkKey, Bitmap>()
+    private val roundedAppIconCache = ConcurrentHashMap<Int, Bitmap>()
+
+    @Volatile
+    private var lastWidgetState = WidgetState(
+        title = context.getString(R.string.not_playing),
+        artist = context.getString(R.string.choose_something_below),
+        artworkUri = null,
+        isPlaying = false,
+        isLiked = false,
+        duration = 0,
+        currentPosition = 0,
+    )
+
+    init {
+        observeQuickPickChanges()
+    }
+
+    suspend fun updateIdleWidgets() {
+        updateWidgets(
+            title = context.getString(R.string.not_playing),
+            artist = context.getString(R.string.choose_something_below),
+            artworkUri = null,
+            isPlaying = false,
+            isLiked = false,
+            duration = 0,
+            currentPosition = 0,
+        )
+    }
+
+    suspend fun updateIdleWidget(
+        appWidgetId: Int,
+        options: Bundle,
+    ) {
+        val appWidgetManager = AppWidgetManager.getInstance(context)
+        val state = lastWidgetState
+        val albumArt = getCachedAlbumArt(state.artworkUri)
+        val quickPicks = buildQuickPicks()
+        val views = createRemoteViews(
+            options = options,
+            title = state.title,
+            artist = state.artist,
+            albumArt = albumArt,
+            isPlaying = state.isPlaying,
+            isLiked = state.isLiked,
+            duration = state.duration,
+            currentPosition = state.currentPosition,
+            quickPicks = quickPicks,
+        )
+        appWidgetManager.updateAppWidget(appWidgetId, views)
+    }
+
+    private suspend fun refreshWidgetsFromLastState() {
+        val state = lastWidgetState
+        updateWidgets(
+            title = state.title,
+            artist = state.artist,
+            artworkUri = state.artworkUri,
+            isPlaying = state.isPlaying,
+            isLiked = state.isLiked,
+            duration = state.duration,
+            currentPosition = state.currentPosition,
+        )
+    }
+
+    suspend fun updateWidgets(
+        title: String,
+        artist: String,
+        artworkUri: String?,
+        isPlaying: Boolean,
+        isLiked: Boolean,
+        duration: Long = 0,
+        currentPosition: Long = 0,
+    ) {
+        lastWidgetState = WidgetState(
+            title = title,
+            artist = artist,
+            artworkUri = artworkUri,
+            isPlaying = isPlaying,
+            isLiked = isLiked,
+            duration = duration,
+            currentPosition = currentPosition,
+        )
+
+        val appWidgetManager = AppWidgetManager.getInstance(context)
+        val componentName = ComponentName(context, PlaylistWidgetReceiver::class.java)
+        val widgetIds = appWidgetManager.getAppWidgetIds(componentName)
+        if (widgetIds.isEmpty()) return
+
+        val albumArt = getCachedAlbumArt(artworkUri)
+        val quickPicks = buildQuickPicks()
+
+        widgetIds.forEach { widgetId ->
+            val options = appWidgetManager.getAppWidgetOptions(widgetId)
+            val views = createRemoteViews(
+                options = options,
+                title = title,
+                artist = artist,
+                albumArt = albumArt,
+                isPlaying = isPlaying,
+                isLiked = isLiked,
+                duration = duration,
+                currentPosition = currentPosition,
+                quickPicks = quickPicks,
+            )
+            appWidgetManager.updateAppWidget(widgetId, views)
+        }
+    }
+
+    @OptIn(FlowPreview::class)
+    private fun observeQuickPickChanges() {
+        combine(
+            database.speedDialDao.getAll().map { items ->
+                items.map { item ->
+                    SpeedDialSnapshot(
+                        type = item.type,
+                        id = item.id,
+                        title = item.title,
+                        thumbnailUrl = item.thumbnailUrl,
+                    )
+                }
+            },
+            database.playlistsByCreateDateAsc().map { playlists ->
+                playlists.map { playlist ->
+                    PlaylistSnapshot(
+                        id = playlist.playlist.id,
+                        browseId = playlist.playlist.browseId,
+                        name = playlist.playlist.name,
+                        thumbnailUrl = playlist.thumbnails.firstOrNull(),
+                        isLocal = playlist.playlist.isLocal,
+                    )
+                }
+            },
+            database.likedSongsByCreateDateAsc().map { songs ->
+                songs.map { song ->
+                    SongSnapshot(
+                        id = song.id,
+                        thumbnailUrl = song.thumbnailUrl,
+                    )
+                }
+            },
+            database.downloadedSongsByCreateDateAsc().map { songs ->
+                songs.map { song ->
+                    SongSnapshot(
+                        id = song.id,
+                        thumbnailUrl = song.thumbnailUrl,
+                    )
+                }
+            },
+            database.mostPlayedSongs(0L, limit = 50).map { songs ->
+                songs.map { song ->
+                    SongSnapshot(
+                        id = song.id,
+                        thumbnailUrl = song.thumbnailUrl,
+                    )
+                }
+            },
+        ) { speedDial, playlists, likedSongs, downloadedSongs, topSongs ->
+            QuickPickSnapshot(
+                speedDial = speedDial,
+                playlists = playlists,
+                likedSongs = likedSongs,
+                downloadedSongs = downloadedSongs,
+                topSongs = topSongs,
+            )
+        }
+            .distinctUntilChanged()
+            .debounce(500L)
+            .onEach { refreshWidgetsFromLastState() }
+            .launchIn(applicationScope)
+    }
+
+    private suspend fun createRemoteViews(
+        options: Bundle,
+        title: String,
+        artist: String,
+        albumArt: Bitmap?,
+        isPlaying: Boolean,
+        isLiked: Boolean,
+        duration: Long,
+        currentPosition: Long,
+        quickPicks: List<QuickPick>,
+    ): RemoteViews {
+        val views = RemoteViews(context.packageName, R.layout.widget_playlist)
+
+        views.setTextViewText(R.id.widget_playlist_song_title, title)
+        views.setTextViewText(R.id.widget_playlist_artist_name, artist)
+
+        if (albumArt != null) {
+            views.setImageViewBitmap(R.id.widget_playlist_album_art, getRoundedAlbumArt(albumArt))
+        } else {
+            views.setImageViewBitmap(R.id.widget_playlist_album_art, getRoundedAppIcon(36f))
+        }
+
+        val playPauseIcon = if (isPlaying) R.drawable.ic_widget_pause else R.drawable.ic_widget_play
+        views.setImageViewResource(R.id.widget_playlist_play_pause, playPauseIcon)
+        views.setImageViewResource(
+            R.id.widget_playlist_like_button,
+            if (isLiked) R.drawable.ic_widget_heart_nav else R.drawable.ic_widget_heart_outline_nav,
+        )
+
+        val progressLevel = if (duration > 0) {
+            ((currentPosition.toDouble() / duration.toDouble()) * 10000).toInt().coerceIn(0, 10000)
+        } else {
+            0
+        }
+        views.setInt(R.id.widget_playlist_progress_fill, "setImageLevel", progressLevel)
+
+        views.setOnClickPendingIntent(R.id.widget_playlist_album_art, getOpenAppIntent())
+        views.setOnClickPendingIntent(
+            R.id.widget_playlist_prev_container,
+            getMusicWidgetIntent(MusicWidgetReceiver.ACTION_PREVIOUS, 501),
+        )
+        views.setOnClickPendingIntent(
+            R.id.widget_playlist_play_pause_container,
+            getMusicWidgetIntent(MusicWidgetReceiver.ACTION_PLAY_PAUSE, 502),
+        )
+        views.setOnClickPendingIntent(
+            R.id.widget_playlist_next_container,
+            getMusicWidgetIntent(MusicWidgetReceiver.ACTION_NEXT, 503),
+        )
+        views.setOnClickPendingIntent(
+            R.id.widget_playlist_like_button,
+            getMusicWidgetIntent(MusicWidgetReceiver.ACTION_LIKE, 504),
+        )
+
+        bindQuickPicks(views, options, quickPicks)
+        return views
+    }
+
+    private suspend fun bindQuickPicks(
+        views: RemoteViews,
+        options: Bundle,
+        quickPicks: List<QuickPick>,
+    ) {
+        val maxItems = maxQuickPicksForSize(options)
+        val displayCount = balancedDisplayCount(quickPicks.size, maxItems)
+        val visiblePicks = quickPicks.take(displayCount)
+        val visibleSlots = (0 until displayCount).toSet()
+        val reservedEmptySlots = reservedEmptySlotsFor(displayCount)
+
+        views.setViewVisibility(
+            R.id.widget_playlist_quick_picks_section,
+            if (displayCount > 0) View.VISIBLE else View.GONE,
+        )
+        views.setViewVisibility(
+            R.id.widget_playlist_row_2,
+            if (displayCount > 4) View.VISIBLE else View.GONE,
+        )
+
+        cardSlots.forEachIndexed { index, slot ->
+            val visibility = when {
+                index in visibleSlots -> View.VISIBLE
+                index in reservedEmptySlots -> View.INVISIBLE
+                else -> View.GONE
+            }
+            views.setViewVisibility(slot.containerId, visibility)
+        }
+
+        visiblePicks.forEachIndexed { index, item ->
+            val slot = cardSlots[index]
+            views.setTextViewText(slot.titleId, item.title)
+            views.setImageViewResource(slot.playIconId, R.drawable.ic_widget_play_low)
+            views.setImageViewBitmap(
+                slot.artworkId,
+                item.thumbnailUrl
+                    ?.let { loadBitmap(it, 180) }
+                    ?.let { getRoundedCornerBitmap(it, 30f) }
+                    ?: getFallbackArtwork(item, 30f),
+            )
+            views.setOnClickPendingIntent(slot.containerId, getOpenTargetIntent(item))
+            views.setOnClickPendingIntent(slot.playContainerId, getPlayTargetIntent(item))
+        }
+    }
+    // Pick the widget size bucket for the shortcut grid
+    private fun maxQuickPicksForSize(options: Bundle): Int {
+        val minWidth = options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH)
+        val minHeight = options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_HEIGHT)
+
+        return when {
+            minWidth < 210 -> 0
+            minHeight < 330 -> 4
+            minWidth >= 360 -> 8
+            else -> 4
+        }
+    }
+    // The widget intentionally avoids an incomplete second row:
+    // show up to 4 playlists in one row, collapse 5-7 to 4, and only use two rows when 8 are available
+    private fun balancedDisplayCount(available: Int, maxItems: Int): Int {
+        val capped = minOf(available, maxItems, 8)
+        return when {
+            capped >= 8 -> 8
+            capped >= 4 -> 4
+            else -> capped
+        }
+    }
+
+
+    private fun reservedEmptySlotsFor(displayCount: Int): Set<Int> = when (displayCount) {
+        1 -> setOf(1, 2, 3)
+        2 -> setOf(2, 3)
+        3 -> setOf(3)
+        else -> emptySet()
+    }
+
+    private suspend fun buildQuickPicks(): List<QuickPick> = withContext(Dispatchers.IO) {
+        val speedDialItemsDeferred = async { database.speedDialDao.getAll().first() }
+        val savedPlaylistsDeferred = async { database.playlistsByCreateDateAsc().first() }
+        val likedSongsDeferred = async { database.likedSongsByCreateDateAsc().first() }
+        val downloadedSongsDeferred = async { database.downloadedSongsByCreateDateAsc().first() }
+        val topSongsDeferred = async { database.mostPlayedSongs(0L, limit = 50).first() }
+
+        val result = mutableListOf<QuickPick>()
+        val seen = mutableSetOf<String>()
+        val speedDialItems = speedDialItemsDeferred.await()
+        val savedPlaylists = savedPlaylistsDeferred.await()
+        val likedSongs = likedSongsDeferred.await()
+        val downloadedSongs = downloadedSongsDeferred.await()
+        val topSongs = topSongsDeferred.await()
+
+        fun add(item: QuickPick) {
+            if (seen.add(item.key)) result += item
+        }
+
+        speedDialItems
+            .filter { it.type == "PLAYLIST" || it.type == "LOCAL_PLAYLIST" }
+            .forEach { item ->
+                if (item.type == "LOCAL_PLAYLIST") {
+                    add(
+                        QuickPick(
+                            key = "local:${item.id}",
+                            targetType = PlaylistWidgetReceiver.TARGET_TYPE_LOCAL,
+                            targetId = item.id,
+                            title = item.title,
+                            thumbnailUrl = item.thumbnailUrl,
+                            fallbackIconRes = R.drawable.playlist_play,
+                        ),
+                    )
+                } else {
+                    val saved = savedPlaylists.firstOrNull {
+                        it.playlist.browseId == item.id || it.playlist.id == item.id
+                    }
+                    if (saved != null) {
+                        add(saved.toQuickPick())
+                    } else {
+                        add(
+                            QuickPick(
+                                key = "online:${item.id}",
+                                targetType = PlaylistWidgetReceiver.TARGET_TYPE_ONLINE,
+                                targetId = item.id,
+                                title = item.title,
+                                thumbnailUrl = item.thumbnailUrl,
+                                fallbackIconRes = R.drawable.playlist_play,
+                            ),
+                        )
+                    }
+                }
+            }
+
+        savedPlaylists
+            .filter { it.playlist.browseId == null || it.playlist.isLocal }
+            .forEach { add(it.toQuickPick()) }
+
+        savedPlaylists
+            .filter { it.playlist.browseId != null && !it.playlist.isLocal }
+            .forEach { add(it.toQuickPick()) }
+
+        if (likedSongs.isNotEmpty()) {
+            add(
+                QuickPick(
+                    key = "auto:liked",
+                    targetType = PlaylistWidgetReceiver.TARGET_TYPE_LIKED,
+                    targetId = PlaylistWidgetReceiver.TARGET_TYPE_LIKED,
+                    title = context.getString(R.string.liked_songs),
+                    thumbnailUrl = likedSongs.firstOrNull()?.thumbnailUrl,
+                    fallbackIconRes = R.drawable.ic_widget_heart_nav,
+                ),
+            )
+        }
+
+        if (downloadedSongs.isNotEmpty()) {
+            add(
+                QuickPick(
+                    key = "auto:downloaded",
+                    targetType = PlaylistWidgetReceiver.TARGET_TYPE_DOWNLOADED,
+                    targetId = PlaylistWidgetReceiver.TARGET_TYPE_DOWNLOADED,
+                    title = context.getString(R.string.downloaded_songs),
+                    thumbnailUrl = downloadedSongs.firstOrNull()?.thumbnailUrl,
+                    fallbackIconRes = R.drawable.cached,
+                ),
+            )
+        }
+
+        if (topSongs.isNotEmpty()) {
+            add(
+                QuickPick(
+                    key = "auto:top50",
+                    targetType = PlaylistWidgetReceiver.TARGET_TYPE_TOP,
+                    targetId = "50",
+                    title = context.getString(R.string.my_top),
+                    thumbnailUrl = topSongs.firstOrNull()?.thumbnailUrl,
+                    fallbackIconRes = R.drawable.trending_up,
+                ),
+            )
+        }
+
+        result
+    }
+
+    private fun Playlist.toQuickPick(): QuickPick {
+        val browseId = playlist.browseId
+        val isOnline = browseId != null && !playlist.isLocal
+        return QuickPick(
+            key = if (isOnline) "online:$browseId" else "local:${playlist.id}",
+            targetType = if (isOnline) {
+                PlaylistWidgetReceiver.TARGET_TYPE_ONLINE
+            } else {
+                PlaylistWidgetReceiver.TARGET_TYPE_LOCAL
+            },
+            targetId = browseId ?: playlist.id,
+            title = playlist.name,
+            thumbnailUrl = thumbnails.firstOrNull(),
+            fallbackIconRes = R.drawable.playlist_play,
+        )
+    }
+
+    private suspend fun getCachedAlbumArt(artworkUri: String?): Bitmap? {
+        if (artworkUri == null) {
+            cachedArtworkUri = null
+            cachedAlbumArt = null
+            cachedRoundedAlbumArt = null
+            cachedRoundedSource = null
+            return null
+        }
+
+        if (artworkUri != cachedArtworkUri) {
+            val loaded = loadBitmap(artworkUri, 240)
+            cachedAlbumArt = loaded
+            cachedRoundedAlbumArt = null
+            cachedRoundedSource = null
+            cachedArtworkUri = artworkUri.takeIf { loaded != null }
+        }
+
+        return cachedAlbumArt
+    }
+
+    private fun getRoundedAlbumArt(albumArt: Bitmap): Bitmap {
+        val cached = cachedRoundedAlbumArt
+        if (cached != null && cachedRoundedSource === albumArt) return cached
+
+        return getRoundedCornerBitmap(albumArt, 36f).also {
+            cachedRoundedSource = albumArt
+            cachedRoundedAlbumArt = it
+        }
+    }
+
+    private suspend fun loadBitmap(uri: String, size: Int): Bitmap? = withContext(Dispatchers.IO) {
+        try {
+            val request = ImageRequest.Builder(context)
+                .data(uri)
+                .size(size, size)
+                .allowHardware(false)
+                .crossfade(false)
+                .build()
+            imageLoader.execute(request).image?.toBitmap()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun getRoundedCornerBitmap(bitmap: Bitmap, cornerRadius: Float): Bitmap {
+        val size = minOf(bitmap.width, bitmap.height)
+        val xOffset = (bitmap.width - size) / 2
+        val yOffset = (bitmap.height - size) / 2
+        val squareBitmap = Bitmap.createBitmap(bitmap, xOffset, yOffset, size, size)
+        val output = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(output)
+        val paint = Paint().apply {
+            isAntiAlias = true
+            isFilterBitmap = true
+            shader = BitmapShader(squareBitmap, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP)
+        }
+        val rect = RectF(0f, 0f, size.toFloat(), size.toFloat())
+        canvas.drawRoundRect(rect, cornerRadius, cornerRadius, paint)
+        if (squareBitmap != bitmap) squareBitmap.recycle()
+        return output
+    }
+
+    private fun getFallbackArtwork(item: QuickPick, cornerRadius: Float): Bitmap {
+        val cacheKey = FallbackArtworkKey(
+            targetType = item.targetType,
+            fallbackIconRes = item.fallbackIconRes,
+            cornerRadius = cornerRadius.toInt(),
+        )
+
+        fallbackArtworkCache[cacheKey]?.let { return it }
+
+        val size = 300
+        val bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        val background = Paint().apply {
+            isAntiAlias = true
+            color = when (item.targetType) {
+                PlaylistWidgetReceiver.TARGET_TYPE_LIKED -> Color.rgb(198, 40, 86)
+                PlaylistWidgetReceiver.TARGET_TYPE_DOWNLOADED -> Color.rgb(38, 128, 118)
+                PlaylistWidgetReceiver.TARGET_TYPE_TOP -> Color.rgb(122, 86, 178)
+                else -> Color.rgb(66, 72, 86)
+            }
+        }
+        val rect = RectF(0f, 0f, size.toFloat(), size.toFloat())
+        canvas.drawRoundRect(rect, cornerRadius, cornerRadius, background)
+
+        val icon = context.getDrawable(item.fallbackIconRes)?.mutate()
+        icon?.setTint(Color.WHITE)
+        val iconSize = 128
+        val iconOffset = (size - iconSize) / 2
+        icon?.setBounds(iconOffset, iconOffset, iconOffset + iconSize, iconOffset + iconSize)
+        icon?.draw(canvas)
+
+        fallbackArtworkCache[cacheKey] = bitmap
+        return bitmap
+    }
+
+    private fun getRoundedAppIcon(cornerRadius: Float): Bitmap {
+        val cacheKey = cornerRadius.toInt()
+        roundedAppIconCache[cacheKey]?.let { return it }
+
+        val drawable = context.packageManager.getApplicationIcon(context.packageName)
+        val size = 300
+        val bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        drawable.setBounds(0, 0, size, size)
+        drawable.draw(canvas)
+
+        return getRoundedCornerBitmap(bitmap, cornerRadius).also {
+            roundedAppIconCache[cacheKey] = it
+        }
+    }
+
+    private fun getOpenAppIntent(): PendingIntent {
+        val intent = Intent(context, MainActivity::class.java)
+        return PendingIntent.getActivity(
+            context,
+            500,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+    }
+
+    private fun getOpenTargetIntent(item: QuickPick): PendingIntent {
+        val intent = Intent(context, MainActivity::class.java).apply {
+            action = MainActivity.ACTION_OPEN_WIDGET_TARGET
+            putExtra(MainActivity.EXTRA_WIDGET_TARGET_TYPE, item.targetType)
+            putExtra(MainActivity.EXTRA_WIDGET_TARGET_ID, item.targetId)
+        }
+        return PendingIntent.getActivity(
+            context,
+            item.key.hashCode(),
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+    }
+
+    private fun getPlayTargetIntent(item: QuickPick): PendingIntent {
+        val intent = Intent(context, PlaylistWidgetReceiver::class.java).apply {
+            action = PlaylistWidgetReceiver.ACTION_PLAY_TARGET
+            putExtra(PlaylistWidgetReceiver.EXTRA_TARGET_TYPE, item.targetType)
+            putExtra(PlaylistWidgetReceiver.EXTRA_TARGET_ID, item.targetId)
+            putExtra(PlaylistWidgetReceiver.EXTRA_TARGET_TITLE, item.title)
+        }
+        return PendingIntent.getBroadcast(
+            context,
+            item.key.hashCode() xor 0x3522,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+    }
+
+    private fun getMusicWidgetIntent(
+        action: String,
+        requestCode: Int,
+    ): PendingIntent {
+        val intent = Intent(context, MusicWidgetReceiver::class.java).apply {
+            this.action = action
+        }
+        return PendingIntent.getBroadcast(
+            context,
+            requestCode,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+    }
+
+    private data class WidgetState(
+        val title: String,
+        val artist: String,
+        val artworkUri: String?,
+        val isPlaying: Boolean,
+        val isLiked: Boolean,
+        val duration: Long,
+        val currentPosition: Long,
+    )
+
+    private data class QuickPickSnapshot(
+        val speedDial: List<SpeedDialSnapshot>,
+        val playlists: List<PlaylistSnapshot>,
+        val likedSongs: List<SongSnapshot>,
+        val downloadedSongs: List<SongSnapshot>,
+        val topSongs: List<SongSnapshot>,
+    )
+
+    private data class SpeedDialSnapshot(
+        val type: String,
+        val id: String,
+        val title: String,
+        val thumbnailUrl: String?,
+    )
+
+    private data class PlaylistSnapshot(
+        val id: String,
+        val browseId: String?,
+        val name: String,
+        val thumbnailUrl: String?,
+        val isLocal: Boolean,
+    )
+
+    private data class SongSnapshot(
+        val id: String,
+        val thumbnailUrl: String?,
+    )
+
+    private data class QuickPick(
+        val key: String,
+        val targetType: String,
+        val targetId: String,
+        val title: String,
+        val thumbnailUrl: String?,
+        val fallbackIconRes: Int,
+    )
+
+    private data class CardSlot(
+        val containerId: Int,
+        val artworkId: Int,
+        val playContainerId: Int,
+        val playIconId: Int,
+        val titleId: Int,
+    )
+
+    private data class FallbackArtworkKey(
+        val targetType: String,
+        val fallbackIconRes: Int,
+        val cornerRadius: Int,
+    )
+
+    private val cardSlots = listOf(
+        CardSlot(R.id.widget_playlist_card_1, R.id.widget_playlist_card_1_art, R.id.widget_playlist_card_1_play_container, R.id.widget_playlist_card_1_play, R.id.widget_playlist_card_1_title),
+        CardSlot(R.id.widget_playlist_card_2, R.id.widget_playlist_card_2_art, R.id.widget_playlist_card_2_play_container, R.id.widget_playlist_card_2_play, R.id.widget_playlist_card_2_title),
+        CardSlot(R.id.widget_playlist_card_3, R.id.widget_playlist_card_3_art, R.id.widget_playlist_card_3_play_container, R.id.widget_playlist_card_3_play, R.id.widget_playlist_card_3_title),
+        CardSlot(R.id.widget_playlist_card_4, R.id.widget_playlist_card_4_art, R.id.widget_playlist_card_4_play_container, R.id.widget_playlist_card_4_play, R.id.widget_playlist_card_4_title),
+        CardSlot(R.id.widget_playlist_card_5, R.id.widget_playlist_card_5_art, R.id.widget_playlist_card_5_play_container, R.id.widget_playlist_card_5_play, R.id.widget_playlist_card_5_title),
+        CardSlot(R.id.widget_playlist_card_6, R.id.widget_playlist_card_6_art, R.id.widget_playlist_card_6_play_container, R.id.widget_playlist_card_6_play, R.id.widget_playlist_card_6_title),
+        CardSlot(R.id.widget_playlist_card_7, R.id.widget_playlist_card_7_art, R.id.widget_playlist_card_7_play_container, R.id.widget_playlist_card_7_play, R.id.widget_playlist_card_7_title),
+        CardSlot(R.id.widget_playlist_card_8, R.id.widget_playlist_card_8_art, R.id.widget_playlist_card_8_play_container, R.id.widget_playlist_card_8_play, R.id.widget_playlist_card_8_title),
+    )
+}

--- a/app/src/main/kotlin/com/metrolist/music/widget/PlaylistWidgetReceiver.kt
+++ b/app/src/main/kotlin/com/metrolist/music/widget/PlaylistWidgetReceiver.kt
@@ -1,0 +1,145 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.widget
+
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.Context
+import android.content.Intent
+import com.metrolist.music.MainActivity
+import com.metrolist.music.playback.MusicService
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import timber.log.Timber
+
+@AndroidEntryPoint
+class PlaylistWidgetReceiver : AppWidgetProvider() {
+    @Inject
+    lateinit var playlistWidgetManager: PlaylistWidgetManager
+
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray,
+    ) {
+        refreshIdleWidgets(appWidgetManager, appWidgetIds)
+    }
+
+    override fun onAppWidgetOptionsChanged(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetId: Int,
+        newOptions: android.os.Bundle,
+    ) {
+        super.onAppWidgetOptionsChanged(context, appWidgetManager, appWidgetId, newOptions)
+        refreshIdleWidget(appWidgetId, newOptions)
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        super.onReceive(context, intent)
+
+        when (intent.action) {
+            ACTION_PLAY_TARGET -> {
+                val serviceIntent = Intent(context, MusicService::class.java).apply {
+                    action = ACTION_PLAY_TARGET
+                    putExtra(EXTRA_TARGET_TYPE, intent.getStringExtra(EXTRA_TARGET_TYPE))
+                    putExtra(EXTRA_TARGET_ID, intent.getStringExtra(EXTRA_TARGET_ID))
+                    putExtra(EXTRA_TARGET_TITLE, intent.getStringExtra(EXTRA_TARGET_TITLE))
+                }
+                try {
+                    context.startService(serviceIntent)
+                } catch (e: Exception) {
+                    Timber.tag(TAG).w(e, "Failed to start playlist widget target")
+                    openTargetInApp(context, intent)
+                }
+            }
+
+            ACTION_UPDATE_WIDGET -> refreshIdleWidgets()
+        }
+    }
+
+    private fun refreshIdleWidgets(
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray,
+    ) {
+        val pendingResult = goAsync()
+        CoroutineScope(Dispatchers.Main).launch {
+            try {
+                appWidgetIds.forEach { appWidgetId ->
+                    playlistWidgetManager.updateIdleWidget(
+                        appWidgetId = appWidgetId,
+                        options = appWidgetManager.getAppWidgetOptions(appWidgetId),
+                    )
+                }
+            } catch (e: Exception) {
+                Timber.tag(TAG).e(e, "Failed to refresh playlist widgets")
+            } finally {
+                pendingResult.finish()
+            }
+        }
+    }
+
+    private fun refreshIdleWidgets() {
+        val pendingResult = goAsync()
+        CoroutineScope(Dispatchers.Main).launch {
+            try {
+                playlistWidgetManager.updateIdleWidgets()
+            } catch (e: Exception) {
+                Timber.tag(TAG).e(e, "Failed to refresh playlist widgets")
+            } finally {
+                pendingResult.finish()
+            }
+        }
+    }
+
+    private fun refreshIdleWidget(appWidgetId: Int, options: android.os.Bundle) {
+        val pendingResult = goAsync()
+        CoroutineScope(Dispatchers.Main).launch {
+            try {
+                playlistWidgetManager.updateIdleWidget(appWidgetId, options)
+            } catch (e: Exception) {
+                Timber.tag(TAG).e(e, "Failed to refresh playlist widget")
+            } finally {
+                pendingResult.finish()
+            }
+        }
+    }
+
+    private fun openTargetInApp(context: Context, source: Intent) {
+        val activityIntent = Intent(context, MainActivity::class.java).apply {
+            action = MainActivity.ACTION_OPEN_WIDGET_TARGET
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
+            putExtra(
+                MainActivity.EXTRA_WIDGET_TARGET_TYPE,
+                source.getStringExtra(EXTRA_TARGET_TYPE),
+            )
+            putExtra(
+                MainActivity.EXTRA_WIDGET_TARGET_ID,
+                source.getStringExtra(EXTRA_TARGET_ID),
+            )
+        }
+        context.startActivity(activityIntent)
+    }
+
+    companion object {
+        private const val TAG = "PlaylistWidgetReceiver"
+        const val ACTION_PLAY_TARGET = "com.metrolist.music.widget.playlists.PLAY_TARGET"
+        const val ACTION_UPDATE_WIDGET = "com.metrolist.music.widget.playlists.UPDATE_WIDGET"
+
+        const val EXTRA_TARGET_TYPE = "playlist_widget_target_type"
+        const val EXTRA_TARGET_ID = "playlist_widget_target_id"
+        const val EXTRA_TARGET_TITLE = "playlist_widget_target_title"
+
+        const val TARGET_TYPE_LOCAL = "local"
+        const val TARGET_TYPE_ONLINE = "online"
+        const val TARGET_TYPE_LIKED = "liked"
+        const val TARGET_TYPE_DOWNLOADED = "downloaded"
+        const val TARGET_TYPE_TOP = "top"
+    }
+}

--- a/app/src/main/res/layout/widget_playlist.xml
+++ b/app/src/main/res/layout/widget_playlist.xml
@@ -1,0 +1,329 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@android:id/background"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:gravity="top"
+    android:background="@drawable/widget_background"
+    android:paddingStart="14dp"
+    android:paddingEnd="14dp"
+    android:paddingTop="12dp"
+    android:paddingBottom="12dp"
+    android:theme="@style/Theme.Widget.Metrolist">
+
+    <LinearLayout
+        android:id="@+id/widget_playlist_player_section"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+
+        <ImageView
+            android:id="@+id/widget_playlist_album_art"
+            android:layout_width="64dp"
+            android:layout_height="64dp"
+            android:scaleType="centerCrop"
+            android:src="@mipmap/ic_launcher"
+            android:contentDescription="@string/album_art" />
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginStart="12dp"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/widget_playlist_song_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/not_playing"
+                android:textSize="15sp"
+                android:textStyle="bold"
+                android:textColor="@color/widget_text_primary"
+                android:maxLines="1"
+                android:ellipsize="end" />
+
+            <TextView
+                android:id="@+id/widget_playlist_artist_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:text="@string/choose_something_below"
+                android:textSize="12sp"
+                android:textColor="@color/widget_text_secondary"
+                android:maxLines="1"
+                android:ellipsize="end" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="36dp"
+                android:layout_marginTop="8dp"
+                android:orientation="horizontal"
+                android:gravity="center_vertical">
+
+                <FrameLayout
+                    android:id="@+id/widget_playlist_prev_container"
+                    android:layout_width="36dp"
+                    android:layout_height="36dp">
+                    <ImageView
+                        android:layout_width="22dp"
+                        android:layout_height="22dp"
+                        android:layout_gravity="center"
+                        android:src="@drawable/ic_widget_skip_previous"
+                        android:contentDescription="@string/previous" />
+                </FrameLayout>
+
+                <FrameLayout
+                    android:id="@+id/widget_playlist_play_pause_container"
+                    android:layout_width="48dp"
+                    android:layout_height="36dp"
+                    android:layout_marginStart="4dp"
+                    android:layout_marginEnd="4dp"
+                    android:background="@drawable/widget_play_pill_bg">
+                    <ImageView
+                        android:id="@+id/widget_playlist_play_pause"
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:layout_gravity="center"
+                        android:src="@drawable/ic_widget_play"
+                        android:contentDescription="@string/play_pause" />
+                </FrameLayout>
+
+                <FrameLayout
+                    android:id="@+id/widget_playlist_next_container"
+                    android:layout_width="36dp"
+                    android:layout_height="36dp">
+                    <ImageView
+                        android:layout_width="22dp"
+                        android:layout_height="22dp"
+                        android:layout_gravity="center"
+                        android:src="@drawable/ic_widget_skip_next"
+                        android:contentDescription="@string/next" />
+                </FrameLayout>
+
+                <FrameLayout
+                    android:layout_width="36dp"
+                    android:layout_height="36dp"
+                    android:layout_marginStart="6dp">
+                    <ImageButton
+                        android:id="@+id/widget_playlist_like_button"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:padding="8dp"
+                        android:scaleType="fitCenter"
+                        android:background="@android:color/transparent"
+                        android:src="@drawable/ic_widget_heart_outline_nav"
+                        android:contentDescription="@string/like" />
+                </FrameLayout>
+            </LinearLayout>
+
+            <FrameLayout
+                android:layout_width="match_parent"
+                android:layout_height="5dp"
+                android:layout_marginTop="8dp">
+                <ImageView
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:src="@drawable/widget_progress_track"
+                    android:scaleType="fitXY"
+                    android:contentDescription="@null" />
+                <ImageView
+                    android:id="@+id/widget_playlist_progress_fill"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:src="@drawable/widget_progress_clip"
+                    android:scaleType="fitXY"
+                    android:contentDescription="@null" />
+            </FrameLayout>
+        </LinearLayout>
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/widget_playlist_quick_picks_section"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:orientation="vertical"
+        android:visibility="gone">
+
+        <LinearLayout
+            android:id="@+id/widget_playlist_row_1"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="start">
+
+            <LinearLayout
+                android:id="@+id/widget_playlist_card_1"
+                style="@style/MetrolistPlaylistWidgetCard">
+                <FrameLayout style="@style/MetrolistPlaylistWidgetArtworkFrame">
+                    <ImageView
+                        android:id="@+id/widget_playlist_card_1_art"
+                        style="@style/MetrolistPlaylistWidgetArtwork"
+                        android:contentDescription="@null" />
+                    <FrameLayout
+                        android:id="@+id/widget_playlist_card_1_play_container"
+                        style="@style/MetrolistPlaylistWidgetCardPlayButton">
+                        <ImageView
+                            android:id="@+id/widget_playlist_card_1_play"
+                            style="@style/MetrolistPlaylistWidgetCardPlayIcon"
+                            android:contentDescription="@null" />
+                    </FrameLayout>
+                </FrameLayout>
+                <TextView android:id="@+id/widget_playlist_card_1_title" style="@style/MetrolistPlaylistWidgetCardTitle" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/widget_playlist_card_2"
+                style="@style/MetrolistPlaylistWidgetCard">
+                <FrameLayout style="@style/MetrolistPlaylistWidgetArtworkFrame">
+                    <ImageView
+                        android:id="@+id/widget_playlist_card_2_art"
+                        style="@style/MetrolistPlaylistWidgetArtwork"
+                        android:contentDescription="@null" />
+                    <FrameLayout
+                        android:id="@+id/widget_playlist_card_2_play_container"
+                        style="@style/MetrolistPlaylistWidgetCardPlayButton">
+                        <ImageView
+                            android:id="@+id/widget_playlist_card_2_play"
+                            style="@style/MetrolistPlaylistWidgetCardPlayIcon"
+                            android:contentDescription="@null" />
+                    </FrameLayout>
+                </FrameLayout>
+                <TextView android:id="@+id/widget_playlist_card_2_title" style="@style/MetrolistPlaylistWidgetCardTitle" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/widget_playlist_card_3"
+                style="@style/MetrolistPlaylistWidgetCard">
+                <FrameLayout style="@style/MetrolistPlaylistWidgetArtworkFrame">
+                    <ImageView
+                        android:id="@+id/widget_playlist_card_3_art"
+                        style="@style/MetrolistPlaylistWidgetArtwork"
+                        android:contentDescription="@null" />
+                    <FrameLayout
+                        android:id="@+id/widget_playlist_card_3_play_container"
+                        style="@style/MetrolistPlaylistWidgetCardPlayButton">
+                        <ImageView
+                            android:id="@+id/widget_playlist_card_3_play"
+                            style="@style/MetrolistPlaylistWidgetCardPlayIcon"
+                            android:contentDescription="@null" />
+                    </FrameLayout>
+                </FrameLayout>
+                <TextView android:id="@+id/widget_playlist_card_3_title" style="@style/MetrolistPlaylistWidgetCardTitle" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/widget_playlist_card_4"
+                style="@style/MetrolistPlaylistWidgetCard">
+                <FrameLayout style="@style/MetrolistPlaylistWidgetArtworkFrame">
+                    <ImageView
+                        android:id="@+id/widget_playlist_card_4_art"
+                        style="@style/MetrolistPlaylistWidgetArtwork"
+                        android:contentDescription="@null" />
+                    <FrameLayout
+                        android:id="@+id/widget_playlist_card_4_play_container"
+                        style="@style/MetrolistPlaylistWidgetCardPlayButton">
+                        <ImageView
+                            android:id="@+id/widget_playlist_card_4_play"
+                            style="@style/MetrolistPlaylistWidgetCardPlayIcon"
+                            android:contentDescription="@null" />
+                    </FrameLayout>
+                </FrameLayout>
+                <TextView android:id="@+id/widget_playlist_card_4_title" style="@style/MetrolistPlaylistWidgetCardTitle" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/widget_playlist_row_2"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:orientation="horizontal"
+            android:gravity="start"
+            android:visibility="gone">
+
+            <LinearLayout
+                android:id="@+id/widget_playlist_card_5"
+                style="@style/MetrolistPlaylistWidgetCard">
+                <FrameLayout style="@style/MetrolistPlaylistWidgetArtworkFrame">
+                    <ImageView
+                        android:id="@+id/widget_playlist_card_5_art"
+                        style="@style/MetrolistPlaylistWidgetArtwork"
+                        android:contentDescription="@null" />
+                    <FrameLayout
+                        android:id="@+id/widget_playlist_card_5_play_container"
+                        style="@style/MetrolistPlaylistWidgetCardPlayButton">
+                        <ImageView
+                            android:id="@+id/widget_playlist_card_5_play"
+                            style="@style/MetrolistPlaylistWidgetCardPlayIcon"
+                            android:contentDescription="@null" />
+                    </FrameLayout>
+                </FrameLayout>
+                <TextView android:id="@+id/widget_playlist_card_5_title" style="@style/MetrolistPlaylistWidgetCardTitle" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/widget_playlist_card_6"
+                style="@style/MetrolistPlaylistWidgetCard">
+                <FrameLayout style="@style/MetrolistPlaylistWidgetArtworkFrame">
+                    <ImageView
+                        android:id="@+id/widget_playlist_card_6_art"
+                        style="@style/MetrolistPlaylistWidgetArtwork"
+                        android:contentDescription="@null" />
+                    <FrameLayout
+                        android:id="@+id/widget_playlist_card_6_play_container"
+                        style="@style/MetrolistPlaylistWidgetCardPlayButton">
+                        <ImageView
+                            android:id="@+id/widget_playlist_card_6_play"
+                            style="@style/MetrolistPlaylistWidgetCardPlayIcon"
+                            android:contentDescription="@null" />
+                    </FrameLayout>
+                </FrameLayout>
+                <TextView android:id="@+id/widget_playlist_card_6_title" style="@style/MetrolistPlaylistWidgetCardTitle" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/widget_playlist_card_7"
+                style="@style/MetrolistPlaylistWidgetCard">
+                <FrameLayout style="@style/MetrolistPlaylistWidgetArtworkFrame">
+                    <ImageView
+                        android:id="@+id/widget_playlist_card_7_art"
+                        style="@style/MetrolistPlaylistWidgetArtwork"
+                        android:contentDescription="@null" />
+                    <FrameLayout
+                        android:id="@+id/widget_playlist_card_7_play_container"
+                        style="@style/MetrolistPlaylistWidgetCardPlayButton">
+                        <ImageView
+                            android:id="@+id/widget_playlist_card_7_play"
+                            style="@style/MetrolistPlaylistWidgetCardPlayIcon"
+                            android:contentDescription="@null" />
+                    </FrameLayout>
+                </FrameLayout>
+                <TextView android:id="@+id/widget_playlist_card_7_title" style="@style/MetrolistPlaylistWidgetCardTitle" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/widget_playlist_card_8"
+                style="@style/MetrolistPlaylistWidgetCard">
+                <FrameLayout style="@style/MetrolistPlaylistWidgetArtworkFrame">
+                    <ImageView
+                        android:id="@+id/widget_playlist_card_8_art"
+                        style="@style/MetrolistPlaylistWidgetArtwork"
+                        android:contentDescription="@null" />
+                    <FrameLayout
+                        android:id="@+id/widget_playlist_card_8_play_container"
+                        style="@style/MetrolistPlaylistWidgetCardPlayButton">
+                        <ImageView
+                            android:id="@+id/widget_playlist_card_8_play"
+                            style="@style/MetrolistPlaylistWidgetCardPlayIcon"
+                            android:contentDescription="@null" />
+                    </FrameLayout>
+                </FrameLayout>
+                <TextView android:id="@+id/widget_playlist_card_8_title" style="@style/MetrolistPlaylistWidgetCardTitle" />
+            </LinearLayout>
+        </LinearLayout>
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/widget_playlist_preview.xml
+++ b/app/src/main/res/layout/widget_playlist_preview.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@android:id/background"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:gravity="top"
+    android:background="@drawable/widget_background"
+    android:paddingStart="14dp"
+    android:paddingEnd="14dp"
+    android:paddingTop="12dp"
+    android:paddingBottom="12dp"
+    android:theme="@style/Theme.Widget.Metrolist">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+
+        <ImageView
+            android:layout_width="64dp"
+            android:layout_height="64dp"
+            android:scaleType="centerCrop"
+            android:src="@mipmap/ic_launcher"
+            android:contentDescription="@string/album_art" />
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginStart="12dp"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/not_playing"
+                android:textSize="15sp"
+                android:textStyle="bold"
+                android:textColor="@color/widget_text_primary"
+                android:maxLines="1"
+                android:ellipsize="end" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:text="@string/choose_something_below"
+                android:textSize="12sp"
+                android:textColor="@color/widget_text_secondary"
+                android:maxLines="1"
+                android:ellipsize="end" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="36dp"
+                android:layout_marginTop="8dp"
+                android:orientation="horizontal"
+                android:gravity="center_vertical">
+
+                <ImageView
+                    android:layout_width="36dp"
+                    android:layout_height="36dp"
+                    android:padding="7dp"
+                    android:src="@drawable/ic_widget_skip_previous"
+                    android:contentDescription="@string/previous" />
+
+                <FrameLayout
+                    android:layout_width="48dp"
+                    android:layout_height="36dp"
+                    android:layout_marginStart="4dp"
+                    android:layout_marginEnd="4dp"
+                    android:background="@drawable/widget_play_pill_bg">
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:layout_gravity="center"
+                        android:src="@drawable/ic_widget_play"
+                        android:contentDescription="@string/play_pause" />
+                </FrameLayout>
+
+                <ImageView
+                    android:layout_width="36dp"
+                    android:layout_height="36dp"
+                    android:padding="7dp"
+                    android:src="@drawable/ic_widget_skip_next"
+                    android:contentDescription="@string/next" />
+
+                <ImageView
+                    android:layout_width="36dp"
+                    android:layout_height="36dp"
+                    android:layout_marginStart="6dp"
+                    android:padding="8dp"
+                    android:src="@drawable/ic_widget_heart_outline_nav"
+                    android:contentDescription="@string/like" />
+            </LinearLayout>
+
+            <FrameLayout
+                android:layout_width="match_parent"
+                android:layout_height="5dp"
+                android:layout_marginTop="8dp">
+                <ImageView
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:src="@drawable/widget_progress_track"
+                    android:scaleType="fitXY" />
+                <ImageView
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:src="@drawable/widget_progress_clip"
+                    android:scaleType="fitXY" />
+            </FrameLayout>
+        </LinearLayout>
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:orientation="horizontal"
+        android:gravity="start">
+
+        <LinearLayout style="@style/MetrolistPlaylistWidgetCard">
+            <FrameLayout style="@style/MetrolistPlaylistWidgetArtworkFrame">
+                <ImageView style="@style/MetrolistPlaylistWidgetArtwork" android:src="@drawable/playlist_play" />
+                <FrameLayout style="@style/MetrolistPlaylistWidgetCardPlayButton"><ImageView style="@style/MetrolistPlaylistWidgetCardPlayIcon" /></FrameLayout>
+            </FrameLayout>
+            <TextView style="@style/MetrolistPlaylistWidgetCardTitle" android:text="@string/widget_playlists" />
+        </LinearLayout>
+
+        <LinearLayout style="@style/MetrolistPlaylistWidgetCard">
+            <FrameLayout style="@style/MetrolistPlaylistWidgetArtworkFrame">
+                <ImageView style="@style/MetrolistPlaylistWidgetArtwork" android:src="@drawable/ic_widget_heart_nav" />
+                <FrameLayout style="@style/MetrolistPlaylistWidgetCardPlayButton"><ImageView style="@style/MetrolistPlaylistWidgetCardPlayIcon" /></FrameLayout>
+            </FrameLayout>
+            <TextView style="@style/MetrolistPlaylistWidgetCardTitle" android:text="@string/liked_songs" />
+        </LinearLayout>
+
+        <LinearLayout style="@style/MetrolistPlaylistWidgetCard">
+            <FrameLayout style="@style/MetrolistPlaylistWidgetArtworkFrame">
+                <ImageView style="@style/MetrolistPlaylistWidgetArtwork" android:src="@drawable/cached" />
+                <FrameLayout style="@style/MetrolistPlaylistWidgetCardPlayButton"><ImageView style="@style/MetrolistPlaylistWidgetCardPlayIcon" /></FrameLayout>
+            </FrameLayout>
+            <TextView style="@style/MetrolistPlaylistWidgetCardTitle" android:text="@string/downloaded_songs" />
+        </LinearLayout>
+
+        <LinearLayout style="@style/MetrolistPlaylistWidgetCard">
+            <FrameLayout style="@style/MetrolistPlaylistWidgetArtworkFrame">
+                <ImageView style="@style/MetrolistPlaylistWidgetArtwork" android:src="@drawable/trending_up" />
+                <FrameLayout style="@style/MetrolistPlaylistWidgetCardPlayButton"><ImageView style="@style/MetrolistPlaylistWidgetCardPlayIcon" /></FrameLayout>
+            </FrameLayout>
+            <TextView style="@style/MetrolistPlaylistWidgetCardTitle" android:text="@string/my_top" />
+        </LinearLayout>
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -958,4 +958,7 @@
     <string name="loudness_level_loud">Loud (-11 dB)</string>
     <string name="loudness_level_balanced">Balanced (-14 dB)</string>
     <string name="loudness_level_quiet">Quiet (-19 dB)</string>
+    <string name="widget_playlists">Playlists</string>
+    <string name="widget_playlists_description">Playlist shortcuts with mini-player controls</string>
+    <string name="choose_something_below">Choose something below</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -26,4 +26,55 @@
         <item name="android:windowDisablePreview">true</item>
         <item name="android:windowAnimationStyle">@null</item>
     </style>
+
+    <style name="MetrolistPlaylistWidgetCard">
+        <item name="android:layout_width">0dp</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_weight">1</item>
+        <item name="android:orientation">vertical</item>
+        <item name="android:gravity">center_horizontal</item>
+    </style>
+
+    <style name="MetrolistPlaylistWidgetArtworkFrame">
+        <item name="android:layout_width">64dp</item>
+        <item name="android:layout_height">64dp</item>
+    </style>
+
+    <style name="MetrolistPlaylistWidgetArtwork">
+        <item name="android:layout_width">64dp</item>
+        <item name="android:layout_height">64dp</item>
+        <item name="android:scaleType">centerCrop</item>
+        <item name="android:src">@mipmap/ic_launcher</item>
+        <item name="android:contentDescription">@string/widget_playlists</item>
+    </style>
+
+    <style name="MetrolistPlaylistWidgetCardPlayButton">
+        <item name="android:layout_width">26dp</item>
+        <item name="android:layout_height">26dp</item>
+        <item name="android:layout_gravity">bottom|end</item>
+        <item name="android:layout_marginEnd">3dp</item>
+        <item name="android:layout_marginBottom">3dp</item>
+        <item name="android:background">@drawable/widget_play_button_circular</item>
+    </style>
+
+    <style name="MetrolistPlaylistWidgetCardPlayIcon">
+        <item name="android:layout_width">15dp</item>
+        <item name="android:layout_height">15dp</item>
+        <item name="android:layout_gravity">center</item>
+        <item name="android:src">@drawable/ic_widget_play_low</item>
+        <item name="android:contentDescription">@string/play</item>
+    </style>
+
+    <style name="MetrolistPlaylistWidgetCardTitle">
+        <item name="android:layout_width">68dp</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_marginTop">5dp</item>
+        <item name="android:textSize">10sp</item>
+        <item name="android:textColor">@color/widget_text_primary</item>
+        <item name="android:maxLines">2</item>
+        <item name="android:ellipsize">end</item>
+        <item name="android:gravity">center</item>
+        <item name="android:includeFontPadding">false</item>
+    </style>
+
 </resources>

--- a/app/src/main/res/xml-v31/playlist_widget_info.xml
+++ b/app/src/main/res/xml-v31/playlist_widget_info.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="110dp"
+    android:minHeight="122dp"
+    android:minResizeWidth="110dp"
+    android:minResizeHeight="122dp"
+    android:maxResizeWidth="520dp"
+    android:maxResizeHeight="405dp"
+    android:targetCellWidth="4"
+    android:targetCellHeight="2"
+    android:updatePeriodMillis="1800000"
+    android:previewImage="@mipmap/ic_launcher"
+    android:previewLayout="@layout/widget_playlist_preview"
+    android:initialLayout="@layout/widget_playlist"
+    android:description="@string/widget_playlists_description"
+    android:widgetCategory="home_screen"
+    android:resizeMode="horizontal|vertical" />

--- a/app/src/main/res/xml/playlist_widget_info.xml
+++ b/app/src/main/res/xml/playlist_widget_info.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="110dp"
+    android:minHeight="122dp"
+    android:minResizeWidth="110dp"
+    android:minResizeHeight="122dp"
+    android:updatePeriodMillis="1800000"
+    android:previewImage="@mipmap/ic_launcher"
+    android:initialLayout="@layout/widget_playlist"
+    android:description="@string/widget_playlists_description"
+    android:widgetCategory="home_screen"
+    android:resizeMode="horizontal|vertical" />


### PR DESCRIPTION
## Problem
<!-- Describe the issue or limitation this PR addresses  -->
Metrolist has home screen widgets focused on controlling the current
playback, but there is no separate widget focused on quickly opening or playing
playlists from the home screen.

## Cause
<!-- Explain the root cause of the problem -->
Metrolist already has playback widgets, but they are not meant for quickly
starting playlists. To play a specific playlist, users still have to open the
app, find the playlist, and start playback from there.

## Solution
<!-- List the changes made to fix the issue -->
This PR adds a new  playlist widget.

The widget includes:

- a music player section with artwork, title, artist, playback controls, like button, and progress bar;
- playlist shortcut cards;
- support for up to 4 cards in one row, or 8 cards in two rows when enough playlists are available;
- priority for pinned Speed Dial playlists, followed by local playlists and saved online playlists;
- fallback entries for Liked Songs, Downloaded Songs, and My Top when available;
- direct playback from playlist card buttons when a queue can be built;
- fallback behavior that opens the chosen playlist when direct playback cannot be started;
- automatic refresh when playback or playlist data changes;
- a widget picker preview that shows the music player and playlist cards.

## Testing
<!-- Describe how the changes were tested -->
Built locally with: ./gradlew.bat :app:assembleFossDebug

Manually tested:
- adding the new Playlists widget from the Android widget picker;
- verifying the widget picker preview;
- resizing the widget between 4-card and 8-card states;
- opening different playlist cards from the widget;
- starting playback directly from playlist card play buttons;
- fallback behavior when direct playback cannot start;
- Speed Dial pin/unpin updates;
- local playlists and saved online playlists ordering;
- Liked Songs, Downloaded Songs, and My Top fallback entries;
- play/pause, previous, next, and like controls;
- existing widgets still working unchanged.

https://github.com/user-attachments/assets/40267cd0-f3cc-4624-81c8-1f43b9a5a7ff

## Related Issues
<!-- List any related issues or PRs -->
- Closes #3522

Co-authored with @David-2765.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a resizable playlist home-screen widget with artwork, progress, playback and like controls.
  * Quick-pick cards (up to 8) for playlists and auto-sections with direct-play actions.
  * Widget preview/layouts, themed styles, and new accessibility strings.
  * Widget actions can start playback or open the app to a specific playlist/target.
  * Background update support to keep widget UI and quick-picks refreshed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MetrolistGroup/Metrolist/pull/3739)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->