### PR TITLE
fix: restore playback broken by YouTube player 57f5d44f (May 2026)

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -29,6 +29,8 @@ import com.metrolist.music.utils.YTPlayerUtils.MAIN_CLIENT
 import com.metrolist.music.utils.YTPlayerUtils.STREAM_FALLBACK_CLIENTS
 import com.metrolist.music.utils.YTPlayerUtils.validateStatus
 import com.metrolist.music.utils.cipher.CipherDeobfuscator
+import com.metrolist.music.utils.cipher.FunctionNameExtractor
+import com.metrolist.music.utils.cipher.PlayerJsFetcher
 import com.metrolist.music.utils.potoken.PoTokenGenerator
 import com.metrolist.music.utils.potoken.PoTokenResult
 import okhttp3.OkHttpClient
@@ -518,12 +520,12 @@ object YTPlayerUtils {
         val isAgeRestricted: Boolean
     )
 
-    private fun getSignatureTimestampOrNull(videoId: String): SignatureTimestampResult {
+    private suspend fun getSignatureTimestampOrNull(videoId: String): SignatureTimestampResult {
         Timber.tag(logTag).d("Getting signature timestamp for videoId: $videoId")
         val result = NewPipeExtractor.getSignatureTimestamp(videoId)
         return result.fold(
             onSuccess = { timestamp ->
-                Timber.tag(logTag).d("Signature timestamp obtained: $timestamp")
+                Timber.tag(logTag).d("Signature timestamp obtained via NewPipe: $timestamp")
                 SignatureTimestampResult(timestamp, isAgeRestricted = false)
             },
             onFailure = { error ->
@@ -533,10 +535,25 @@ object YTPlayerUtils {
                     Timber.tag(logTag).d("Age-restricted content detected from NewPipe")
                     Timber.tag(TAG).i("Age-restricted detected early via NewPipe: videoId=$videoId")
                 } else {
-                    Timber.tag(logTag).e(error, "Failed to get signature timestamp")
+                    Timber.tag(logTag).e(error, "Failed to get signature timestamp via NewPipe")
                     reportException(error)
                 }
-                SignatureTimestampResult(null, isAgeRestricted)
+                // Fallback: extract signatureTimestamp directly from player.js when NewPipe fails.
+                // This keeps playback working when the NewPipe extractor is outdated for a new
+                // player version, as long as the player.js still embeds signatureTimestamp inline.
+                val fallbackSts = runCatching {
+                    Timber.tag(logTag).d("Trying player.js fallback for signature timestamp")
+                    val (playerJs, hash) = PlayerJsFetcher.getPlayerJs()
+                        ?: error("PlayerJsFetcher returned null")
+                    Timber.tag(logTag).d("Got player.js (hash=$hash), extracting signatureTimestamp")
+                    FunctionNameExtractor.extractSignatureTimestamp(playerJs)
+                        ?: error("extractSignatureTimestamp returned null for hash=$hash")
+                }.onSuccess { sts ->
+                    Timber.tag(logTag).d("Signature timestamp obtained via player.js fallback: $sts")
+                }.onFailure { e ->
+                    Timber.tag(logTag).e(e, "player.js fallback for signature timestamp also failed")
+                }.getOrNull()
+                SignatureTimestampResult(fallbackSts, isAgeRestricted)
             }
         )
     }

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/FunctionNameExtractor.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/FunctionNameExtractor.kt
@@ -77,6 +77,18 @@ object FunctionNameExtractor {
             nArrayIndex = null,
             nConstantArgs = null,
             signatureTimestamp = 20543
+        ),
+        // May 2026: direct URLs, no client-side cipher or n-transform
+        "57f5d44f" to HardcodedPlayerConfig(
+            sigFuncName = "",
+            sigConstantArg = null,
+            sigConstantArgs = null,
+            sigPreprocessFunc = null,
+            sigPreprocessArgs = null,
+            nFuncName = "",
+            nArrayIndex = null,
+            nConstantArgs = null,
+            signatureTimestamp = 20591
         )
     )
 


### PR DESCRIPTION
YouTube new player dropped client-side cipher and n-transform but kept signatureTimestamp embedded in JS. NewPipe (pinned to commit 6305155) could not parse the new format, so getSignatureTimestampOrNull returned null, WEB_REMIX sent requests without sts, and YouTube CDN throttled all streams (ExoPlayer Source error).

- Add hardcoded config for player hash 57f5d44f (sts=20591, no cipher, no n-transform) to KNOWN_PLAYER_CONFIGS in FunctionNameExtractor
- Add direct player.js fallback in getSignatureTimestampOrNull: when NewPipe fails, download player.js via PlayerJsFetcher and extract sts with FunctionNameExtractor.extractSignatureTimestamp()

## Problem
<!-- Describe the issue or limitation this PR addresses  
DO NOT PR NEW FEATURES, WE'RE ON A FEATURE FREEZE!!! -->

## Cause
<!-- Explain the root cause of the problem -->
Youtube changed the playerapi

## Solution
<!-- List the changes made to fix the issue -->
- Add hardcoded config for player hash 57f5d44f to KNOWN_PLAYER_CONFIGS in FunctionNameExtractor
- Add direct player.js fallback

## Testing
<!-- Describe how the changes were tested -->
 - unit test tried the code, but were not commited by request of maintainer

## Related Issues
<!-- List any related issues or PRs -->
- Closes #
- Related to #3760


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented automatic fallback mechanism for signature timestamp extraction to ensure the app continues functioning when the primary extraction method fails
  * Improved error reporting and logging to provide better visibility into extraction failures and sources
  * Extended fallback configuration database to support additional YouTube player versions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MetrolistGroup/Metrolist/pull/3777?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->