### PR TITLE
Update widget_background.xml

### DIFF
--- a/app/src/main/res/drawable/widget_background.xml
+++ b/app/src/main/res/drawable/widget_background.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Widget background - uses Material 3 surface colors -->
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:shape="rectangle">
-    <solid android:color="@android:color/system_accent1_100"
-        tools:targetApi="31" />
+    
+    <solid android:color="#A60A0B10" />
+    
     <corners android:radius="28dp" />
+    
+    <stroke
+        android:width="1dp"
+        android:color="#26FFFFFF" />
 </shape>


### PR DESCRIPTION
## Problem
The music player home screen widget currently suffers from poor legibility and contrast issues depending on the user's active system wallpaper. Because the widget background utilizes a flat, solid surface token, text elements frequently clip or blend invisibly into bright, busy, or highly detailed custom wallpapers, creating a broken user experience.

## Cause
The existing `widget_background.xml` uses a flat, solid color drawable token (`@android:color/system_accent1_100`) without any transparency layers, edge borders, or background render effects. This lack of alpha separation prevents proper contrast isolation between the home screen wallpaper layer and the widget's text layout components.

## Solution
- Rewrote `widget_background.xml` to replace the solid background token with a highly legible, translucent ARGB mask (`#A60A0B10`).
- Added an ultra-thin white border stroke (`1dp`, `#26FFFFFF`) to simulate a clean light reflection edge, separating the widget boundaries visually from any underlying background elements.
- Maintained the native design dimensions (`28dp` corner radius profile) to keep visual consistency with standard system panels.

## Testing
- Tested on a local device running Android 12+ (API 31+).
- Verified widget container rendering against multiple system wallpapers (including purely white, dark, and highly detailed multi-colored backgrounds) to ensure typography remains 100% readable.
- Confirmed the translucent stroke boundary renders smoothly on both light and dark system themes without layout distortion.

## Related Issues
- Related to #3703 (Fixes in-app media crashes and bitmap rendering blocks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated widget background color scheme to a darker, semi-transparent appearance
  * Added a subtle light-colored border for enhanced visual definition
  * Maintained existing rounded corner styling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MetrolistGroup/Metrolist/pull/3790?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->