### PR TITLE
fix: auto toggle from repeat(1) to repeat(all) after song change

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
@@ -755,6 +755,24 @@ fun BottomSheetPlayer(
         }
     }
 
+    // Auto-switch from repeat one to repeat all when song changes
+    var previousMediaId by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(mediaMetadata?.id, repeatMode) {
+        val currentId = mediaMetadata?.id
+        
+        // If we've moved to a new song and were in REPEAT_MODE_ONE, switch to REPEAT_MODE_ALL
+        if (currentId != null && 
+            currentId != previousMediaId && 
+            previousMediaId != null && 
+            repeatMode == Player.REPEAT_MODE_ONE &&
+            !isListenTogetherGuest) {
+            playerConnection.player.setRepeatMode(Player.REPEAT_MODE_ALL)
+        }
+        
+        previousMediaId = currentId
+    }
+
     // When casting, use Cast position/duration directly
     // But wait a bit after manual seeks to let Cast catch up
     LaunchedEffect(isCasting, castPosition, castDuration) {


### PR DESCRIPTION
## Problem

When repeat mode is set to "Repeat One", the app continues to repeat the same song even after manually playing the next track or skipping to another song. This behavior differs from standard music players (Spotify, Apple Music, YouTube Music) which automatically switch to "Repeat All" mode when moving to a different song, providing better UX and preventing accidental infinite loops of a single track.

## Cause

The repeat mode state was not being monitored for song changes. When a user selected "Repeat One" and then played a different song, the app did not detect this transition and failed to automatically adjust the repeat mode, leaving the user in "Repeat One" state with a different track instead of switching to the expected "Repeat All" behavior.

## Solution

- Added `LaunchedEffect` in `BottomSheetPlayer()` to monitor both `mediaMetadata?.id` and `repeatMode` changes
- When a new song starts playing and the current repeat mode is `REPEAT_MODE_ONE`, automatically switches to `REPEAT_MODE_ALL`
- Respects "Listen Together" guest mode restrictions (guests cannot change repeat mode)
- Only triggers on actual song transitions, not on initial app load

## Testing

- ✅ Set repeat mode to "Repeat One" and play a song
- ✅ Verify song repeats when it finishes naturally
- ✅ Click next/skip while in "Repeat One" → Verify repeat mode auto-switches to "Repeat All"
- ✅ Click previous while in "Repeat One" → Verify repeat mode auto-switches to "Repeat All"
- ✅ Test in "Listen Together" guest mode → Verify repeat mode does not auto-switch (guests have no control)
- ✅ Verify no auto-switch occurs on first song load
- ✅ Test with different media sources (local playlists, YouTube Music, etc.)
- ✅ Test in both landscape and portrait orientations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * **Player Repeat Mode**: Adjusted repeat mode behavior when skipping tracks—it now automatically switches from single-track repeat to all-tracks repeat when advancing to the next song, except for Listen Together guest users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MetrolistGroup/Metrolist/pull/3743)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->