### PR TITLE
feat(ui): add automatic tablet UI scaling with density adaptation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -57,6 +57,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:launchMode="singleTask"
+            android:resizeableActivity="true"
             android:theme="@style/Theme.Metrolist"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>

--- a/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
@@ -85,6 +85,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalWindowInfo
@@ -92,6 +93,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastAny
 import androidx.compose.ui.window.Dialog
@@ -641,6 +643,26 @@ class MainActivity : ComponentActivity() {
             pureBlack = pureBlack,
             themeColor = themeColor,
         ) {
+            val currentDensity = LocalDensity.current
+            val realConfig = LocalConfiguration.current
+            val realScreenWidthDp = realConfig.screenWidthDp
+
+            val densityScale = remember(realScreenWidthDp) {
+                when {
+                    realScreenWidthDp >= 840 -> 1.25f
+                    realScreenWidthDp >= 720 -> 1.15f
+                    realScreenWidthDp >= 600 -> 1.1f
+                    else -> 1.0f
+                }
+            }
+            val scaledDensity: Density = remember(currentDensity, densityScale) {
+                Density(
+                    density = currentDensity.density * densityScale,
+                    fontScale = currentDensity.fontScale,
+                )
+            }
+
+            CompositionLocalProvider(LocalDensity provides scaledDensity) {
             BoxWithConstraints(
                 modifier =
                     Modifier
@@ -756,8 +778,9 @@ class MainActivity : ComponentActivity() {
                     }
 
                 val isLandscape = configuration.containerDpSize.width > configuration.containerDpSize.height
+                val isTablet = realScreenWidthDp >= 600
 
-                val showRail = isLandscape && !inSearchScreen
+                val showRail = (isLandscape || isTablet) && !inSearchScreen
 
                 val navPadding =
                     if (shouldShowNavigationBar && !showRail) {
@@ -1366,6 +1389,7 @@ class MainActivity : ComponentActivity() {
                         }
                     }
                 }
+            }
             }
         }
     }

--- a/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
@@ -644,14 +644,14 @@ class MainActivity : ComponentActivity() {
             themeColor = themeColor,
         ) {
             val currentDensity = LocalDensity.current
-            val realConfig = LocalConfiguration.current
-            val realScreenWidthDp = realConfig.screenWidthDp
+            val windowInfo = LocalWindowInfo.current
+            val containerWidthDp = windowInfo.containerDpSize.width
 
-            val densityScale = remember(realScreenWidthDp) {
+            val densityScale = remember(containerWidthDp) {
                 when {
-                    realScreenWidthDp >= 840 -> 1.25f
-                    realScreenWidthDp >= 720 -> 1.15f
-                    realScreenWidthDp >= 600 -> 1.1f
+                    containerWidthDp >= 840.dp -> 1.25f
+                    containerWidthDp >= 720.dp -> 1.15f
+                    containerWidthDp >= 600.dp -> 1.1f
                     else -> 1.0f
                 }
             }
@@ -778,7 +778,7 @@ class MainActivity : ComponentActivity() {
                     }
 
                 val isLandscape = configuration.containerDpSize.width > configuration.containerDpSize.height
-                val isTablet = realScreenWidthDp >= 600
+                val isTablet = configuration.containerDpSize.width >= 600.dp
 
                 val showRail = (isLandscape || isTablet) && !inSearchScreen
 


### PR DESCRIPTION
## Problem
Icons, menu, text and everything looks very small when Metrolist is installed on a tablet or phablet (≥7" screens). The app has zero tablet awareness — no WindowSizeClass, no density adaptation, no sw600dp qualifiers, and layout grids hardcoded for phone-width screens (~412dp).

## Cause
All Compose layouts use fixed dp values designed for phones. On tablets (600-950dp wide) the same dp values produce UI elements that are proportionally tiny because they occupy a smaller fraction of the larger screen. The only adaptive UI was a landscape check that toggles bottom nav ↔ rail; there was no detection of tablet-sized screens at all.

## Solution
- Added automatic Density scaling via CompositionLocalProvider(LocalDensity provides scaledDensity) in MetrolistApp — the entire Compose tree gets a proportional density multiplier based on the real screen width:
  - <600dp → scale 1.0× (phone, unchanged)
  - 600-720dp → scale 1.1× (phablet/small tablet)
  - 720-840dp → scale 1.15× (medium tablet)
  - ≥840dp → scale 1.25× (large tablet)
- Added isTablet detection (≥600dp) and changed the navigation rail logic to show AppNavigationRail on tablets in portrait mode, not just landscape — matching Material 3 guidelines for expandable navigation.
- Added android:resizeableActivity="true" to the main activity in the manifest for proper multi-window and desktop-mode support on tablets and Chromebooks.

## Testing
- Built successfully with ./gradlew :app:assembleFossDebug (no compilation errors, no new warnings).
- Tested on emulator: Pixel C (tablet) shows properly scaled UI with navigation rail in portrait; Pixel 6 (phone) shows no change from previous behavior.

## Related Issues
- Closes https://github.com/MetrolistGroup/Metrolist/issues/2338
- Related to https://github.com/MetrolistGroup/Metrolist/issues/2909

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App now supports resizing on compatible Android devices.
  * Navigation rail now displays on tablets and landscape orientation (excluding search screen) for improved layout support.

* **Bug Fixes**
  * Fixed UI composition structure issue.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MetrolistGroup/Metrolist/pull/3793?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->