### PR TITLE
fix(player): Fix random playback pauses

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -708,11 +708,11 @@ class MusicService :
                     // Skip reload on first emit (app startup)
                     if (isFirstQualityEmit) {
                         isFirstQualityEmit = false
-                        Timber.tag("MusicService").i("QUALITY INIT: $newQuality")
+                        Timber.tag(TAG).i("QUALITY INIT: $newQuality")
                         return@collect
                     }
 
-                    Timber.tag("MusicService").i("QUALITY CHANGED: $oldQuality -> $newQuality")
+                    Timber.tag(TAG).i("QUALITY CHANGED: $oldQuality -> $newQuality")
 
                     // Reload current song with new quality
                     val mediaId = player.currentMediaItem?.mediaId ?: return@collect
@@ -720,7 +720,7 @@ class MusicService :
                     val wasPlaying = player.isPlaying
                     val currentIndex = player.currentMediaItemIndex
 
-                    Timber.tag("MusicService").i("RELOADING STREAM: $mediaId at position ${currentPosition}ms")
+                    Timber.tag(TAG).i("RELOADING STREAM: $mediaId at position ${currentPosition}ms")
 
                     // Clear cached URL to force fresh fetch
                     songUrlCache.remove(mediaId)
@@ -730,15 +730,15 @@ class MusicService :
                         try {
                             playerCache.removeResource(mediaId)
                             downloadCache.removeResource(mediaId)
-                            Timber.tag("MusicService").d("Cleared player and download cache for $mediaId")
+                            Timber.tag(TAG).d("Cleared player and download cache for $mediaId")
                         } catch (e: Exception) {
-                            Timber.tag("MusicService").e(e, "Failed to clear cache for $mediaId")
+                            Timber.tag(TAG).e(e, "Failed to clear cache for $mediaId")
                         }
                     }
 
                     // Set bypass flag so resolver skips cache checks
                     bypassCacheForQualityChange.add(mediaId)
-                    Timber.tag("MusicService").d("Set bypass cache flag for $mediaId")
+                    Timber.tag(TAG).d("Set bypass cache flag for $mediaId")
 
                     // Reload player at same position
                     player.stop()
@@ -3358,7 +3358,7 @@ class MusicService :
                         scope.launch(Dispatchers.IO) { recoverSong(mediaId) }
                         return@Factory dataSpec.withUri(url.toUri())
                     }
-                    Timber.tag("MusicService").w("Ghost cache entry for $mediaId, re-fetching")
+                    Timber.tag(TAG).w("Ghost cache entry for $mediaId, re-fetching")
                     playerCache.removeResource(mediaId)
                 }
 
@@ -3367,10 +3367,10 @@ class MusicService :
                     return@Factory dataSpec.withUri(it.first.toUri())
                 }
             } else {
-                Timber.tag("MusicService").i("BYPASSING CACHE for $mediaId due to quality change")
+                Timber.tag(TAG).i("BYPASSING CACHE for $mediaId due to quality change")
             }
 
-            Timber.tag("MusicService").i("FETCHING STREAM: $mediaId | quality=$audioQuality")
+            Timber.tag(TAG).i("FETCHING STREAM: $mediaId | quality=$audioQuality")
             val playbackData =
                 runBlocking(Dispatchers.IO) {
                     YTPlayerUtils.playerResponseForPlayback(
@@ -3446,7 +3446,7 @@ class MusicService :
 
                 // Clear bypass flag now that we've fetched fresh stream
                 if (bypassCacheForQualityChange.remove(mediaId)) {
-                    Timber.tag("MusicService").d("Cleared bypass cache flag for $mediaId after fresh fetch")
+                    Timber.tag(TAG).d("Cleared bypass cache flag for $mediaId after fresh fetch")
                 }
 
                 val streamUrl = nonNullPlayback.streamUrl

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -3043,8 +3043,6 @@ class MusicService :
         retryJob?.cancel()
         retryJob =
             scope.launch {
-                delay(RETRY_DELAY_MS)
-
                 val currentPosition = player.currentPosition
                 val currentIndex = player.currentMediaItemIndex
                 if (currentIndex == C.INDEX_UNSET) {
@@ -3319,7 +3317,9 @@ class MusicService :
             Timber.d("[ArtistFetch] Thumbnail from API: ${thumbnail != null}")
             
             if (thumbnail != null) {
-                database.update(artist.copy(thumbnailUrl = thumbnail))
+                withContext(Dispatchers.IO) {
+                    database.update(artist.copy(thumbnailUrl = thumbnail))
+                }
                 Timber.d("[ArtistFetch] Database updated with thumbnail")
                 val updatedSong = database.getSongById(song.song.id)
                 Timber.d("[ArtistFetch] Returning updated song")
@@ -3347,11 +3347,19 @@ class MusicService :
                         mediaId,
                         dataSpec.position,
                         if (dataSpec.length >= 0) dataSpec.length else 1,
-                    ) ||
-                    (usePlayerCache && playerCache.isCached(mediaId, dataSpec.position, CHUNK_LENGTH))
+                    )
                 ) {
                     scope.launch(Dispatchers.IO) { recoverSong(mediaId) }
                     return@Factory dataSpec
+                }
+
+                if (usePlayerCache && playerCache.isCached(mediaId, dataSpec.position, CHUNK_LENGTH)) {
+                    songUrlCache[mediaId]?.takeIf { it.second > System.currentTimeMillis() }?.let { (url, _) ->
+                        scope.launch(Dispatchers.IO) { recoverSong(mediaId) }
+                        return@Factory dataSpec.withUri(url.toUri())
+                    }
+                    Timber.tag("MusicService").w("Ghost cache entry for $mediaId, re-fetching")
+                    playerCache.removeResource(mediaId)
                 }
 
                 songUrlCache[mediaId]?.takeIf { it.second > System.currentTimeMillis() }?.let {


### PR DESCRIPTION
## Problem
Users are experiencing random playback pauses (auto-pausing) followed by long resume delays (2-3 seconds) on Android 16. This severely disrupts the listening experience.

## Expected behavior:
- Playback should be continuous without random interruptions.
- Resuming playback after any pause should be near-instant (< 0.5s).

## Actual behavior:
- The player stops randomly even when the device is not being touched.
- Significant delay occurs while the app "re-fetches" the stream after pausing.

## Cause
- An unnecessary delay(RETRY_DELAY_MS) was being applied before retrying playback after an error/pause.
- "Ghost cache" entries in playerCache (where the cache thinks a resource is available but the URL has expired or become invalid) were not being properly detected and cleared, causing the player to attempt to play from stale cache data before falling back.

## Solution
- Removed the unnecessary retry delay that was artificially slowing down recovery.
- Improved ghost cache detection and handling in the data source factory:
  - Better logic to identify when a cached entry is invalid/expired.
  - Immediately remove the problematic cache resource and force a fresh stream fetch.
- Standardized Timber logging tags in MusicService for better debuggability.

## Testing
- Tested on my S25 for an hour with the exact symptoms reported.
- Verified that random pauses no longer occur and that resuming is now near-instant.

## Related Issues
Closes #3798 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio stream quality switching with enhanced cache management to prevent serving stale data.
  * Faster recovery when audio files become temporarily unavailable, with more efficient retry handling.

* **Performance**
  * Enhanced caching mechanisms for podcast content with better recovery and reliability features.
  * Optimized database operations for improved application responsiveness and overall system efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MetrolistGroup/Metrolist/pull/3802?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->