### PR TITLE
fix(artist): split conjunctions correctly, resolve missing IDs, make artists clickable

### DIFF
--- a/app/schemas/com.metrolist.music.db.InternalDatabase/38.json
+++ b/app/schemas/com.metrolist.music.db.InternalDatabase/38.json
@@ -1,0 +1,1368 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 38,
+    "identityHash": "bcf76ed36a3cb785f239e5cfbd28440e",
+    "entities": [
+      {
+        "tableName": "song",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `duration` INTEGER NOT NULL, `thumbnailUrl` TEXT, `albumId` TEXT, `albumName` TEXT, `explicit` INTEGER NOT NULL DEFAULT 0, `year` INTEGER, `date` INTEGER, `dateModified` INTEGER, `liked` INTEGER NOT NULL, `likedDate` INTEGER, `totalPlayTime` INTEGER NOT NULL, `inLibrary` INTEGER, `dateDownload` INTEGER, `isLocal` INTEGER NOT NULL DEFAULT false, `libraryAddToken` TEXT, `libraryRemoveToken` TEXT, `lyricsOffset` INTEGER NOT NULL DEFAULT 0, `romanizeLyrics` INTEGER NOT NULL DEFAULT true, `isDownloaded` INTEGER NOT NULL DEFAULT 0, `isUploaded` INTEGER NOT NULL DEFAULT false, `isVideo` INTEGER NOT NULL DEFAULT false, `isEpisode` INTEGER NOT NULL DEFAULT false, `playbackPosition` INTEGER DEFAULT NULL, `uploadEntityId` TEXT DEFAULT NULL, `isCached` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumName",
+            "columnName": "albumName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "explicit",
+            "columnName": "explicit",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "dateModified",
+            "columnName": "dateModified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "liked",
+            "columnName": "liked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "likedDate",
+            "columnName": "likedDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalPlayTime",
+            "columnName": "totalPlayTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inLibrary",
+            "columnName": "inLibrary",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "dateDownload",
+            "columnName": "dateDownload",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isLocal",
+            "columnName": "isLocal",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "libraryAddToken",
+            "columnName": "libraryAddToken",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "libraryRemoveToken",
+            "columnName": "libraryRemoveToken",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lyricsOffset",
+            "columnName": "lyricsOffset",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "romanizeLyrics",
+            "columnName": "romanizeLyrics",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "isDownloaded",
+            "columnName": "isDownloaded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isUploaded",
+            "columnName": "isUploaded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "isVideo",
+            "columnName": "isVideo",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "isEpisode",
+            "columnName": "isEpisode",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "playbackPosition",
+            "columnName": "playbackPosition",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "uploadEntityId",
+            "columnName": "uploadEntityId",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "isCached",
+            "columnName": "isCached",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_song_albumId",
+            "unique": false,
+            "columnNames": [
+              "albumId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_albumId` ON `${TABLE_NAME}` (`albumId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "artist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `thumbnailUrl` TEXT, `channelId` TEXT, `lastUpdateTime` INTEGER NOT NULL, `bookmarkedAt` INTEGER, `isLocal` INTEGER NOT NULL DEFAULT false, `isPodcastChannel` INTEGER NOT NULL DEFAULT false, `cachedPageJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "lastUpdateTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkedAt",
+            "columnName": "bookmarkedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isLocal",
+            "columnName": "isLocal",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "isPodcastChannel",
+            "columnName": "isPodcastChannel",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "cachedPageJson",
+            "columnName": "cachedPageJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "album",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `playlistId` TEXT, `title` TEXT NOT NULL, `year` INTEGER, `thumbnailUrl` TEXT, `themeColor` INTEGER, `songCount` INTEGER NOT NULL, `duration` INTEGER NOT NULL, `explicit` INTEGER NOT NULL DEFAULT 0, `lastUpdateTime` INTEGER NOT NULL, `bookmarkedAt` INTEGER, `likedDate` INTEGER, `inLibrary` INTEGER, `isLocal` INTEGER NOT NULL DEFAULT false, `isUploaded` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "themeColor",
+            "columnName": "themeColor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "songCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "explicit",
+            "columnName": "explicit",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "lastUpdateTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkedAt",
+            "columnName": "bookmarkedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "likedDate",
+            "columnName": "likedDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "inLibrary",
+            "columnName": "inLibrary",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isLocal",
+            "columnName": "isLocal",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "isUploaded",
+            "columnName": "isUploaded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `browseId` TEXT, `createdAt` INTEGER, `lastUpdateTime` INTEGER, `isEditable` INTEGER NOT NULL DEFAULT true, `bookmarkedAt` INTEGER, `remoteSongCount` INTEGER, `playEndpointParams` TEXT, `thumbnailUrl` TEXT, `shuffleEndpointParams` TEXT, `radioEndpointParams` TEXT, `isLocal` INTEGER NOT NULL DEFAULT false, `isAutoSync` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browseId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "lastUpdateTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isEditable",
+            "columnName": "isEditable",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "bookmarkedAt",
+            "columnName": "bookmarkedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "remoteSongCount",
+            "columnName": "remoteSongCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playEndpointParams",
+            "columnName": "playEndpointParams",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shuffleEndpointParams",
+            "columnName": "shuffleEndpointParams",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "radioEndpointParams",
+            "columnName": "radioEndpointParams",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isLocal",
+            "columnName": "isLocal",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "isAutoSync",
+            "columnName": "isAutoSync",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "song_artist_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`songId` TEXT NOT NULL, `artistId` TEXT NOT NULL, `position` INTEGER NOT NULL, PRIMARY KEY(`songId`, `artistId`), FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`artistId`) REFERENCES `artist`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "songId",
+            "artistId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_song_artist_map_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_artist_map_songId` ON `${TABLE_NAME}` (`songId`)"
+          },
+          {
+            "name": "index_song_artist_map_artistId",
+            "unique": false,
+            "columnNames": [
+              "artistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_artist_map_artistId` ON `${TABLE_NAME}` (`artistId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "artist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "artistId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "song_album_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`songId` TEXT NOT NULL, `albumId` TEXT NOT NULL, `index` INTEGER NOT NULL, PRIMARY KEY(`songId`, `albumId`), FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`albumId`) REFERENCES `album`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "songId",
+            "albumId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_song_album_map_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_album_map_songId` ON `${TABLE_NAME}` (`songId`)"
+          },
+          {
+            "name": "index_song_album_map_albumId",
+            "unique": false,
+            "columnNames": [
+              "albumId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_album_map_albumId` ON `${TABLE_NAME}` (`albumId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "album",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "albumId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "album_artist_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`albumId` TEXT NOT NULL, `artistId` TEXT NOT NULL, `order` INTEGER NOT NULL, PRIMARY KEY(`albumId`, `artistId`), FOREIGN KEY(`albumId`) REFERENCES `album`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`artistId`) REFERENCES `artist`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "albumId",
+            "artistId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_album_artist_map_albumId",
+            "unique": false,
+            "columnNames": [
+              "albumId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_album_artist_map_albumId` ON `${TABLE_NAME}` (`albumId`)"
+          },
+          {
+            "name": "index_album_artist_map_artistId",
+            "unique": false,
+            "columnNames": [
+              "artistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_album_artist_map_artistId` ON `${TABLE_NAME}` (`artistId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "album",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "albumId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "artist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "artistId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_song_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `playlistId` TEXT NOT NULL, `songId` TEXT NOT NULL, `position` INTEGER NOT NULL, `setVideoId` TEXT, FOREIGN KEY(`playlistId`) REFERENCES `playlist`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "setVideoId",
+            "columnName": "setVideoId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_song_map_playlistId",
+            "unique": false,
+            "columnNames": [
+              "playlistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_song_map_playlistId` ON `${TABLE_NAME}` (`playlistId`)"
+          },
+          {
+            "name": "index_playlist_song_map_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_song_map_songId` ON `${TABLE_NAME}` (`songId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlistId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `query` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_search_history_query",
+            "unique": true,
+            "columnNames": [
+              "query"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_query` ON `${TABLE_NAME}` (`query`)"
+          }
+        ]
+      },
+      {
+        "tableName": "format",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `itag` INTEGER NOT NULL, `mimeType` TEXT NOT NULL, `codecs` TEXT NOT NULL, `bitrate` INTEGER NOT NULL, `sampleRate` INTEGER, `contentLength` INTEGER NOT NULL, `loudnessDb` REAL, `perceptualLoudnessDb` REAL, `playbackUrl` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itag",
+            "columnName": "itag",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mimeType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "codecs",
+            "columnName": "codecs",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bitrate",
+            "columnName": "bitrate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sampleRate",
+            "columnName": "sampleRate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "contentLength",
+            "columnName": "contentLength",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "loudnessDb",
+            "columnName": "loudnessDb",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "perceptualLoudnessDb",
+            "columnName": "perceptualLoudnessDb",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "playbackUrl",
+            "columnName": "playbackUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lyrics",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `lyrics` TEXT NOT NULL, `provider` TEXT NOT NULL DEFAULT 'Unknown', `translatedLyrics` TEXT NOT NULL DEFAULT '', `translationLanguage` TEXT NOT NULL DEFAULT '', `translationMode` TEXT NOT NULL DEFAULT '', PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lyrics",
+            "columnName": "lyrics",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Unknown'"
+          },
+          {
+            "fieldPath": "translatedLyrics",
+            "columnName": "translatedLyrics",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "translationLanguage",
+            "columnName": "translationLanguage",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "translationMode",
+            "columnName": "translationMode",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "event",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `songId` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `playTime` INTEGER NOT NULL, FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playTime",
+            "columnName": "playTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_event_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_event_songId` ON `${TABLE_NAME}` (`songId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "related_song_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `songId` TEXT NOT NULL, `relatedSongId` TEXT NOT NULL, FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`relatedSongId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "relatedSongId",
+            "columnName": "relatedSongId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_related_song_map_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_related_song_map_songId` ON `${TABLE_NAME}` (`songId`)"
+          },
+          {
+            "name": "index_related_song_map_relatedSongId",
+            "unique": false,
+            "columnNames": [
+              "relatedSongId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_related_song_map_relatedSongId` ON `${TABLE_NAME}` (`relatedSongId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "relatedSongId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "set_video_id",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`videoId` TEXT NOT NULL, `setVideoId` TEXT, PRIMARY KEY(`videoId`))",
+        "fields": [
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "setVideoId",
+            "columnName": "setVideoId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "videoId"
+          ]
+        }
+      },
+      {
+        "tableName": "playCount",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`song` TEXT NOT NULL, `year` INTEGER NOT NULL, `month` INTEGER NOT NULL, `count` INTEGER NOT NULL, PRIMARY KEY(`song`, `year`, `month`))",
+        "fields": [
+          {
+            "fieldPath": "song",
+            "columnName": "song",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "song",
+            "year",
+            "month"
+          ]
+        }
+      },
+      {
+        "tableName": "recognition_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `trackId` TEXT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT, `coverArtUrl` TEXT, `coverArtHqUrl` TEXT, `genre` TEXT, `releaseDate` TEXT, `label` TEXT, `shazamUrl` TEXT, `appleMusicUrl` TEXT, `spotifyUrl` TEXT, `isrc` TEXT, `youtubeVideoId` TEXT, `recognizedAt` INTEGER NOT NULL, `liked` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "trackId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtUrl",
+            "columnName": "coverArtUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtHqUrl",
+            "columnName": "coverArtHqUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "releaseDate",
+            "columnName": "releaseDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shazamUrl",
+            "columnName": "shazamUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "appleMusicUrl",
+            "columnName": "appleMusicUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "spotifyUrl",
+            "columnName": "spotifyUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isrc",
+            "columnName": "isrc",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "youtubeVideoId",
+            "columnName": "youtubeVideoId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "recognizedAt",
+            "columnName": "recognizedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "liked",
+            "columnName": "liked",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_recognition_history_trackId",
+            "unique": false,
+            "columnNames": [
+              "trackId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recognition_history_trackId` ON `${TABLE_NAME}` (`trackId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "speed_dial_item",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `secondaryId` TEXT, `title` TEXT NOT NULL, `subtitle` TEXT, `subtitleIds` TEXT, `thumbnailUrl` TEXT, `type` TEXT NOT NULL, `explicit` INTEGER NOT NULL, `createDate` INTEGER NOT NULL, `albumId` TEXT, `albumName` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "secondaryId",
+            "columnName": "secondaryId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitleIds",
+            "columnName": "subtitleIds",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "explicit",
+            "columnName": "explicit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createDate",
+            "columnName": "createDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumName",
+            "columnName": "albumName",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "podcast",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT, `thumbnailUrl` TEXT, `channelId` TEXT, `bookmarkedAt` INTEGER, `lastUpdateTime` INTEGER NOT NULL, `libraryAddToken` TEXT, `libraryRemoveToken` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookmarkedAt",
+            "columnName": "bookmarkedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "lastUpdateTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryAddToken",
+            "columnName": "libraryAddToken",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "libraryRemoveToken",
+            "columnName": "libraryRemoveToken",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "views": [
+      {
+        "viewName": "sorted_song_artist_map",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT * FROM song_artist_map ORDER BY position"
+      },
+      {
+        "viewName": "sorted_song_album_map",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT * FROM song_album_map ORDER BY `index`"
+      },
+      {
+        "viewName": "playlist_song_map_preview",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT * FROM playlist_song_map WHERE position <= 3 ORDER BY position"
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'bcf76ed36a3cb785f239e5cfbd28440e')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
@@ -112,6 +112,7 @@ import androidx.lifecycle.coroutineScope
 import androidx.lifecycle.lifecycleScope
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
+import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -990,6 +991,7 @@ class MainActivity : ComponentActivity() {
 
                 CompositionLocalProvider(
                     LocalDatabase provides database,
+                    LocalNavController provides navController,
                     LocalContentColor provides if (pureBlack) Color.White else contentColorFor(MaterialTheme.colorScheme.surface),
                     LocalPlayerConnection provides playerConnection,
                     LocalPlayerAwareWindowInsets provides playerAwareWindowInsets,
@@ -1361,7 +1363,6 @@ class MainActivity : ComponentActivity() {
 
                     if (showAccountDialog) {
                         AccountSettingsDialog(
-                            navController = navController,
                             onDismiss = {
                                 showAccountDialog = false
                                 homeViewModel.refresh()
@@ -1387,7 +1388,6 @@ class MainActivity : ComponentActivity() {
                                     ) {
                                         YouTubeSongMenu(
                                             song = song,
-                                            navController = navController,
                                             onDismiss = { sharedSong = null },
                                         )
                                     }
@@ -1587,6 +1587,7 @@ class MainActivity : ComponentActivity() {
 }
 
 val LocalDatabase = staticCompositionLocalOf<MusicDatabase> { error("No database provided") }
+val LocalNavController = staticCompositionLocalOf<NavController> { error("No NavController provided") }
 val LocalPlayerConnection = staticCompositionLocalOf<PlayerConnection?> { error("No PlayerConnection provided") }
 val LocalPlayerAwareWindowInsets = compositionLocalOf<WindowInsets> { error("No WindowInsets provided") }
 val LocalDownloadUtil = staticCompositionLocalOf<DownloadUtil> { error("No DownloadUtil provided") }

--- a/app/src/main/kotlin/com/metrolist/music/db/MusicDatabase.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/MusicDatabase.kt
@@ -118,7 +118,7 @@ class MusicDatabase(
         SortedSongAlbumMap::class,
         PlaylistSongMapPreview::class,
     ],
-    version = 37,
+    version = 38,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 2, to = 3),
@@ -156,6 +156,7 @@ class MusicDatabase(
         AutoMigration(from = 34, to = 35),
         AutoMigration(from = 35, to = 36, spec = Migration35To36::class),
         AutoMigration(from = 36, to = 37),
+        AutoMigration(from = 37, to = 38),
     ],
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/ArtistEntity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/ArtistEntity.kt
@@ -28,7 +28,9 @@ data class ArtistEntity(
     @ColumnInfo(name = "isLocal", defaultValue = false.toString())
     val isLocal: Boolean = false,
     @ColumnInfo(name = "isPodcastChannel", defaultValue = false.toString())
-    val isPodcastChannel: Boolean = false
+    val isPodcastChannel: Boolean = false,
+    @ColumnInfo(name = "cachedPageJson")
+    val cachedPageJson: String? = null
 ) {
     val isYouTubeArtist: Boolean
         get() = id.startsWith("UC") || id.startsWith("FEmusic_library_privately_owned_artist")

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/ArtistPageCache.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/ArtistPageCache.kt
@@ -1,0 +1,278 @@
+package com.metrolist.music.db.entities
+
+import com.metrolist.innertube.models.ArtistItem
+import com.metrolist.innertube.models.AlbumItem
+import com.metrolist.innertube.models.EpisodeItem
+import com.metrolist.innertube.models.PlaylistItem
+import com.metrolist.innertube.models.PodcastItem
+import com.metrolist.innertube.models.SongItem
+import com.metrolist.innertube.models.YTItem
+import com.metrolist.innertube.pages.ArtistSection
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+private val json = Json {
+    ignoreUnknownKeys = true
+    explicitNulls = false
+    encodeDefaults = true
+}
+
+@Serializable
+data class CachedArtistPage(
+    val artist: CachedArtistItem? = null,
+    val sections: List<CachedSection>,
+    val description: String? = null,
+    val subscriberCountText: String? = null,
+    val monthlyListenerCount: String? = null,
+    val isSubscribed: Boolean = false,
+)
+
+@Serializable
+data class CachedArtistItem(
+    val id: String,
+    val title: String,
+    val thumbnail: String? = null,
+    val channelId: String? = null,
+    val isProfile: Boolean = false,
+)
+
+@Serializable
+data class CachedSection(
+    val title: String,
+    val items: List<CachedItem>,
+    val moreBrowseId: String? = null,
+    val moreParams: String? = null,
+)
+
+@Serializable
+data class CachedItem(
+    val id: String,
+    val title: String,
+    val thumbnail: String,
+    val type: String,
+    val explicit: Boolean = false,
+    val artists: List<CachedArtist> = emptyList(),
+    val album: CachedAlbum? = null,
+    val duration: Int? = null,
+    val year: Int? = null,
+    val songCountText: String? = null,
+    val author: CachedArtist? = null,
+    val channelId: String? = null,
+    val browseId: String? = null,
+    val playlistId: String? = null,
+    val authorAvatarUrl: String? = null,
+    val episodeCountText: String? = null,
+    val videoId: String? = null,
+)
+
+@Serializable
+data class CachedArtist(val name: String, val id: String? = null)
+
+@Serializable
+data class CachedAlbum(val name: String, val id: String)
+
+fun serializeArtistPage(
+    sections: List<ArtistSection>,
+    description: String?,
+    subscriberCountText: String?,
+    monthlyListenerCount: String?,
+    isSubscribed: Boolean,
+    artist: com.metrolist.innertube.models.ArtistItem? = null,
+): String {
+    val cached = CachedArtistPage(
+        artist = artist?.let { CachedArtistItem(it.id, it.title, it.thumbnail, it.channelId, it.isProfile) },
+        sections = sections.map { section ->
+            CachedSection(
+                title = section.title,
+                items = section.items.map { item -> item.toCachedItem() },
+                moreBrowseId = section.moreEndpoint?.browseId,
+                moreParams = section.moreEndpoint?.params,
+            )
+        },
+        description = description,
+        subscriberCountText = subscriberCountText,
+        monthlyListenerCount = monthlyListenerCount,
+        isSubscribed = isSubscribed,
+    )
+    return json.encodeToString(cached)
+}
+
+fun deserializeArtistPage(jsonString: String): CachedArtistPage {
+    return json.decodeFromString(jsonString)
+}
+
+fun CachedArtistPage.toArtistPage(): com.metrolist.innertube.pages.ArtistPage {
+    return com.metrolist.innertube.pages.ArtistPage(
+        artist = artist?.let { cached ->
+            com.metrolist.innertube.models.ArtistItem(
+                id = cached.id,
+                title = cached.title,
+                thumbnail = cached.thumbnail,
+                channelId = cached.channelId,
+                playEndpoint = null,
+                shuffleEndpoint = null,
+                radioEndpoint = null,
+                isProfile = cached.isProfile,
+            )
+        } ?: com.metrolist.innertube.models.ArtistItem(
+            id = "",
+            title = "",
+            thumbnail = null,
+            shuffleEndpoint = null,
+            radioEndpoint = null,
+        ),
+        sections = sections.map { section ->
+            ArtistSection(
+                title = section.title,
+                items = section.items.map { it.toYTItem() },
+                moreEndpoint = section.moreBrowseId?.let { browseId ->
+                    com.metrolist.innertube.models.BrowseEndpoint(
+                        browseId = browseId,
+                        params = section.moreParams,
+                    )
+                },
+            )
+        },
+        description = description,
+        subscriberCountText = subscriberCountText,
+        monthlyListenerCount = monthlyListenerCount,
+        isSubscribed = isSubscribed,
+    )
+}
+
+private fun CachedItem.toYTItem(): YTItem {
+    return when (type) {
+        "song" -> SongItem(
+            id = id,
+            title = title,
+            thumbnail = thumbnail,
+            explicit = explicit,
+            artists = artists.map { com.metrolist.innertube.models.Artist(it.name, it.id) },
+            album = album?.let { com.metrolist.innertube.models.Album(it.name, it.id) },
+            duration = duration ?: 0,
+            setVideoId = videoId,
+        )
+        "album" -> AlbumItem(
+            browseId = browseId ?: id,
+            playlistId = playlistId ?: id,
+            id = id,
+            title = title,
+            thumbnail = thumbnail,
+            explicit = explicit,
+            artists = artists.map { com.metrolist.innertube.models.Artist(it.name, it.id) }.ifEmpty { null },
+            year = year,
+        )
+        "playlist" -> PlaylistItem(
+            id = id,
+            title = title,
+            thumbnail = thumbnail,
+            author = author?.let { com.metrolist.innertube.models.Artist(it.name, it.id) },
+            songCountText = songCountText,
+            playEndpoint = null,
+            shuffleEndpoint = null,
+            radioEndpoint = null,
+            authorAvatarUrl = authorAvatarUrl,
+        )
+        "artist" -> ArtistItem(
+            id = id,
+            title = title,
+            thumbnail = thumbnail,
+            channelId = channelId,
+            playEndpoint = null,
+            shuffleEndpoint = null,
+            radioEndpoint = null,
+        )
+        "podcast" -> PodcastItem(
+            id = id,
+            title = title,
+            thumbnail = thumbnail,
+            author = author?.let { com.metrolist.innertube.models.Artist(it.name, it.id) },
+            episodeCountText = episodeCountText,
+            playEndpoint = null,
+            shuffleEndpoint = null,
+            channelId = channelId,
+        )
+        "episode" -> EpisodeItem(
+            id = id,
+            title = title,
+            thumbnail = thumbnail,
+            explicit = explicit,
+            author = author?.let { com.metrolist.innertube.models.Artist(it.name, it.id) },
+            podcast = album?.let { com.metrolist.innertube.models.Album(it.name, it.id) },
+            duration = duration,
+            endpoint = null,
+        )
+        else -> SongItem(
+            id = id,
+            title = title,
+            thumbnail = thumbnail,
+            explicit = explicit,
+            artists = artists.map { com.metrolist.innertube.models.Artist(it.name, it.id) },
+            album = album?.let { com.metrolist.innertube.models.Album(it.name, it.id) },
+            duration = duration ?: 0,
+        )
+    }
+}
+
+private fun YTItem.toCachedItem(): CachedItem {
+    return when (this) {
+        is SongItem -> CachedItem(
+            id = id,
+            title = title,
+            thumbnail = thumbnail,
+            type = "song",
+            explicit = explicit,
+            artists = artists.map { CachedArtist(it.name, it.id) },
+            album = album?.let { CachedAlbum(it.name, it.id) },
+            duration = duration,
+            videoId = setVideoId,
+        )
+        is AlbumItem -> CachedItem(
+            id = id,
+            title = title,
+            thumbnail = thumbnail,
+            type = "album",
+            explicit = explicit,
+            artists = artists?.map { CachedArtist(it.name, it.id) } ?: emptyList(),
+            year = year,
+            browseId = browseId,
+            playlistId = playlistId,
+        )
+        is PlaylistItem -> CachedItem(
+            id = id,
+            title = title,
+            thumbnail = thumbnail ?: "",
+            type = "playlist",
+            author = author?.let { CachedArtist(it.name, it.id) },
+            songCountText = songCountText,
+            authorAvatarUrl = authorAvatarUrl,
+        )
+        is ArtistItem -> CachedItem(
+            id = id,
+            title = title,
+            thumbnail = thumbnail ?: "",
+            type = "artist",
+            channelId = channelId,
+        )
+        is PodcastItem -> CachedItem(
+            id = id,
+            title = title,
+            thumbnail = thumbnail ?: "",
+            type = "podcast",
+            author = author?.let { CachedArtist(it.name, it.id) },
+            episodeCountText = episodeCountText,
+            channelId = channelId,
+        )
+        is EpisodeItem -> CachedItem(
+            id = id,
+            title = title,
+            thumbnail = thumbnail,
+            type = "episode",
+            explicit = explicit,
+            author = author?.let { CachedArtist(it.name, it.id) },
+            album = podcast?.let { CachedAlbum(it.name, it.id) },
+            duration = duration,
+        )
+    }
+}

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/ArtistPageCache.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/ArtistPageCache.kt
@@ -166,7 +166,7 @@ private fun CachedItem.toYTItem(): YTItem {
         "playlist" -> PlaylistItem(
             id = id,
             title = title,
-            thumbnail = thumbnail,
+            thumbnail = thumbnail.takeIf { it.isNotBlank() },
             author = author?.let { com.metrolist.innertube.models.Artist(it.name, it.id) },
             songCountText = songCountText,
             playEndpoint = null,
@@ -177,7 +177,7 @@ private fun CachedItem.toYTItem(): YTItem {
         "artist" -> ArtistItem(
             id = id,
             title = title,
-            thumbnail = thumbnail,
+            thumbnail = thumbnail.takeIf { it.isNotBlank() },
             channelId = channelId,
             playEndpoint = null,
             shuffleEndpoint = null,
@@ -186,7 +186,7 @@ private fun CachedItem.toYTItem(): YTItem {
         "podcast" -> PodcastItem(
             id = id,
             title = title,
-            thumbnail = thumbnail,
+            thumbnail = thumbnail.takeIf { it.isNotBlank() },
             author = author?.let { com.metrolist.innertube.models.Artist(it.name, it.id) },
             episodeCountText = episodeCountText,
             playEndpoint = null,

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/ArtistPageCache.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/ArtistPageCache.kt
@@ -8,6 +8,7 @@ import com.metrolist.innertube.models.PodcastItem
 import com.metrolist.innertube.models.SongItem
 import com.metrolist.innertube.models.YTItem
 import com.metrolist.innertube.pages.ArtistSection
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -46,25 +47,76 @@ data class CachedSection(
 )
 
 @Serializable
-data class CachedItem(
-    val id: String,
-    val title: String,
-    val thumbnail: String,
-    val type: String,
-    val explicit: Boolean = false,
-    val artists: List<CachedArtist> = emptyList(),
-    val album: CachedAlbum? = null,
-    val duration: Int? = null,
-    val year: Int? = null,
-    val songCountText: String? = null,
-    val author: CachedArtist? = null,
-    val channelId: String? = null,
-    val browseId: String? = null,
-    val playlistId: String? = null,
-    val authorAvatarUrl: String? = null,
-    val episodeCountText: String? = null,
-    val videoId: String? = null,
-)
+sealed class CachedItem {
+    @Serializable
+    @SerialName("song")
+    data class Song(
+        val id: String,
+        val title: String,
+        val thumbnail: String,
+        val explicit: Boolean = false,
+        val artists: List<CachedArtist> = emptyList(),
+        val album: CachedAlbum? = null,
+        val duration: Int? = null,
+        val videoId: String? = null
+    ) : CachedItem()
+
+    @Serializable
+    @SerialName("album")
+    data class Album(
+        val id: String,
+        val title: String,
+        val thumbnail: String,
+        val explicit: Boolean = false,
+        val artists: List<CachedArtist> = emptyList(),
+        val year: Int? = null,
+        val browseId: String? = null,
+        val playlistId: String? = null
+    ) : CachedItem()
+
+    @Serializable
+    @SerialName("playlist")
+    data class Playlist(
+        val id: String,
+        val title: String,
+        val thumbnail: String,
+        val author: CachedArtist? = null,
+        val songCountText: String? = null,
+        val authorAvatarUrl: String? = null
+    ) : CachedItem()
+
+    @Serializable
+    @SerialName("artist")
+    data class Artist(
+        val id: String,
+        val title: String,
+        val thumbnail: String,
+        val channelId: String? = null
+    ) : CachedItem()
+
+    @Serializable
+    @SerialName("podcast")
+    data class Podcast(
+        val id: String,
+        val title: String,
+        val thumbnail: String,
+        val author: CachedArtist? = null,
+        val episodeCountText: String? = null,
+        val channelId: String? = null
+    ) : CachedItem()
+
+    @Serializable
+    @SerialName("episode")
+    data class Episode(
+        val id: String,
+        val title: String,
+        val thumbnail: String,
+        val explicit: Boolean = false,
+        val author: CachedArtist? = null,
+        val album: CachedAlbum? = null,
+        val duration: Int? = null
+    ) : CachedItem()
+}
 
 @Serializable
 data class CachedArtist(val name: String, val id: String? = null)
@@ -142,8 +194,8 @@ fun CachedArtistPage.toArtistPage(): com.metrolist.innertube.pages.ArtistPage {
 }
 
 private fun CachedItem.toYTItem(): YTItem {
-    return when (type) {
-        "song" -> SongItem(
+    return when (this) {
+        is CachedItem.Song -> SongItem(
             id = id,
             title = title,
             thumbnail = thumbnail,
@@ -153,7 +205,7 @@ private fun CachedItem.toYTItem(): YTItem {
             duration = duration ?: 0,
             setVideoId = videoId,
         )
-        "album" -> AlbumItem(
+        is CachedItem.Album -> AlbumItem(
             browseId = browseId ?: id,
             playlistId = playlistId ?: id,
             id = id,
@@ -163,7 +215,7 @@ private fun CachedItem.toYTItem(): YTItem {
             artists = artists.map { com.metrolist.innertube.models.Artist(it.name, it.id) }.ifEmpty { null },
             year = year,
         )
-        "playlist" -> PlaylistItem(
+        is CachedItem.Playlist -> PlaylistItem(
             id = id,
             title = title,
             thumbnail = thumbnail.takeIf { it.isNotBlank() },
@@ -174,7 +226,7 @@ private fun CachedItem.toYTItem(): YTItem {
             radioEndpoint = null,
             authorAvatarUrl = authorAvatarUrl,
         )
-        "artist" -> ArtistItem(
+        is CachedItem.Artist -> ArtistItem(
             id = id,
             title = title,
             thumbnail = thumbnail.takeIf { it.isNotBlank() },
@@ -183,7 +235,7 @@ private fun CachedItem.toYTItem(): YTItem {
             shuffleEndpoint = null,
             radioEndpoint = null,
         )
-        "podcast" -> PodcastItem(
+        is CachedItem.Podcast -> PodcastItem(
             id = id,
             title = title,
             thumbnail = thumbnail.takeIf { it.isNotBlank() },
@@ -193,7 +245,7 @@ private fun CachedItem.toYTItem(): YTItem {
             shuffleEndpoint = null,
             channelId = channelId,
         )
-        "episode" -> EpisodeItem(
+        is CachedItem.Episode -> EpisodeItem(
             id = id,
             title = title,
             thumbnail = thumbnail,
@@ -203,72 +255,57 @@ private fun CachedItem.toYTItem(): YTItem {
             duration = duration,
             endpoint = null,
         )
-        else -> SongItem(
-            id = id,
-            title = title,
-            thumbnail = thumbnail,
-            explicit = explicit,
-            artists = artists.map { com.metrolist.innertube.models.Artist(it.name, it.id) },
-            album = album?.let { com.metrolist.innertube.models.Album(it.name, it.id) },
-            duration = duration ?: 0,
-        )
     }
 }
 
 private fun YTItem.toCachedItem(): CachedItem {
     return when (this) {
-        is SongItem -> CachedItem(
+        is SongItem -> CachedItem.Song(
             id = id,
             title = title,
             thumbnail = thumbnail,
-            type = "song",
             explicit = explicit,
             artists = artists.map { CachedArtist(it.name, it.id) },
             album = album?.let { CachedAlbum(it.name, it.id) },
             duration = duration,
             videoId = setVideoId,
         )
-        is AlbumItem -> CachedItem(
+        is AlbumItem -> CachedItem.Album(
             id = id,
             title = title,
             thumbnail = thumbnail,
-            type = "album",
             explicit = explicit,
             artists = artists?.map { CachedArtist(it.name, it.id) } ?: emptyList(),
             year = year,
             browseId = browseId,
             playlistId = playlistId,
         )
-        is PlaylistItem -> CachedItem(
+        is PlaylistItem -> CachedItem.Playlist(
             id = id,
             title = title,
             thumbnail = thumbnail ?: "",
-            type = "playlist",
             author = author?.let { CachedArtist(it.name, it.id) },
             songCountText = songCountText,
             authorAvatarUrl = authorAvatarUrl,
         )
-        is ArtistItem -> CachedItem(
+        is ArtistItem -> CachedItem.Artist(
             id = id,
             title = title,
             thumbnail = thumbnail ?: "",
-            type = "artist",
             channelId = channelId,
         )
-        is PodcastItem -> CachedItem(
+        is PodcastItem -> CachedItem.Podcast(
             id = id,
             title = title,
             thumbnail = thumbnail ?: "",
-            type = "podcast",
             author = author?.let { CachedArtist(it.name, it.id) },
             episodeCountText = episodeCountText,
             channelId = channelId,
         )
-        is EpisodeItem -> CachedItem(
+        is EpisodeItem -> CachedItem.Episode(
             id = id,
             title = title,
             thumbnail = thumbnail,
-            type = "episode",
             explicit = explicit,
             author = author?.let { CachedArtist(it.name, it.id) },
             album = podcast?.let { CachedAlbum(it.name, it.id) },

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/SpeedDialItem.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/SpeedDialItem.kt
@@ -1,4 +1,5 @@
 package com.metrolist.music.db.entities
+import com.metrolist.music.utils.ARTIST_SEPARATOR
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
@@ -76,7 +77,7 @@ data class SpeedDialItem(
                 is SongItem -> SpeedDialItem(
                     id = item.id,
                     title = item.title,
-                    subtitle = item.artists.joinToString(", ") { it.name },
+                    subtitle = item.artists.joinToString(ARTIST_SEPARATOR) { it.name },
                     subtitleIds = item.artists.joinToString(", ") { it.id ?: "" },
                     thumbnailUrl = item.thumbnail,
                     type = "SONG",
@@ -88,7 +89,7 @@ data class SpeedDialItem(
                     id = item.browseId,
                     secondaryId = item.playlistId,
                     title = item.title,
-                    subtitle = item.artists?.joinToString(", ") { it.name },
+                    subtitle = item.artists?.joinToString(ARTIST_SEPARATOR) { it.name },
                     subtitleIds = item.artists?.joinToString(", ") { it.id ?: "" },
                     thumbnailUrl = item.thumbnail,
                     type = "ALBUM",

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/SpeedDialItem.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/SpeedDialItem.kt
@@ -1,5 +1,4 @@
 package com.metrolist.music.db.entities
-import com.metrolist.music.utils.ARTIST_SEPARATOR
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
@@ -26,13 +25,13 @@ data class SpeedDialItem(
     val albumId: String? = null,
     val albumName: String? = null
 ) {
-    fun toYTItem(): YTItem {
+    fun toYTItem(separator: String): YTItem {
         return when (type) {
             "SONG" -> SongItem(
                 id = id,
                 title = title,
-                artists = subtitle?.split(", ")?.mapIndexed { index, name ->
-                    Artist(name = name, id = subtitleIds?.split(", ")?.getOrNull(index))
+                artists = subtitle?.split(separator)?.mapIndexed { index, name ->
+                    Artist(name = name, id = subtitleIds?.split(separator)?.getOrNull(index))
                 } ?: emptyList(),
                 album = if (albumId != null && albumName != null) com.metrolist.innertube.models.Album(name = albumName, id = albumId) else null,
                 thumbnail = thumbnailUrl ?: "",
@@ -42,8 +41,8 @@ data class SpeedDialItem(
                 browseId = id,
                 playlistId = secondaryId ?: "",
                 title = title,
-                artists = subtitle?.split(", ")?.mapIndexed { index, name ->
-                    Artist(name = name, id = subtitleIds?.split(", ")?.getOrNull(index))
+                artists = subtitle?.split(separator)?.mapIndexed { index, name ->
+                    Artist(name = name, id = subtitleIds?.split(separator)?.getOrNull(index))
                 },
                 thumbnail = thumbnailUrl ?: "",
                 explicit = explicit
@@ -72,12 +71,12 @@ data class SpeedDialItem(
     }
 
     companion object {
-        fun fromYTItem(item: YTItem): SpeedDialItem {
+        fun fromYTItem(item: YTItem, separator: String): SpeedDialItem {
             return when (item) {
                 is SongItem -> SpeedDialItem(
                     id = item.id,
                     title = item.title,
-                    subtitle = item.artists.joinToString(ARTIST_SEPARATOR) { it.name },
+                    subtitle = item.artists.joinToString(separator) { it.name },
                     subtitleIds = item.artists.joinToString(", ") { it.id ?: "" },
                     thumbnailUrl = item.thumbnail,
                     type = "SONG",
@@ -89,7 +88,7 @@ data class SpeedDialItem(
                     id = item.browseId,
                     secondaryId = item.playlistId,
                     title = item.title,
-                    subtitle = item.artists?.joinToString(ARTIST_SEPARATOR) { it.name },
+                    subtitle = item.artists?.joinToString(separator) { it.name },
                     subtitleIds = item.artists?.joinToString(", ") { it.id ?: "" },
                     thumbnailUrl = item.thumbnail,
                     type = "ALBUM",

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/SpeedDialItem.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/SpeedDialItem.kt
@@ -25,13 +25,13 @@ data class SpeedDialItem(
     val albumId: String? = null,
     val albumName: String? = null
 ) {
-    fun toYTItem(separator: String): YTItem {
+    fun toYTItem(): YTItem {
         return when (type) {
             "SONG" -> SongItem(
                 id = id,
                 title = title,
-                artists = subtitle?.split(separator)?.mapIndexed { index, name ->
-                    Artist(name = name, id = subtitleIds?.split(separator)?.getOrNull(index))
+                artists = subtitle?.split(", ")?.mapIndexed { index, name ->
+                    Artist(name = name, id = subtitleIds?.split(", ")?.getOrNull(index))
                 } ?: emptyList(),
                 album = if (albumId != null && albumName != null) com.metrolist.innertube.models.Album(name = albumName, id = albumId) else null,
                 thumbnail = thumbnailUrl ?: "",
@@ -41,8 +41,8 @@ data class SpeedDialItem(
                 browseId = id,
                 playlistId = secondaryId ?: "",
                 title = title,
-                artists = subtitle?.split(separator)?.mapIndexed { index, name ->
-                    Artist(name = name, id = subtitleIds?.split(separator)?.getOrNull(index))
+                artists = subtitle?.split(", ")?.mapIndexed { index, name ->
+                    Artist(name = name, id = subtitleIds?.split(", ")?.getOrNull(index))
                 },
                 thumbnail = thumbnailUrl ?: "",
                 explicit = explicit
@@ -71,12 +71,12 @@ data class SpeedDialItem(
     }
 
     companion object {
-        fun fromYTItem(item: YTItem, separator: String): SpeedDialItem {
+        fun fromYTItem(item: YTItem): SpeedDialItem {
             return when (item) {
                 is SongItem -> SpeedDialItem(
                     id = item.id,
                     title = item.title,
-                    subtitle = item.artists.joinToString(separator) { it.name },
+                    subtitle = item.artists.joinToString(", ") { it.name },
                     subtitleIds = item.artists.joinToString(", ") { it.id ?: "" },
                     thumbnailUrl = item.thumbnail,
                     type = "SONG",
@@ -88,7 +88,7 @@ data class SpeedDialItem(
                     id = item.browseId,
                     secondaryId = item.playlistId,
                     title = item.title,
-                    subtitle = item.artists?.joinToString(separator) { it.name },
+                    subtitle = item.artists?.joinToString(", ") { it.name },
                     subtitleIds = item.artists?.joinToString(", ") { it.id ?: "" },
                     thumbnailUrl = item.thumbnail,
                     type = "ALBUM",

--- a/app/src/main/kotlin/com/metrolist/music/listentogether/ListenTogetherManager.kt
+++ b/app/src/main/kotlin/com/metrolist/music/listentogether/ListenTogetherManager.kt
@@ -21,6 +21,7 @@ import com.metrolist.music.models.toMediaMetadata
 import com.metrolist.music.playback.PlayerConnection
 import com.metrolist.music.playback.queues.YouTubeQueue
 import com.metrolist.music.utils.dataStore
+import com.metrolist.music.utils.getArtistSeparator
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -1719,11 +1720,11 @@ class ListenTogetherManager
             // Use a default duration of 3 minutes if duration is 0 or negative
             val durationMs = if (metadata.duration > 0) metadata.duration.toLong() * 1000 else 180000L
 
-            val trackInfo =
-                TrackInfo(
-                    id = metadata.id,
-                    title = metadata.title,
-                    artist = metadata.artists.joinToString(", ") { it.name },
+             val trackInfo =
+                 TrackInfo(
+                     id = metadata.id,
+                     title = metadata.title,
+                     artist = metadata.artists.joinToString(getArtistSeparator(context)) { it.name },
                     album = metadata.album?.title,
                     duration = durationMs,
                     thumbnail = metadata.thumbnailUrl,
@@ -1820,10 +1821,10 @@ class ListenTogetherManager
         private fun androidx.media3.common.Timeline.Window.toTrackInfo(): TrackInfo {
             val metadata = mediaItem.metadata ?: return TrackInfo("unknown", "Unknown", "Unknown", "", 0, "")
             val durationMs = if (metadata.duration > 0) metadata.duration.toLong() * 1000 else 180000L
-            return TrackInfo(
-                id = metadata.id,
-                title = metadata.title,
-                artist = metadata.artists.joinToString(", ") { it.name },
+             return TrackInfo(
+                 id = metadata.id,
+                 title = metadata.title,
+                 artist = metadata.artists.joinToString(getArtistSeparator(context)) { it.name },
                 album = metadata.album?.title,
                 duration = durationMs,
                 thumbnail = metadata.thumbnailUrl,

--- a/app/src/main/kotlin/com/metrolist/music/listentogether/ListenTogetherManager.kt
+++ b/app/src/main/kotlin/com/metrolist/music/listentogether/ListenTogetherManager.kt
@@ -5,6 +5,7 @@
 
 package com.metrolist.music.listentogether
 
+import com.metrolist.music.utils.ARTIST_SEPARATOR
 import android.content.Context
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
@@ -1723,7 +1724,7 @@ class ListenTogetherManager
                 TrackInfo(
                     id = metadata.id,
                     title = metadata.title,
-                    artist = metadata.artists.joinToString(", ") { it.name },
+                    artist = metadata.artists.joinToString(ARTIST_SEPARATOR) { it.name },
                     album = metadata.album?.title,
                     duration = durationMs,
                     thumbnail = metadata.thumbnailUrl,
@@ -1823,7 +1824,7 @@ class ListenTogetherManager
             return TrackInfo(
                 id = metadata.id,
                 title = metadata.title,
-                artist = metadata.artists.joinToString(", ") { it.name },
+                artist = metadata.artists.joinToString(ARTIST_SEPARATOR) { it.name },
                 album = metadata.album?.title,
                 duration = durationMs,
                 thumbnail = metadata.thumbnailUrl,

--- a/app/src/main/kotlin/com/metrolist/music/listentogether/ListenTogetherManager.kt
+++ b/app/src/main/kotlin/com/metrolist/music/listentogether/ListenTogetherManager.kt
@@ -5,7 +5,7 @@
 
 package com.metrolist.music.listentogether
 
-import com.metrolist.music.utils.ARTIST_SEPARATOR
+import com.metrolist.music.utils.getArtistSeparator
 import android.content.Context
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
@@ -1724,7 +1724,7 @@ class ListenTogetherManager
                 TrackInfo(
                     id = metadata.id,
                     title = metadata.title,
-                    artist = metadata.artists.joinToString(ARTIST_SEPARATOR) { it.name },
+                    artist = metadata.artists.joinToString(getArtistSeparator(context)) { it.name },
                     album = metadata.album?.title,
                     duration = durationMs,
                     thumbnail = metadata.thumbnailUrl,
@@ -1824,7 +1824,7 @@ class ListenTogetherManager
             return TrackInfo(
                 id = metadata.id,
                 title = metadata.title,
-                artist = metadata.artists.joinToString(ARTIST_SEPARATOR) { it.name },
+                artist = metadata.artists.joinToString(getArtistSeparator(context)) { it.name },
                 album = metadata.album?.title,
                 duration = durationMs,
                 thumbnail = metadata.thumbnailUrl,

--- a/app/src/main/kotlin/com/metrolist/music/listentogether/ListenTogetherManager.kt
+++ b/app/src/main/kotlin/com/metrolist/music/listentogether/ListenTogetherManager.kt
@@ -22,6 +22,7 @@ import com.metrolist.music.playback.PlayerConnection
 import com.metrolist.music.playback.queues.YouTubeQueue
 import com.metrolist.music.utils.dataStore
 import com.metrolist.music.utils.getArtistSeparator
+import com.metrolist.music.utils.joinToArtistString
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -1724,7 +1725,7 @@ class ListenTogetherManager
                  TrackInfo(
                      id = metadata.id,
                      title = metadata.title,
-                     artist = metadata.artists.joinToString(getArtistSeparator(context)) { it.name },
+                     artist = metadata.artists.joinToArtistString(getArtistSeparator(context)) { it.name },
                     album = metadata.album?.title,
                     duration = durationMs,
                     thumbnail = metadata.thumbnailUrl,
@@ -1824,7 +1825,7 @@ class ListenTogetherManager
              return TrackInfo(
                  id = metadata.id,
                  title = metadata.title,
-                 artist = metadata.artists.joinToString(getArtistSeparator(context)) { it.name },
+                 artist = metadata.artists.joinToArtistString(getArtistSeparator(context)) { it.name },
                 album = metadata.album?.title,
                 duration = durationMs,
                 thumbnail = metadata.thumbnailUrl,

--- a/app/src/main/kotlin/com/metrolist/music/listentogether/ListenTogetherManager.kt
+++ b/app/src/main/kotlin/com/metrolist/music/listentogether/ListenTogetherManager.kt
@@ -5,7 +5,6 @@
 
 package com.metrolist.music.listentogether
 
-import com.metrolist.music.utils.getArtistSeparator
 import android.content.Context
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
@@ -1724,7 +1723,7 @@ class ListenTogetherManager
                 TrackInfo(
                     id = metadata.id,
                     title = metadata.title,
-                    artist = metadata.artists.joinToString(getArtistSeparator(context)) { it.name },
+                    artist = metadata.artists.joinToString(", ") { it.name },
                     album = metadata.album?.title,
                     duration = durationMs,
                     thumbnail = metadata.thumbnailUrl,
@@ -1824,7 +1823,7 @@ class ListenTogetherManager
             return TrackInfo(
                 id = metadata.id,
                 title = metadata.title,
-                artist = metadata.artists.joinToString(getArtistSeparator(context)) { it.name },
+                artist = metadata.artists.joinToString(", ") { it.name },
                 album = metadata.album?.title,
                 duration = durationMs,
                 thumbnail = metadata.thumbnailUrl,

--- a/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
@@ -46,6 +46,7 @@ import com.metrolist.music.extensions.toggleRepeatMode
 import com.metrolist.music.models.toMediaMetadata
 import com.metrolist.music.utils.dataStore
 import com.metrolist.music.utils.get
+import com.metrolist.music.utils.getArtistSeparator
 import com.metrolist.music.utils.reportException
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
@@ -422,8 +423,8 @@ constructor(
                                             .setMediaMetadata(
                                                 MediaMetadata.Builder()
                                                     .setTitle(songItem.title)
-                                                    .setSubtitle(songItem.artists.joinToString(", ") { it.name })
-                                                    .setArtist(songItem.artists.joinToString(", ") { it.name })
+                                                    .setSubtitle(songItem.artists.joinToString(getArtistSeparator(context)) { it.name })
+                                                    .setArtist(songItem.artists.joinToString(getArtistSeparator(context)) { it.name })
                                                     .setArtworkUri(songItem.thumbnail.toUri())
                                                     .setIsPlayable(true)
                                                     .setIsBrowsable(false)
@@ -551,8 +552,8 @@ constructor(
                                 .setMediaMetadata(
                                     MediaMetadata.Builder()
                                         .setTitle(songItem.title)
-                                        .setSubtitle(songItem.artists.joinToString(", ") { it.name })
-                                        .setArtist(songItem.artists.joinToString(", ") { it.name })
+                                        .setSubtitle(songItem.artists.joinToString(getArtistSeparator(context)) { it.name })
+                                        .setArtist(songItem.artists.joinToString(getArtistSeparator(context)) { it.name })
                                         .setArtworkUri(songItem.thumbnail.toUri())
                                         .setIsPlayable(true)
                                         .setIsBrowsable(true)
@@ -826,12 +827,12 @@ constructor(
             .Builder()
             .setMediaId("$path/$id")
             .setMediaMetadata(
-                MediaMetadata
-                    .Builder()
-                    .setTitle(song.title)
-                    .setSubtitle(artists.joinToString { it.name })
-                    .setArtist(artists.joinToString { it.name })
-                    .setArtworkData(artworkBytes, MediaMetadata.PICTURE_TYPE_ILLUSTRATION)
+                 MediaMetadata
+                     .Builder()
+                     .setTitle(song.title)
+                     .setSubtitle(artists.joinToString(getArtistSeparator(context)) { it.name })
+                     .setArtist(artists.joinToString(getArtistSeparator(context)) { it.name })
+                     .setArtworkData(artworkBytes, MediaMetadata.PICTURE_TYPE_ILLUSTRATION)
                     .setIsPlayable(isPlayable)
                     .setIsBrowsable(isBrowsable)
                     .setMediaType(MediaMetadata.MEDIA_TYPE_MUSIC)

--- a/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
@@ -5,6 +5,7 @@
 
 package com.metrolist.music.playback
 
+import com.metrolist.music.utils.ARTIST_SEPARATOR
 import android.content.ContentResolver
 import android.content.Context
 import android.net.Uri
@@ -422,8 +423,8 @@ constructor(
                                             .setMediaMetadata(
                                                 MediaMetadata.Builder()
                                                     .setTitle(songItem.title)
-                                                    .setSubtitle(songItem.artists.joinToString(", ") { it.name })
-                                                    .setArtist(songItem.artists.joinToString(", ") { it.name })
+                                                    .setSubtitle(songItem.artists.joinToString(ARTIST_SEPARATOR) { it.name })
+                                                    .setArtist(songItem.artists.joinToString(ARTIST_SEPARATOR) { it.name })
                                                     .setArtworkUri(songItem.thumbnail.toUri())
                                                     .setIsPlayable(true)
                                                     .setIsBrowsable(false)
@@ -551,8 +552,8 @@ constructor(
                                 .setMediaMetadata(
                                     MediaMetadata.Builder()
                                         .setTitle(songItem.title)
-                                        .setSubtitle(songItem.artists.joinToString(", ") { it.name })
-                                        .setArtist(songItem.artists.joinToString(", ") { it.name })
+                                        .setSubtitle(songItem.artists.joinToString(ARTIST_SEPARATOR) { it.name })
+                                        .setArtist(songItem.artists.joinToString(ARTIST_SEPARATOR) { it.name })
                                         .setArtworkUri(songItem.thumbnail.toUri())
                                         .setIsPlayable(true)
                                         .setIsBrowsable(true)

--- a/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
@@ -5,7 +5,7 @@
 
 package com.metrolist.music.playback
 
-import com.metrolist.music.utils.ARTIST_SEPARATOR
+import com.metrolist.music.utils.getArtistSeparator
 import android.content.ContentResolver
 import android.content.Context
 import android.net.Uri
@@ -423,8 +423,8 @@ constructor(
                                             .setMediaMetadata(
                                                 MediaMetadata.Builder()
                                                     .setTitle(songItem.title)
-                                                    .setSubtitle(songItem.artists.joinToString(ARTIST_SEPARATOR) { it.name })
-                                                    .setArtist(songItem.artists.joinToString(ARTIST_SEPARATOR) { it.name })
+                                                    .setSubtitle(songItem.artists.joinToString(getArtistSeparator(context)) { it.name })
+                                                    .setArtist(songItem.artists.joinToString(getArtistSeparator(context)) { it.name })
                                                     .setArtworkUri(songItem.thumbnail.toUri())
                                                     .setIsPlayable(true)
                                                     .setIsBrowsable(false)
@@ -552,8 +552,8 @@ constructor(
                                 .setMediaMetadata(
                                     MediaMetadata.Builder()
                                         .setTitle(songItem.title)
-                                        .setSubtitle(songItem.artists.joinToString(ARTIST_SEPARATOR) { it.name })
-                                        .setArtist(songItem.artists.joinToString(ARTIST_SEPARATOR) { it.name })
+                                        .setSubtitle(songItem.artists.joinToString(getArtistSeparator(context)) { it.name })
+                                        .setArtist(songItem.artists.joinToString(getArtistSeparator(context)) { it.name })
                                         .setArtworkUri(songItem.thumbnail.toUri())
                                         .setIsPlayable(true)
                                         .setIsBrowsable(true)

--- a/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
@@ -5,7 +5,6 @@
 
 package com.metrolist.music.playback
 
-import com.metrolist.music.utils.getArtistSeparator
 import android.content.ContentResolver
 import android.content.Context
 import android.net.Uri
@@ -423,8 +422,8 @@ constructor(
                                             .setMediaMetadata(
                                                 MediaMetadata.Builder()
                                                     .setTitle(songItem.title)
-                                                    .setSubtitle(songItem.artists.joinToString(getArtistSeparator(context)) { it.name })
-                                                    .setArtist(songItem.artists.joinToString(getArtistSeparator(context)) { it.name })
+                                                    .setSubtitle(songItem.artists.joinToString(", ") { it.name })
+                                                    .setArtist(songItem.artists.joinToString(", ") { it.name })
                                                     .setArtworkUri(songItem.thumbnail.toUri())
                                                     .setIsPlayable(true)
                                                     .setIsBrowsable(false)
@@ -552,8 +551,8 @@ constructor(
                                 .setMediaMetadata(
                                     MediaMetadata.Builder()
                                         .setTitle(songItem.title)
-                                        .setSubtitle(songItem.artists.joinToString(getArtistSeparator(context)) { it.name })
-                                        .setArtist(songItem.artists.joinToString(getArtistSeparator(context)) { it.name })
+                                        .setSubtitle(songItem.artists.joinToString(", ") { it.name })
+                                        .setArtist(songItem.artists.joinToString(", ") { it.name })
                                         .setArtworkUri(songItem.thumbnail.toUri())
                                         .setIsPlayable(true)
                                         .setIsBrowsable(true)

--- a/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
@@ -47,6 +47,7 @@ import com.metrolist.music.models.toMediaMetadata
 import com.metrolist.music.utils.dataStore
 import com.metrolist.music.utils.get
 import com.metrolist.music.utils.getArtistSeparator
+import com.metrolist.music.utils.joinToArtistString
 import com.metrolist.music.utils.reportException
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
@@ -423,8 +424,8 @@ constructor(
                                             .setMediaMetadata(
                                                 MediaMetadata.Builder()
                                                     .setTitle(songItem.title)
-                                                    .setSubtitle(songItem.artists.joinToString(getArtistSeparator(context)) { it.name })
-                                                    .setArtist(songItem.artists.joinToString(getArtistSeparator(context)) { it.name })
+                                                    .setSubtitle(songItem.artists.joinToArtistString(getArtistSeparator(context)) { it.name })
+                                                    .setArtist(songItem.artists.joinToArtistString(getArtistSeparator(context)) { it.name })
                                                     .setArtworkUri(songItem.thumbnail.toUri())
                                                     .setIsPlayable(true)
                                                     .setIsBrowsable(false)
@@ -552,8 +553,8 @@ constructor(
                                 .setMediaMetadata(
                                     MediaMetadata.Builder()
                                         .setTitle(songItem.title)
-                                        .setSubtitle(songItem.artists.joinToString(getArtistSeparator(context)) { it.name })
-                                        .setArtist(songItem.artists.joinToString(getArtistSeparator(context)) { it.name })
+                                        .setSubtitle(songItem.artists.joinToArtistString(getArtistSeparator(context)) { it.name })
+                                        .setArtist(songItem.artists.joinToArtistString(getArtistSeparator(context)) { it.name })
                                         .setArtworkUri(songItem.thumbnail.toUri())
                                         .setIsPlayable(true)
                                         .setIsBrowsable(true)
@@ -830,8 +831,8 @@ constructor(
                  MediaMetadata
                      .Builder()
                      .setTitle(song.title)
-                     .setSubtitle(artists.joinToString(getArtistSeparator(context)) { it.name })
-                     .setArtist(artists.joinToString(getArtistSeparator(context)) { it.name })
+                     .setSubtitle(artists.joinToArtistString(getArtistSeparator(context)) { it.name })
+                     .setArtist(artists.joinToArtistString(getArtistSeparator(context)) { it.name })
                      .setArtworkData(artworkBytes, MediaMetadata.PICTURE_TYPE_ILLUSTRATION)
                     .setIsPlayable(isPlayable)
                     .setIsBrowsable(isBrowsable)

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -7,7 +7,7 @@
 
 package com.metrolist.music.playback
 
-import com.metrolist.music.utils.ARTIST_SEPARATOR
+import com.metrolist.music.utils.getArtistSeparator
 import android.app.ForegroundServiceStartNotAllowedException
 import android.app.Notification
 import android.app.NotificationChannel
@@ -4211,7 +4211,7 @@ class MusicService :
                 val songData = currentSong.value
                 val song = songData?.song
                 val songTitle = song?.title ?: getString(R.string.no_song_playing)
-                val artistName = songData?.artists?.joinToString(ARTIST_SEPARATOR) { it.name } ?: getString(R.string.tap_to_open)
+                val artistName = songData?.artists?.joinToString(getArtistSeparator(this@MusicService)) { it.name } ?: getString(R.string.tap_to_open)
                 val isLiked = songData?.song?.liked == true
 
                 widgetManager.updateWidgets(

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -7,6 +7,7 @@
 
 package com.metrolist.music.playback
 
+import com.metrolist.music.utils.ARTIST_SEPARATOR
 import android.app.ForegroundServiceStartNotAllowedException
 import android.app.Notification
 import android.app.NotificationChannel
@@ -4210,7 +4211,7 @@ class MusicService :
                 val songData = currentSong.value
                 val song = songData?.song
                 val songTitle = song?.title ?: getString(R.string.no_song_playing)
-                val artistName = songData?.artists?.joinToString(", ") { it.name } ?: getString(R.string.tap_to_open)
+                val artistName = songData?.artists?.joinToString(ARTIST_SEPARATOR) { it.name } ?: getString(R.string.tap_to_open)
                 val isLiked = songData?.song?.liked == true
 
                 widgetManager.updateWidgets(

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -196,6 +196,7 @@ import com.metrolist.music.utils.CoilBitmapLoader
 import com.metrolist.music.utils.NetworkConnectivityObserver
 import com.metrolist.music.utils.ScrobbleManager
 import com.metrolist.music.utils.SyncUtils
+import com.metrolist.music.utils.getArtistSeparator
 import com.metrolist.music.utils.YTPlayerUtils
 import com.metrolist.music.utils.dataStore
 import com.metrolist.music.utils.get
@@ -4210,7 +4211,7 @@ class MusicService :
                 val songData = currentSong.value
                 val song = songData?.song
                 val songTitle = song?.title ?: getString(R.string.no_song_playing)
-                val artistName = songData?.artists?.joinToString(", ") { it.name } ?: getString(R.string.tap_to_open)
+                 val artistName = songData?.artists?.joinToString(getArtistSeparator(this@MusicService)) { it.name } ?: getString(R.string.tap_to_open)
                 val isLiked = songData?.song?.liked == true
 
                 widgetManager.updateWidgets(

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -197,6 +197,7 @@ import com.metrolist.music.utils.NetworkConnectivityObserver
 import com.metrolist.music.utils.ScrobbleManager
 import com.metrolist.music.utils.SyncUtils
 import com.metrolist.music.utils.getArtistSeparator
+import com.metrolist.music.utils.joinToArtistString
 import com.metrolist.music.utils.YTPlayerUtils
 import com.metrolist.music.utils.dataStore
 import com.metrolist.music.utils.get
@@ -4211,7 +4212,7 @@ class MusicService :
                 val songData = currentSong.value
                 val song = songData?.song
                 val songTitle = song?.title ?: getString(R.string.no_song_playing)
-                 val artistName = songData?.artists?.joinToString(getArtistSeparator(this@MusicService)) { it.name } ?: getString(R.string.tap_to_open)
+                 val artistName = songData?.artists?.joinToArtistString(getArtistSeparator(this@MusicService)) { it.name } ?: getString(R.string.tap_to_open)
                 val isLiked = songData?.song?.liked == true
 
                 widgetManager.updateWidgets(

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -7,7 +7,6 @@
 
 package com.metrolist.music.playback
 
-import com.metrolist.music.utils.getArtistSeparator
 import android.app.ForegroundServiceStartNotAllowedException
 import android.app.Notification
 import android.app.NotificationChannel
@@ -4211,7 +4210,7 @@ class MusicService :
                 val songData = currentSong.value
                 val song = songData?.song
                 val songTitle = song?.title ?: getString(R.string.no_song_playing)
-                val artistName = songData?.artists?.joinToString(getArtistSeparator(this@MusicService)) { it.name } ?: getString(R.string.tap_to_open)
+                val artistName = songData?.artists?.joinToString(", ") { it.name } ?: getString(R.string.tap_to_open)
                 val isLiked = songData?.song?.liked == true
 
                 widgetManager.updateWidgets(

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Dialog.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Dialog.kt
@@ -57,7 +57,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import androidx.navigation.NavController
+import com.metrolist.music.LocalNavController
 import com.metrolist.music.R
 import com.metrolist.music.ui.screens.settings.AccountSettings
 import kotlinx.coroutines.delay
@@ -138,10 +138,10 @@ fun DefaultDialog(
 
 @Composable
 fun AccountSettingsDialog(
-    navController: NavController,
     onDismiss: () -> Unit,
     latestVersionName: String,
 ) {
+    val navController = LocalNavController.current
     Dialog(
         onDismissRequest = onDismiss,
         properties =

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
@@ -119,6 +119,7 @@ import com.metrolist.music.models.MediaMetadata
 import com.metrolist.music.playback.queues.LocalAlbumRadio
 import com.metrolist.music.ui.utils.resize
 import com.metrolist.music.utils.joinByBullet
+import com.metrolist.music.utils.joinToArtistString
 import com.metrolist.music.utils.makeTimeString
 import com.metrolist.music.utils.rememberEnumPreference
 import com.metrolist.music.utils.rememberPreference
@@ -519,7 +520,7 @@ fun SongListItem(
                  } else {
                      Text(
                          text = subtitleOverride ?: joinByBullet(
-                            song.orderedArtists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
+                            song.orderedArtists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name },
                              makeTimeString(song.song.duration * 1000L)
                          ),
                          style = MaterialTheme.typography.bodySmall,
@@ -618,7 +619,7 @@ fun SongGridItem(
         } else {
             Text(
                 text = joinByBullet(
-                    song.orderedArtists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
+                    song.orderedArtists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name },
                     makeTimeString(song.song.duration * 1000L)
                 ),
                 style = MaterialTheme.typography.bodyMedium,
@@ -786,7 +787,7 @@ fun AlbumListItem(
         } else {
             Text(
                 text = joinByBullet(
-                    album.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
+                    album.artists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name },
                     pluralStringResource(R.plurals.n_song, album.album.songCount, album.album.songCount),
                     album.album.year?.toString()
                 ),
@@ -865,7 +866,7 @@ fun AlbumGridItem(
     },
      subtitle = {
          Text(
-             text = album.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
+             text = album.artists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name },
              style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.secondary,
             maxLines = 2,
@@ -1140,7 +1141,7 @@ fun MediaMetadataListItem(
             } else if (mediaMetadata.suggestedBy != null) {
                 Text(
                     text = buildAnnotatedString {
-                        append(mediaMetadata.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name })
+                        append(mediaMetadata.artists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name })
                         append(" • ")
                         append(makeTimeString(mediaMetadata.duration * 1000L))
                         append(" • ")
@@ -1155,7 +1156,7 @@ fun MediaMetadataListItem(
             } else {
                 Text(
                     text = joinByBullet(
-                        mediaMetadata.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
+                        mediaMetadata.artists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name },
                         makeTimeString(mediaMetadata.duration * 1000L)
                     ),
                     style = MaterialTheme.typography.bodyMedium,
@@ -1223,8 +1224,8 @@ fun YouTubeListItem(
         ListItem(
             title = item.title,
             subtitle = when (item) {
-                is SongItem -> joinByBullet(item.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name }, makeTimeString(item.duration?.times(1000L)))
-                is AlbumItem -> joinByBullet(item.artists?.joinToString(" ${stringResource(R.string.and)} ") { it.name }, item.year?.toString())
+                is SongItem -> joinByBullet(item.artists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name }, makeTimeString(item.duration?.times(1000L)))
+                is AlbumItem -> joinByBullet(item.artists?.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name }, item.year?.toString())
                 is ArtistItem -> null
                 is PlaylistItem -> joinByBullet(item.author?.name, item.songCountText)
                 is PodcastItem -> joinByBullet(item.author?.name, item.episodeCountText)
@@ -1304,8 +1305,8 @@ fun YouTubeGridItem(
     },
      subtitle = {
          val subtitle = when (item) {
-             is SongItem -> joinByBullet(item.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name }, makeTimeString(item.duration?.times(1000L)))
-             is AlbumItem -> joinByBullet(item.artists?.joinToString(" ${stringResource(R.string.and)} ") { it.name }, item.year?.toString())
+             is SongItem -> joinByBullet(item.artists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name }, makeTimeString(item.duration?.times(1000L)))
+             is AlbumItem -> joinByBullet(item.artists?.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name }, item.year?.toString())
             is ArtistItem -> null
             is PlaylistItem -> joinByBullet(item.author?.name, item.songCountText)
             is PodcastItem -> joinByBullet(item.author?.name, item.episodeCountText)

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
@@ -404,8 +404,8 @@ fun SongListItem(
     val content: @Composable () -> Unit = {
         ListItem(
             title = song.song.title,
-            subtitle = subtitleOverride ?: joinByBullet(
-                song.orderedArtists.joinToString { it.name },
+             subtitle = subtitleOverride ?: joinByBullet(
+                song.orderedArtists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
                 makeTimeString(song.song.duration * 1000L)
             ),
             badges = badges,
@@ -475,7 +475,7 @@ fun SongGridItem(
     subtitle = {
         Text(
             text = joinByBullet(
-                song.orderedArtists.joinToString { it.name },
+                song.orderedArtists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
                 makeTimeString(song.song.duration * 1000L)
             ),
             style = MaterialTheme.typography.bodyMedium,
@@ -621,7 +621,7 @@ fun AlbumListItem(
 ) = ListItem(
     title = album.album.title,
     subtitle = joinByBullet(
-        album.artists.joinToString { it.name },
+        album.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
         pluralStringResource(R.plurals.n_song, album.album.songCount, album.album.songCount),
         album.album.year?.toString()
     ),
@@ -692,10 +692,10 @@ fun AlbumGridItem(
             modifier = Modifier.basicMarquee().fillMaxWidth()
         )
     },
-    subtitle = {
-        Text(
-            text = album.artists.joinToString { it.name },
-            style = MaterialTheme.typography.bodyMedium,
+     subtitle = {
+         Text(
+             text = album.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
+             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.secondary,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis
@@ -931,7 +931,7 @@ fun MediaMetadataListItem(
         title = mediaMetadata.title,
         subtitle = if (mediaMetadata.suggestedBy != null) {
             buildAnnotatedString {
-                append(mediaMetadata.artists.joinToString { it.name })
+                append(mediaMetadata.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name })
                 append(" • ")
                 append(makeTimeString(mediaMetadata.duration * 1000L))
                 append(" • ")
@@ -939,11 +939,11 @@ fun MediaMetadataListItem(
                     append(mediaMetadata.suggestedBy)
                 }
             }
-        } else {
-            AnnotatedString(
-                joinByBullet(
-                    mediaMetadata.artists.joinToString { it.name },
-                    makeTimeString(mediaMetadata.duration * 1000L)
+         } else {
+             AnnotatedString(
+                 joinByBullet(
+                    mediaMetadata.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
+                     makeTimeString(mediaMetadata.duration * 1000L)
                 )
             )
         },
@@ -1006,8 +1006,8 @@ fun YouTubeListItem(
         ListItem(
             title = item.title,
             subtitle = when (item) {
-                is SongItem -> joinByBullet(item.artists.joinToString { it.name }, makeTimeString(item.duration?.times(1000L)))
-                is AlbumItem -> joinByBullet(item.artists?.joinToString { it.name }, item.year?.toString())
+                is SongItem -> joinByBullet(item.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name }, makeTimeString(item.duration?.times(1000L)))
+                is AlbumItem -> joinByBullet(item.artists?.joinToString(" ${stringResource(R.string.and)} ") { it.name }, item.year?.toString())
                 is ArtistItem -> null
                 is PlaylistItem -> joinByBullet(item.author?.name, item.songCountText)
                 is PodcastItem -> joinByBullet(item.author?.name, item.episodeCountText)
@@ -1085,10 +1085,10 @@ fun YouTubeGridItem(
             modifier = Modifier.basicMarquee().fillMaxWidth()
         )
     },
-    subtitle = {
-        val subtitle = when (item) {
-            is SongItem -> joinByBullet(item.artists.joinToString { it.name }, makeTimeString(item.duration?.times(1000L)))
-            is AlbumItem -> joinByBullet(item.artists?.joinToString { it.name }, item.year?.toString())
+     subtitle = {
+         val subtitle = when (item) {
+             is SongItem -> joinByBullet(item.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name }, makeTimeString(item.duration?.times(1000L)))
+             is AlbumItem -> joinByBullet(item.artists?.joinToString(" ${stringResource(R.string.and)} ") { it.name }, item.year?.toString())
             is ArtistItem -> null
             is PlaylistItem -> joinByBullet(item.author?.name, item.songCountText)
             is PodcastItem -> joinByBullet(item.author?.name, item.episodeCountText)

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
@@ -141,7 +141,6 @@ fun ClickableArtistText(
     navController: NavController,
     modifier: Modifier = Modifier,
     style: TextStyle = MaterialTheme.typography.bodySmall,
-    color: Color = MaterialTheme.colorScheme.secondary,
     maxLines: Int = 1,
     overflow: TextOverflow = TextOverflow.Ellipsis,
 ) {
@@ -162,7 +161,7 @@ fun ClickableArtistText(
     }
     ClickableText(
         text = annotatedString,
-        style = style.copy(color = color),
+        style = style,
         maxLines = maxLines,
         overflow = overflow,
         modifier = modifier,
@@ -182,7 +181,6 @@ fun ClickableArtistText(
     navController: NavController,
     modifier: Modifier = Modifier,
     style: TextStyle = MaterialTheme.typography.bodySmall,
-    color: Color = MaterialTheme.colorScheme.secondary,
     maxLines: Int = 1,
     overflow: TextOverflow = TextOverflow.Ellipsis,
 ) {
@@ -203,7 +201,7 @@ fun ClickableArtistText(
     }
     ClickableText(
         text = annotatedString,
-        style = style.copy(color = color),
+        style = style,
         maxLines = maxLines,
         overflow = overflow,
         modifier = modifier,
@@ -499,8 +497,7 @@ fun SongListItem(
                         ClickableArtistText(
                             artists = song.orderedArtists,
                             navController = navController,
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.secondary,
+                            style = MaterialTheme.typography.bodySmall.copy(color = MaterialTheme.colorScheme.secondary),
                             modifier = Modifier.weight(1f)
                         )
                         Text(
@@ -597,8 +594,7 @@ fun SongGridItem(
                 ClickableArtistText(
                     artists = song.orderedArtists,
                     navController = navController,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.secondary,
+                    style = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.secondary),
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.weight(1f)
@@ -768,8 +764,7 @@ fun AlbumListItem(
                 ClickableArtistText(
                     artists = album.artists,
                     navController = navController,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.secondary,
+                    style = MaterialTheme.typography.bodySmall.copy(color = MaterialTheme.colorScheme.secondary),
                     modifier = Modifier.weight(1f)
                 )
                 Text(
@@ -1105,8 +1100,7 @@ fun MediaMetadataListItem(
                     ClickableArtistText(
                         artists = mediaMetadata.artists,
                         navController = navController,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.secondary,
+                        style = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.secondary),
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier.weight(1f)

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
@@ -7,6 +7,7 @@
 
 package com.metrolist.music.ui.component
 
+import com.metrolist.music.utils.ARTIST_SEPARATOR
 import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animate
@@ -405,7 +406,7 @@ fun SongListItem(
         ListItem(
             title = song.song.title,
             subtitle = subtitleOverride ?: joinByBullet(
-                song.orderedArtists.joinToString { it.name },
+                song.orderedArtists.joinToString(ARTIST_SEPARATOR) { it.name },
                 makeTimeString(song.song.duration * 1000L)
             ),
             badges = badges,
@@ -475,7 +476,7 @@ fun SongGridItem(
     subtitle = {
         Text(
             text = joinByBullet(
-                song.orderedArtists.joinToString { it.name },
+                song.orderedArtists.joinToString(ARTIST_SEPARATOR) { it.name },
                 makeTimeString(song.song.duration * 1000L)
             ),
             style = MaterialTheme.typography.bodyMedium,
@@ -621,7 +622,7 @@ fun AlbumListItem(
 ) = ListItem(
     title = album.album.title,
     subtitle = joinByBullet(
-        album.artists.joinToString { it.name },
+        album.artists.joinToString(ARTIST_SEPARATOR) { it.name },
         pluralStringResource(R.plurals.n_song, album.album.songCount, album.album.songCount),
         album.album.year?.toString()
     ),
@@ -694,7 +695,7 @@ fun AlbumGridItem(
     },
     subtitle = {
         Text(
-            text = album.artists.joinToString { it.name },
+            text = album.artists.joinToString(ARTIST_SEPARATOR) { it.name },
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.secondary,
             maxLines = 2,
@@ -931,7 +932,7 @@ fun MediaMetadataListItem(
         title = mediaMetadata.title,
         subtitle = if (mediaMetadata.suggestedBy != null) {
             buildAnnotatedString {
-                append(mediaMetadata.artists.joinToString { it.name })
+                append(mediaMetadata.artists.joinToString(ARTIST_SEPARATOR) { it.name })
                 append(" • ")
                 append(makeTimeString(mediaMetadata.duration * 1000L))
                 append(" • ")
@@ -942,7 +943,7 @@ fun MediaMetadataListItem(
         } else {
             AnnotatedString(
                 joinByBullet(
-                    mediaMetadata.artists.joinToString { it.name },
+                    mediaMetadata.artists.joinToString(ARTIST_SEPARATOR) { it.name },
                     makeTimeString(mediaMetadata.duration * 1000L)
                 )
             )
@@ -1006,8 +1007,8 @@ fun YouTubeListItem(
         ListItem(
             title = item.title,
             subtitle = when (item) {
-                is SongItem -> joinByBullet(item.artists.joinToString { it.name }, makeTimeString(item.duration?.times(1000L)))
-                is AlbumItem -> joinByBullet(item.artists?.joinToString { it.name }, item.year?.toString())
+                is SongItem -> joinByBullet(item.artists.joinToString(ARTIST_SEPARATOR) { it.name }, makeTimeString(item.duration?.times(1000L)))
+                is AlbumItem -> joinByBullet(item.artists?.joinToString(ARTIST_SEPARATOR) { it.name }, item.year?.toString())
                 is ArtistItem -> null
                 is PlaylistItem -> joinByBullet(item.author?.name, item.songCountText)
                 is PodcastItem -> joinByBullet(item.author?.name, item.episodeCountText)
@@ -1087,8 +1088,8 @@ fun YouTubeGridItem(
     },
     subtitle = {
         val subtitle = when (item) {
-            is SongItem -> joinByBullet(item.artists.joinToString { it.name }, makeTimeString(item.duration?.times(1000L)))
-            is AlbumItem -> joinByBullet(item.artists?.joinToString { it.name }, item.year?.toString())
+            is SongItem -> joinByBullet(item.artists.joinToString(ARTIST_SEPARATOR) { it.name }, makeTimeString(item.duration?.times(1000L)))
+            is AlbumItem -> joinByBullet(item.artists?.joinToString(ARTIST_SEPARATOR) { it.name }, item.year?.toString())
             is ArtistItem -> null
             is PlaylistItem -> joinByBullet(item.author?.name, item.songCountText)
             is PodcastItem -> joinByBullet(item.author?.name, item.episodeCountText)

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
@@ -39,6 +39,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -68,6 +69,7 @@ import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -96,6 +98,7 @@ import com.metrolist.innertube.models.YTItem
 import com.metrolist.music.LocalDatabase
 import com.metrolist.music.LocalDownloadUtil
 import com.metrolist.music.LocalPlayerConnection
+import androidx.navigation.NavController
 import com.metrolist.music.R
 import com.metrolist.music.constants.CropAlbumArtKey
 import com.metrolist.music.constants.GridItemSize
@@ -108,6 +111,7 @@ import com.metrolist.music.constants.SwipeToSongKey
 import com.metrolist.music.constants.ThumbnailCornerRadius
 import com.metrolist.music.db.entities.Album
 import com.metrolist.music.db.entities.Artist
+import com.metrolist.music.db.entities.ArtistEntity
 import com.metrolist.music.db.entities.Playlist
 import com.metrolist.music.db.entities.Song
 import com.metrolist.music.extensions.toMediaItem
@@ -126,8 +130,91 @@ import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlin.math.roundToInt
+import kotlin.jvm.JvmName
 
 const val ActiveBoxAlpha = 0.6f
+
+@JvmName("ClickableArtistTextEntities")
+@Composable
+fun ClickableArtistText(
+    artists: List<ArtistEntity>,
+    navController: NavController,
+    modifier: Modifier = Modifier,
+    style: TextStyle = MaterialTheme.typography.bodySmall,
+    color: Color = MaterialTheme.colorScheme.secondary,
+    maxLines: Int = 1,
+    overflow: TextOverflow = TextOverflow.Ellipsis,
+) {
+    val andString = stringResource(R.string.and)
+    val annotatedString = remember(artists, andString) {
+        buildAnnotatedString {
+            artists.forEachIndexed { index, artist ->
+                artist.id.let { id ->
+                    pushStringAnnotation("artist_$id", id)
+                    append(artist.name)
+                    pop()
+                }
+                if (index != artists.lastIndex) {
+                    append(" $andString ")
+                }
+            }
+        }
+    }
+    ClickableText(
+        text = annotatedString,
+        style = style.copy(color = color),
+        maxLines = maxLines,
+        overflow = overflow,
+        modifier = modifier,
+        onClick = { offset ->
+            annotatedString
+                .getStringAnnotations(offset, offset)
+                .firstOrNull()
+                ?.let { navController.navigate("artist/${it.item}") }
+        },
+    )
+}
+
+@JvmName("ClickableArtistTextMedia")
+@Composable
+fun ClickableArtistText(
+    artists: List<MediaMetadata.Artist>,
+    navController: NavController,
+    modifier: Modifier = Modifier,
+    style: TextStyle = MaterialTheme.typography.bodySmall,
+    color: Color = MaterialTheme.colorScheme.secondary,
+    maxLines: Int = 1,
+    overflow: TextOverflow = TextOverflow.Ellipsis,
+) {
+    val andString = stringResource(R.string.and)
+    val annotatedString = remember(artists, andString) {
+        buildAnnotatedString {
+            artists.forEachIndexed { index, artist ->
+                artist.id?.let { id ->
+                    pushStringAnnotation("artist_$id", id)
+                    append(artist.name)
+                    pop()
+                } ?: append(artist.name)
+                if (index != artists.lastIndex) {
+                    append(" $andString ")
+                }
+            }
+        }
+    }
+    ClickableText(
+        text = annotatedString,
+        style = style.copy(color = color),
+        maxLines = maxLines,
+        overflow = overflow,
+        modifier = modifier,
+        onClick = { offset ->
+            annotatedString
+                .getStringAnnotations(offset, offset)
+                .firstOrNull()
+                ?.let { navController.navigate("artist/${it.item}") }
+        },
+    )
+}
 
 @Composable
 fun currentGridThumbnailHeight(): Dp {
@@ -377,6 +464,7 @@ fun SongListItem(
     showInLibraryIcon: Boolean = false,
     showDownloadIcon: Boolean = true,
     subtitleOverride: String? = null,
+    navController: NavController? = null,
     badges: @Composable RowScope.() -> Unit = {
         if (showLikedIcon && song.song.liked) {
             Icon.Favorite()
@@ -402,30 +490,57 @@ fun SongListItem(
     val swipeEnabled by rememberPreference(SwipeToSongKey, defaultValue = false)
 
     val content: @Composable () -> Unit = {
-        ListItem(
-            title = song.song.title,
-             subtitle = subtitleOverride ?: joinByBullet(
-                song.orderedArtists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
-                makeTimeString(song.song.duration * 1000L)
-            ),
-            badges = badges,
-            thumbnailContent = {
-                ItemThumbnail(
-                    thumbnailUrl = song.song.thumbnailUrl?.resize(200, 200),
-                    albumIndex = albumIndex,
-                    isSelected = isSelected,
-                    isActive = isActive,
-                    isPlaying = isPlaying,
-                    shape = RoundedCornerShape(ThumbnailCornerRadius),
-                    modifier = Modifier.size(ListThumbnailSize)
-                )
-            },
-            trailingContent = trailingContent,
-            modifier = modifier,
-            isSelected = isSelected,
-            isActive = isActive
-        )
-    }
+         ListItem(
+             title = song.song.title,
+             subtitle = {
+                 badges()
+                 if (navController != null && subtitleOverride == null) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        ClickableArtistText(
+                            artists = song.orderedArtists,
+                            navController = navController,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.secondary,
+                            modifier = Modifier.weight(1f)
+                        )
+                        Text(
+                            text = " • ${makeTimeString(song.song.duration * 1000L)}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.secondary,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                 } else {
+                     Text(
+                         text = subtitleOverride ?: joinByBullet(
+                            song.orderedArtists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
+                             makeTimeString(song.song.duration * 1000L)
+                         ),
+                         style = MaterialTheme.typography.bodySmall,
+                         color = MaterialTheme.colorScheme.secondary,
+                         maxLines = 1,
+                         overflow = TextOverflow.Ellipsis,
+                     )
+                 }
+             },
+             thumbnailContent = {
+                 ItemThumbnail(
+                     thumbnailUrl = song.song.thumbnailUrl?.resize(200, 200),
+                     albumIndex = albumIndex,
+                     isSelected = isSelected,
+                     isActive = isActive,
+                     isPlaying = isPlaying,
+                     shape = RoundedCornerShape(ThumbnailCornerRadius),
+                     modifier = Modifier.size(ListThumbnailSize)
+                 )
+             },
+             trailingContent = trailingContent,
+             modifier = modifier,
+             isSelected = isSelected,
+             isActive = isActive
+         )
+     }
 
     if (isSwipeable && swipeEnabled) {
         SwipeToSongBox(
@@ -446,6 +561,7 @@ fun SongGridItem(
     showLikedIcon: Boolean = true,
     showInLibraryIcon: Boolean = false,
     showDownloadIcon: Boolean = true,
+    navController: NavController? = null,
     badges: @Composable RowScope.() -> Unit = {
         if (showLikedIcon && song.song.liked) {
             Icon.Favorite()
@@ -473,16 +589,40 @@ fun SongGridItem(
         )
     },
     subtitle = {
-        Text(
-            text = joinByBullet(
-                song.orderedArtists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
-                makeTimeString(song.song.duration * 1000L)
-            ),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.secondary,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-        )
+        if (navController != null) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                ClickableArtistText(
+                    artists = song.orderedArtists,
+                    navController = navController,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.secondary,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f)
+                )
+                Text(
+                    text = " • ${makeTimeString(song.song.duration * 1000L)}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.secondary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        } else {
+            Text(
+                text = joinByBullet(
+                    song.orderedArtists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
+                    makeTimeString(song.song.duration * 1000L)
+                ),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.secondary,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
     },
     badges = badges,
     thumbnailContent = {
@@ -581,6 +721,7 @@ fun AlbumListItem(
     album: Album,
     modifier: Modifier = Modifier,
     showLikedIcon: Boolean = true,
+    navController: NavController? = null,
     badges: @Composable RowScope.() -> Unit = {
         val downloadUtil = LocalDownloadUtil.current
         val database = LocalDatabase.current
@@ -620,12 +761,39 @@ fun AlbumListItem(
     trailingContent: @Composable RowScope.() -> Unit = {},
 ) = ListItem(
     title = album.album.title,
-    subtitle = joinByBullet(
-        album.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
-        pluralStringResource(R.plurals.n_song, album.album.songCount, album.album.songCount),
-        album.album.year?.toString()
-    ),
-    badges = badges,
+    subtitle = {
+        badges()
+        if (navController != null) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                ClickableArtistText(
+                    artists = album.artists,
+                    navController = navController,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.secondary,
+                    modifier = Modifier.weight(1f)
+                )
+                Text(
+                    text = " • ${pluralStringResource(R.plurals.n_song, album.album.songCount, album.album.songCount)}${album.album.year?.let { " • $it" } ?: ""}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.secondary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        } else {
+            Text(
+                text = joinByBullet(
+                    album.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
+                    pluralStringResource(R.plurals.n_song, album.album.songCount, album.album.songCount),
+                    album.album.year?.toString()
+                ),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.secondary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    },
     thumbnailContent = {
         ItemThumbnail(
             thumbnailUrl = album.album.thumbnailUrl,
@@ -925,29 +1093,76 @@ fun MediaMetadataListItem(
     isSelected: Boolean = false,
     isActive: Boolean = false,
     isPlaying: Boolean = false,
+    navController: NavController? = null,
     trailingContent: @Composable RowScope.() -> Unit = {},
 ) {
     ListItem(
         title = mediaMetadata.title,
-        subtitle = if (mediaMetadata.suggestedBy != null) {
-            buildAnnotatedString {
-                append(mediaMetadata.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name })
-                append(" • ")
-                append(makeTimeString(mediaMetadata.duration * 1000L))
-                append(" • ")
-                withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
-                    append(mediaMetadata.suggestedBy)
+        subtitle = {
+            if (mediaMetadata.explicit) Icon.Explicit()
+            if (navController != null) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    ClickableArtistText(
+                        artists = mediaMetadata.artists,
+                        navController = navController,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.secondary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f)
+                    )
+                    Text(
+                        text = " • ${makeTimeString(mediaMetadata.duration * 1000L)}",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.secondary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    if (mediaMetadata.suggestedBy != null) {
+                        Text(
+                            text = " • ",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.secondary,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Text(
+                            text = mediaMetadata.suggestedBy,
+                            style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold),
+                            color = MaterialTheme.colorScheme.secondary,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
                 }
-            }
-         } else {
-             AnnotatedString(
-                 joinByBullet(
-                    mediaMetadata.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
-                     makeTimeString(mediaMetadata.duration * 1000L)
+            } else if (mediaMetadata.suggestedBy != null) {
+                Text(
+                    text = buildAnnotatedString {
+                        append(mediaMetadata.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name })
+                        append(" • ")
+                        append(makeTimeString(mediaMetadata.duration * 1000L))
+                        append(" • ")
+                        withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
+                            append(mediaMetadata.suggestedBy)
+                        }
+                    },
+                    style = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.secondary),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
-            )
+            } else {
+                Text(
+                    text = joinByBullet(
+                        mediaMetadata.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
+                        makeTimeString(mediaMetadata.duration * 1000L)
+                    ),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.secondary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
         },
-        badges = { if (mediaMetadata.explicit) Icon.Explicit()},
         thumbnailContent = {
             ItemThumbnail(
                 thumbnailUrl = mediaMetadata.thumbnailUrl,

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
@@ -7,7 +7,7 @@
 
 package com.metrolist.music.ui.component
 
-import com.metrolist.music.utils.ARTIST_SEPARATOR
+
 import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animate
@@ -40,6 +40,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -97,6 +98,7 @@ import com.metrolist.innertube.models.YTItem
 import com.metrolist.music.LocalDatabase
 import com.metrolist.music.LocalDownloadUtil
 import com.metrolist.music.LocalPlayerConnection
+import androidx.navigation.NavController
 import com.metrolist.music.R
 import com.metrolist.music.constants.CropAlbumArtKey
 import com.metrolist.music.constants.GridItemSize
@@ -129,6 +131,45 @@ import kotlinx.coroutines.withContext
 import kotlin.math.roundToInt
 
 const val ActiveBoxAlpha = 0.6f
+
+@Composable
+fun ClickableArtistText(
+    artists: List<Artist>,
+    navController: NavController,
+    modifier: Modifier = Modifier,
+    style: TextStyle = MaterialTheme.typography.bodySmall,
+    color: Color = MaterialTheme.colorScheme.secondary,
+    maxLines: Int = 1,
+    overflow: TextOverflow = TextOverflow.Ellipsis,
+) {
+    val annotatedString = remember(artists) {
+        buildAnnotatedString {
+            artists.forEachIndexed { index, artist ->
+                artist.id?.let { id ->
+                    pushStringAnnotation("artist_$id", id)
+                    append(artist.name)
+                    pop()
+                } ?: append(artist.name)
+                if (index != artists.lastIndex) {
+                    append(" ${stringResource(R.string.and)} ")
+                }
+            }
+        }
+    }
+    ClickableText(
+        text = annotatedString,
+        style = style.copy(color = color),
+        maxLines = maxLines,
+        overflow = overflow,
+        modifier = modifier,
+        onClick = { offset ->
+            annotatedString
+                .getStringAnnotations(offset, offset)
+                .firstOrNull()
+                ?.let { navController.navigate("artist/${it.item}") }
+        },
+    )
+}
 
 @Composable
 fun currentGridThumbnailHeight(): Dp {
@@ -378,6 +419,7 @@ fun SongListItem(
     showInLibraryIcon: Boolean = false,
     showDownloadIcon: Boolean = true,
     subtitleOverride: String? = null,
+    navController: NavController? = null,
     badges: @Composable RowScope.() -> Unit = {
         if (showLikedIcon && song.song.liked) {
             Icon.Favorite()
@@ -405,10 +447,47 @@ fun SongListItem(
     val content: @Composable () -> Unit = {
         ListItem(
             title = song.song.title,
-            subtitle = subtitleOverride ?: joinByBullet(
-                song.orderedArtists.joinToString(ARTIST_SEPARATOR) { it.name },
-                makeTimeString(song.song.duration * 1000L)
-            ),
+            subtitle = if (navController != null && subtitleOverride == null) {
+                {
+                    val annotated = remember(song.orderedArtists) {
+                        buildAnnotatedString {
+                            song.orderedArtists.forEachIndexed { index, artist ->
+                                artist.id?.let { id ->
+                                    pushStringAnnotation("artist_$id", id)
+                                    append(artist.name)
+                                    pop()
+                                } ?: append(artist.name)
+                                if (index != song.orderedArtists.lastIndex) {
+                                    append(" ${stringResource(R.string.and)} ")
+                                }
+                            }
+                            append(" • ")
+                            append(makeTimeString(song.song.duration * 1000L))
+                        }
+                    }
+                    ClickableText(
+                        text = annotated,
+                        style = MaterialTheme.typography.bodySmall.copy(
+                            color = MaterialTheme.colorScheme.secondary
+                        ),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        onClick = { offset ->
+                            annotated
+                                .getStringAnnotations(offset, offset)
+                                .firstOrNull()
+                                ?.let {
+                                    navController.navigate("artist/${it.item}")
+                                }
+                        },
+                    )
+                }
+            } else {
+                subtitleOverride ?: joinByBullet(
+                    song.orderedArtists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
+                    makeTimeString(song.song.duration * 1000L)
+                )
+            },
             badges = badges,
             thumbnailContent = {
                 ItemThumbnail(
@@ -447,6 +526,7 @@ fun SongGridItem(
     showLikedIcon: Boolean = true,
     showInLibraryIcon: Boolean = false,
     showDownloadIcon: Boolean = true,
+    navController: NavController? = null,
     badges: @Composable RowScope.() -> Unit = {
         if (showLikedIcon && song.song.liked) {
             Icon.Favorite()
@@ -473,17 +553,29 @@ fun SongGridItem(
             modifier = Modifier.basicMarquee().fillMaxWidth()
         )
     },
-    subtitle = {
-        Text(
-            text = joinByBullet(
-                song.orderedArtists.joinToString(ARTIST_SEPARATOR) { it.name },
-                makeTimeString(song.song.duration * 1000L)
-            ),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.secondary,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-        )
+    subtitle = if (navController != null) {
+        {
+            ClickableArtistText(
+                artists = song.orderedArtists,
+                navController = navController,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.secondary,
+                maxLines = 2,
+            )
+        }
+    } else {
+        {
+            Text(
+                text = joinByBullet(
+                    song.orderedArtists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
+                    makeTimeString(song.song.duration * 1000L)
+                ),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.secondary,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
     },
     badges = badges,
     thumbnailContent = {
@@ -582,6 +674,7 @@ fun AlbumListItem(
     album: Album,
     modifier: Modifier = Modifier,
     showLikedIcon: Boolean = true,
+    navController: NavController? = null,
     badges: @Composable RowScope.() -> Unit = {
         val downloadUtil = LocalDownloadUtil.current
         val database = LocalDatabase.current
@@ -621,11 +714,50 @@ fun AlbumListItem(
     trailingContent: @Composable RowScope.() -> Unit = {},
 ) = ListItem(
     title = album.album.title,
-    subtitle = joinByBullet(
-        album.artists.joinToString(ARTIST_SEPARATOR) { it.name },
-        pluralStringResource(R.plurals.n_song, album.album.songCount, album.album.songCount),
-        album.album.year?.toString()
-    ),
+    subtitle = if (navController != null) {
+        {
+            val annotated = remember(album.artists) {
+                buildAnnotatedString {
+                    album.artists.forEachIndexed { index, artist ->
+                        artist.id?.let { id ->
+                            pushStringAnnotation("artist_$id", id)
+                            append(artist.name)
+                            pop()
+                        } ?: append(artist.name)
+                        if (index != album.artists.lastIndex) {
+                            append(" ${stringResource(R.string.and)} ")
+                        }
+                    }
+                    append(" • ")
+                    append(pluralStringResource(R.plurals.n_song, album.album.songCount, album.album.songCount))
+                    if (album.album.year != null) {
+                        append(" • ")
+                        append(album.album.year.toString())
+                    }
+                }
+            }
+            ClickableText(
+                text = annotated,
+                style = MaterialTheme.typography.bodySmall.copy(
+                    color = MaterialTheme.colorScheme.secondary
+                ),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                onClick = { offset ->
+                    annotated
+                        .getStringAnnotations(offset, offset)
+                        .firstOrNull()
+                        ?.let { navController.navigate("artist/${it.item}") }
+                },
+            )
+        }
+    } else {
+        joinByBullet(
+            album.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
+            pluralStringResource(R.plurals.n_song, album.album.songCount, album.album.songCount),
+            album.album.year?.toString()
+        )
+    },
     badges = badges,
     thumbnailContent = {
         ItemThumbnail(
@@ -695,7 +827,7 @@ fun AlbumGridItem(
     },
     subtitle = {
         Text(
-            text = album.artists.joinToString(ARTIST_SEPARATOR) { it.name },
+            text = album.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.secondary,
             maxLines = 2,
@@ -932,7 +1064,7 @@ fun MediaMetadataListItem(
         title = mediaMetadata.title,
         subtitle = if (mediaMetadata.suggestedBy != null) {
             buildAnnotatedString {
-                append(mediaMetadata.artists.joinToString(ARTIST_SEPARATOR) { it.name })
+                append(mediaMetadata.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name })
                 append(" • ")
                 append(makeTimeString(mediaMetadata.duration * 1000L))
                 append(" • ")
@@ -943,7 +1075,7 @@ fun MediaMetadataListItem(
         } else {
             AnnotatedString(
                 joinByBullet(
-                    mediaMetadata.artists.joinToString(ARTIST_SEPARATOR) { it.name },
+                    mediaMetadata.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
                     makeTimeString(mediaMetadata.duration * 1000L)
                 )
             )
@@ -1007,8 +1139,8 @@ fun YouTubeListItem(
         ListItem(
             title = item.title,
             subtitle = when (item) {
-                is SongItem -> joinByBullet(item.artists.joinToString(ARTIST_SEPARATOR) { it.name }, makeTimeString(item.duration?.times(1000L)))
-                is AlbumItem -> joinByBullet(item.artists?.joinToString(ARTIST_SEPARATOR) { it.name }, item.year?.toString())
+                is SongItem -> joinByBullet(item.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name }, makeTimeString(item.duration?.times(1000L)))
+                is AlbumItem -> joinByBullet(item.artists?.joinToString(" ${stringResource(R.string.and)} ") { it.name }, item.year?.toString())
                 is ArtistItem -> null
                 is PlaylistItem -> joinByBullet(item.author?.name, item.songCountText)
                 is PodcastItem -> joinByBullet(item.author?.name, item.episodeCountText)
@@ -1088,8 +1220,8 @@ fun YouTubeGridItem(
     },
     subtitle = {
         val subtitle = when (item) {
-            is SongItem -> joinByBullet(item.artists.joinToString(ARTIST_SEPARATOR) { it.name }, makeTimeString(item.duration?.times(1000L)))
-            is AlbumItem -> joinByBullet(item.artists?.joinToString(ARTIST_SEPARATOR) { it.name }, item.year?.toString())
+            is SongItem -> joinByBullet(item.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name }, makeTimeString(item.duration?.times(1000L)))
+            is AlbumItem -> joinByBullet(item.artists?.joinToString(" ${stringResource(R.string.and)} ") { it.name }, item.year?.toString())
             is ArtistItem -> null
             is PlaylistItem -> joinByBullet(item.author?.name, item.songCountText)
             is PodcastItem -> joinByBullet(item.author?.name, item.episodeCountText)

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
@@ -97,8 +97,8 @@ import com.metrolist.innertube.models.SongItem
 import com.metrolist.innertube.models.YTItem
 import com.metrolist.music.LocalDatabase
 import com.metrolist.music.LocalDownloadUtil
+import com.metrolist.music.LocalNavController
 import com.metrolist.music.LocalPlayerConnection
-import androidx.navigation.NavController
 import com.metrolist.music.R
 import com.metrolist.music.constants.CropAlbumArtKey
 import com.metrolist.music.constants.GridItemSize
@@ -139,12 +139,12 @@ const val ActiveBoxAlpha = 0.6f
 @Composable
 fun ClickableArtistText(
     artists: List<ArtistEntity>,
-    navController: NavController,
     modifier: Modifier = Modifier,
     style: TextStyle = MaterialTheme.typography.bodySmall,
     maxLines: Int = 1,
     overflow: TextOverflow = TextOverflow.Ellipsis,
 ) {
+    val navController = LocalNavController.current
     val andString = stringResource(R.string.and)
     val annotatedString = remember(artists, andString) {
         buildAnnotatedString {
@@ -183,12 +183,12 @@ fun ClickableArtistText(
 @Composable
 fun ClickableArtistText(
     artists: List<MediaMetadata.Artist>,
-    navController: NavController,
     modifier: Modifier = Modifier,
     style: TextStyle = MaterialTheme.typography.bodySmall,
     maxLines: Int = 1,
     overflow: TextOverflow = TextOverflow.Ellipsis,
 ) {
+    val navController = LocalNavController.current
     val andString = stringResource(R.string.and)
     val annotatedString = remember(artists, andString) {
         buildAnnotatedString {
@@ -471,7 +471,6 @@ fun SongListItem(
     showInLibraryIcon: Boolean = false,
     showDownloadIcon: Boolean = true,
     subtitleOverride: String? = null,
-    navController: NavController? = null,
     badges: @Composable RowScope.() -> Unit = {
         if (showLikedIcon && song.song.liked) {
             Icon.Favorite()
@@ -501,11 +500,10 @@ fun SongListItem(
              title = song.song.title,
              subtitle = {
                  badges()
-                 if (navController != null && subtitleOverride == null) {
+                 if (subtitleOverride == null) {
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         ClickableArtistText(
                             artists = song.orderedArtists,
-                            navController = navController,
                             style = MaterialTheme.typography.bodySmall.copy(color = MaterialTheme.colorScheme.secondary),
                             modifier = Modifier.weight(1f)
                         )
@@ -519,10 +517,7 @@ fun SongListItem(
                     }
                  } else {
                      Text(
-                         text = subtitleOverride ?: joinByBullet(
-                            song.orderedArtists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name },
-                             makeTimeString(song.song.duration * 1000L)
-                         ),
+                         text = subtitleOverride,
                          style = MaterialTheme.typography.bodySmall,
                          color = MaterialTheme.colorScheme.secondary,
                          maxLines = 1,
@@ -567,7 +562,6 @@ fun SongGridItem(
     showLikedIcon: Boolean = true,
     showInLibraryIcon: Boolean = false,
     showDownloadIcon: Boolean = true,
-    navController: NavController? = null,
     badges: @Composable RowScope.() -> Unit = {
         if (showLikedIcon && song.song.liked) {
             Icon.Favorite()
@@ -595,36 +589,22 @@ fun SongGridItem(
         )
     },
     subtitle = {
-        if (navController != null) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                ClickableArtistText(
-                    artists = song.orderedArtists,
-                    navController = navController,
-                    style = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.secondary),
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f)
-                )
-                Text(
-                    text = " | ${makeTimeString(song.song.duration * 1000L)}",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.secondary,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
-        } else {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            ClickableArtistText(
+                artists = song.orderedArtists,
+                style = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.secondary),
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f)
+            )
             Text(
-                text = joinByBullet(
-                    song.orderedArtists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name },
-                    makeTimeString(song.song.duration * 1000L)
-                ),
+                text = " | ${makeTimeString(song.song.duration * 1000L)}",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.secondary,
-                maxLines = 2,
+                maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
         }
@@ -726,7 +706,6 @@ fun AlbumListItem(
     album: Album,
     modifier: Modifier = Modifier,
     showLikedIcon: Boolean = true,
-    navController: NavController? = null,
     badges: @Composable RowScope.() -> Unit = {
         val downloadUtil = LocalDownloadUtil.current
         val database = LocalDatabase.current
@@ -768,29 +747,14 @@ fun AlbumListItem(
     title = album.album.title,
     subtitle = {
         badges()
-        if (navController != null) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                ClickableArtistText(
-                    artists = album.artists,
-                    navController = navController,
-                    style = MaterialTheme.typography.bodySmall.copy(color = MaterialTheme.colorScheme.secondary),
-                    modifier = Modifier.weight(1f)
-                )
-                Text(
-                    text = " | ${pluralStringResource(R.plurals.n_song, album.album.songCount, album.album.songCount)}${album.album.year?.let { " | $it" } ?: ""}",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.secondary,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
-        } else {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            ClickableArtistText(
+                artists = album.artists,
+                style = MaterialTheme.typography.bodySmall.copy(color = MaterialTheme.colorScheme.secondary),
+                modifier = Modifier.weight(1f)
+            )
             Text(
-                text = joinByBullet(
-                    album.artists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name },
-                    pluralStringResource(R.plurals.n_song, album.album.songCount, album.album.songCount),
-                    album.album.year?.toString()
-                ),
+                text = " | ${pluralStringResource(R.plurals.n_song, album.album.songCount, album.album.songCount)}${album.album.year?.let { " | $it" } ?: ""}",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.secondary,
                 maxLines = 1,
@@ -1097,73 +1061,43 @@ fun MediaMetadataListItem(
     isSelected: Boolean = false,
     isActive: Boolean = false,
     isPlaying: Boolean = false,
-    navController: NavController? = null,
     trailingContent: @Composable RowScope.() -> Unit = {},
 ) {
     ListItem(
         title = mediaMetadata.title,
         subtitle = {
             if (mediaMetadata.explicit) Icon.Explicit()
-            if (navController != null) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    ClickableArtistText(
-                        artists = mediaMetadata.artists,
-                        navController = navController,
-                        style = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.secondary),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.weight(1f)
-                    )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                ClickableArtistText(
+                    artists = mediaMetadata.artists,
+                    style = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.secondary),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f)
+                )
+                Text(
+                    text = " | ${makeTimeString(mediaMetadata.duration * 1000L)}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.secondary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (mediaMetadata.suggestedBy != null) {
                     Text(
-                        text = " | ${makeTimeString(mediaMetadata.duration * 1000L)}",
+                        text = " | ",
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.secondary,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )
-                    if (mediaMetadata.suggestedBy != null) {
-                        Text(
-                            text = " | ",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.secondary,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                        Text(
-                            text = mediaMetadata.suggestedBy,
-                            style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold),
-                            color = MaterialTheme.colorScheme.secondary,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    }
+                    Text(
+                        text = mediaMetadata.suggestedBy,
+                        style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold),
+                        color = MaterialTheme.colorScheme.secondary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
                 }
-            } else if (mediaMetadata.suggestedBy != null) {
-                Text(
-                    text = buildAnnotatedString {
-                        append(mediaMetadata.artists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name })
-                        append(" | ")
-                        append(makeTimeString(mediaMetadata.duration * 1000L))
-                        append(" | ")
-                        withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
-                            append(mediaMetadata.suggestedBy)
-                        }
-                    },
-                    style = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.secondary),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            } else {
-                Text(
-                    text = joinByBullet(
-                        mediaMetadata.artists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name },
-                        makeTimeString(mediaMetadata.duration * 1000L)
-                    ),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.secondary,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
             }
         },
         thumbnailContent = {

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
@@ -154,7 +154,11 @@ fun ClickableArtistText(
                     pop()
                 }
                 if (index != artists.lastIndex) {
-                    append(" $andString ")
+                    if (index == artists.lastIndex - 1) {
+                        append(" $andString ")
+                    } else {
+                        append(", ")
+                    }
                 }
             }
         }
@@ -194,7 +198,11 @@ fun ClickableArtistText(
                     pop()
                 } ?: append(artist.name)
                 if (index != artists.lastIndex) {
-                    append(" $andString ")
+                    if (index == artists.lastIndex - 1) {
+                        append(" $andString ")
+                    } else {
+                        append(", ")
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
@@ -39,7 +39,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.ClickableText
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.withLink
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -146,13 +148,19 @@ fun ClickableArtistText(
 ) {
     val navController = LocalNavController.current
     val andString = stringResource(R.string.and)
+    val linkColor = LocalContentColor.current
     val annotatedString = remember(artists, andString) {
         buildAnnotatedString {
             artists.forEachIndexed { index, artist ->
-                artist.id.let { id ->
-                    pushStringAnnotation("artist_$id", id)
+                withLink(
+                    LinkAnnotation.Clickable(
+                        tag = artist.id,
+                        styles = TextLinkStyles(SpanStyle(color = linkColor)),
+                    ) {
+                        navController.navigate("artist/${artist.id}")
+                    }
+                ) {
                     append(artist.name)
-                    pop()
                 }
                 if (index != artists.lastIndex) {
                     if (index == artists.lastIndex - 1) {
@@ -164,18 +172,12 @@ fun ClickableArtistText(
             }
         }
     }
-    ClickableText(
+    Text(
         text = annotatedString,
         style = style,
         maxLines = maxLines,
         overflow = overflow,
         modifier = modifier,
-        onClick = { offset ->
-            annotatedString
-                .getStringAnnotations(offset, offset)
-                .firstOrNull()
-                ?.let { navController.navigate("artist/${it.item}") }
-        },
     )
 }
 
@@ -190,14 +192,24 @@ fun ClickableArtistText(
 ) {
     val navController = LocalNavController.current
     val andString = stringResource(R.string.and)
+    val linkColor = LocalContentColor.current
     val annotatedString = remember(artists, andString) {
         buildAnnotatedString {
             artists.forEachIndexed { index, artist ->
-                artist.id?.let { id ->
-                    pushStringAnnotation("artist_$id", id)
+                if (artist.id != null) {
+                    withLink(
+                        LinkAnnotation.Clickable(
+                            tag = artist.id!!,
+                            styles = TextLinkStyles(SpanStyle(color = linkColor)),
+                        ) {
+                            navController.navigate("artist/${artist.id}")
+                        }
+                    ) {
+                        append(artist.name)
+                    }
+                } else {
                     append(artist.name)
-                    pop()
-                } ?: append(artist.name)
+                }
                 if (index != artists.lastIndex) {
                     if (index == artists.lastIndex - 1) {
                         append(" $andString ")
@@ -208,18 +220,12 @@ fun ClickableArtistText(
             }
         }
     }
-    ClickableText(
+    Text(
         text = annotatedString,
         style = style,
         maxLines = maxLines,
         overflow = overflow,
         modifier = modifier,
-        onClick = { offset ->
-            annotatedString
-                .getStringAnnotations(offset, offset)
-                .firstOrNull()
-                ?.let { navController.navigate("artist/${it.item}") }
-        },
     )
 }
 

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
@@ -7,7 +7,6 @@
 
 package com.metrolist.music.ui.component
 
-
 import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animate
@@ -40,7 +39,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -98,7 +96,6 @@ import com.metrolist.innertube.models.YTItem
 import com.metrolist.music.LocalDatabase
 import com.metrolist.music.LocalDownloadUtil
 import com.metrolist.music.LocalPlayerConnection
-import androidx.navigation.NavController
 import com.metrolist.music.R
 import com.metrolist.music.constants.CropAlbumArtKey
 import com.metrolist.music.constants.GridItemSize
@@ -131,45 +128,6 @@ import kotlinx.coroutines.withContext
 import kotlin.math.roundToInt
 
 const val ActiveBoxAlpha = 0.6f
-
-@Composable
-fun ClickableArtistText(
-    artists: List<Artist>,
-    navController: NavController,
-    modifier: Modifier = Modifier,
-    style: TextStyle = MaterialTheme.typography.bodySmall,
-    color: Color = MaterialTheme.colorScheme.secondary,
-    maxLines: Int = 1,
-    overflow: TextOverflow = TextOverflow.Ellipsis,
-) {
-    val annotatedString = remember(artists) {
-        buildAnnotatedString {
-            artists.forEachIndexed { index, artist ->
-                artist.id?.let { id ->
-                    pushStringAnnotation("artist_$id", id)
-                    append(artist.name)
-                    pop()
-                } ?: append(artist.name)
-                if (index != artists.lastIndex) {
-                    append(" ${stringResource(R.string.and)} ")
-                }
-            }
-        }
-    }
-    ClickableText(
-        text = annotatedString,
-        style = style.copy(color = color),
-        maxLines = maxLines,
-        overflow = overflow,
-        modifier = modifier,
-        onClick = { offset ->
-            annotatedString
-                .getStringAnnotations(offset, offset)
-                .firstOrNull()
-                ?.let { navController.navigate("artist/${it.item}") }
-        },
-    )
-}
 
 @Composable
 fun currentGridThumbnailHeight(): Dp {
@@ -419,7 +377,6 @@ fun SongListItem(
     showInLibraryIcon: Boolean = false,
     showDownloadIcon: Boolean = true,
     subtitleOverride: String? = null,
-    navController: NavController? = null,
     badges: @Composable RowScope.() -> Unit = {
         if (showLikedIcon && song.song.liked) {
             Icon.Favorite()
@@ -447,47 +404,10 @@ fun SongListItem(
     val content: @Composable () -> Unit = {
         ListItem(
             title = song.song.title,
-            subtitle = if (navController != null && subtitleOverride == null) {
-                {
-                    val annotated = remember(song.orderedArtists) {
-                        buildAnnotatedString {
-                            song.orderedArtists.forEachIndexed { index, artist ->
-                                artist.id?.let { id ->
-                                    pushStringAnnotation("artist_$id", id)
-                                    append(artist.name)
-                                    pop()
-                                } ?: append(artist.name)
-                                if (index != song.orderedArtists.lastIndex) {
-                                    append(" ${stringResource(R.string.and)} ")
-                                }
-                            }
-                            append(" • ")
-                            append(makeTimeString(song.song.duration * 1000L))
-                        }
-                    }
-                    ClickableText(
-                        text = annotated,
-                        style = MaterialTheme.typography.bodySmall.copy(
-                            color = MaterialTheme.colorScheme.secondary
-                        ),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        onClick = { offset ->
-                            annotated
-                                .getStringAnnotations(offset, offset)
-                                .firstOrNull()
-                                ?.let {
-                                    navController.navigate("artist/${it.item}")
-                                }
-                        },
-                    )
-                }
-            } else {
-                subtitleOverride ?: joinByBullet(
-                    song.orderedArtists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
-                    makeTimeString(song.song.duration * 1000L)
-                )
-            },
+            subtitle = subtitleOverride ?: joinByBullet(
+                song.orderedArtists.joinToString { it.name },
+                makeTimeString(song.song.duration * 1000L)
+            ),
             badges = badges,
             thumbnailContent = {
                 ItemThumbnail(
@@ -526,7 +446,6 @@ fun SongGridItem(
     showLikedIcon: Boolean = true,
     showInLibraryIcon: Boolean = false,
     showDownloadIcon: Boolean = true,
-    navController: NavController? = null,
     badges: @Composable RowScope.() -> Unit = {
         if (showLikedIcon && song.song.liked) {
             Icon.Favorite()
@@ -553,29 +472,17 @@ fun SongGridItem(
             modifier = Modifier.basicMarquee().fillMaxWidth()
         )
     },
-    subtitle = if (navController != null) {
-        {
-            ClickableArtistText(
-                artists = song.orderedArtists,
-                navController = navController,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.secondary,
-                maxLines = 2,
-            )
-        }
-    } else {
-        {
-            Text(
-                text = joinByBullet(
-                    song.orderedArtists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
-                    makeTimeString(song.song.duration * 1000L)
-                ),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.secondary,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-            )
-        }
+    subtitle = {
+        Text(
+            text = joinByBullet(
+                song.orderedArtists.joinToString { it.name },
+                makeTimeString(song.song.duration * 1000L)
+            ),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.secondary,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
     },
     badges = badges,
     thumbnailContent = {
@@ -674,7 +581,6 @@ fun AlbumListItem(
     album: Album,
     modifier: Modifier = Modifier,
     showLikedIcon: Boolean = true,
-    navController: NavController? = null,
     badges: @Composable RowScope.() -> Unit = {
         val downloadUtil = LocalDownloadUtil.current
         val database = LocalDatabase.current
@@ -714,50 +620,11 @@ fun AlbumListItem(
     trailingContent: @Composable RowScope.() -> Unit = {},
 ) = ListItem(
     title = album.album.title,
-    subtitle = if (navController != null) {
-        {
-            val annotated = remember(album.artists) {
-                buildAnnotatedString {
-                    album.artists.forEachIndexed { index, artist ->
-                        artist.id?.let { id ->
-                            pushStringAnnotation("artist_$id", id)
-                            append(artist.name)
-                            pop()
-                        } ?: append(artist.name)
-                        if (index != album.artists.lastIndex) {
-                            append(" ${stringResource(R.string.and)} ")
-                        }
-                    }
-                    append(" • ")
-                    append(pluralStringResource(R.plurals.n_song, album.album.songCount, album.album.songCount))
-                    if (album.album.year != null) {
-                        append(" • ")
-                        append(album.album.year.toString())
-                    }
-                }
-            }
-            ClickableText(
-                text = annotated,
-                style = MaterialTheme.typography.bodySmall.copy(
-                    color = MaterialTheme.colorScheme.secondary
-                ),
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                onClick = { offset ->
-                    annotated
-                        .getStringAnnotations(offset, offset)
-                        .firstOrNull()
-                        ?.let { navController.navigate("artist/${it.item}") }
-                },
-            )
-        }
-    } else {
-        joinByBullet(
-            album.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
-            pluralStringResource(R.plurals.n_song, album.album.songCount, album.album.songCount),
-            album.album.year?.toString()
-        )
-    },
+    subtitle = joinByBullet(
+        album.artists.joinToString { it.name },
+        pluralStringResource(R.plurals.n_song, album.album.songCount, album.album.songCount),
+        album.album.year?.toString()
+    ),
     badges = badges,
     thumbnailContent = {
         ItemThumbnail(
@@ -827,7 +694,7 @@ fun AlbumGridItem(
     },
     subtitle = {
         Text(
-            text = album.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
+            text = album.artists.joinToString { it.name },
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.secondary,
             maxLines = 2,
@@ -1064,7 +931,7 @@ fun MediaMetadataListItem(
         title = mediaMetadata.title,
         subtitle = if (mediaMetadata.suggestedBy != null) {
             buildAnnotatedString {
-                append(mediaMetadata.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name })
+                append(mediaMetadata.artists.joinToString { it.name })
                 append(" • ")
                 append(makeTimeString(mediaMetadata.duration * 1000L))
                 append(" • ")
@@ -1075,7 +942,7 @@ fun MediaMetadataListItem(
         } else {
             AnnotatedString(
                 joinByBullet(
-                    mediaMetadata.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
+                    mediaMetadata.artists.joinToString { it.name },
                     makeTimeString(mediaMetadata.duration * 1000L)
                 )
             )
@@ -1139,8 +1006,8 @@ fun YouTubeListItem(
         ListItem(
             title = item.title,
             subtitle = when (item) {
-                is SongItem -> joinByBullet(item.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name }, makeTimeString(item.duration?.times(1000L)))
-                is AlbumItem -> joinByBullet(item.artists?.joinToString(" ${stringResource(R.string.and)} ") { it.name }, item.year?.toString())
+                is SongItem -> joinByBullet(item.artists.joinToString { it.name }, makeTimeString(item.duration?.times(1000L)))
+                is AlbumItem -> joinByBullet(item.artists?.joinToString { it.name }, item.year?.toString())
                 is ArtistItem -> null
                 is PlaylistItem -> joinByBullet(item.author?.name, item.songCountText)
                 is PodcastItem -> joinByBullet(item.author?.name, item.episodeCountText)
@@ -1220,8 +1087,8 @@ fun YouTubeGridItem(
     },
     subtitle = {
         val subtitle = when (item) {
-            is SongItem -> joinByBullet(item.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name }, makeTimeString(item.duration?.times(1000L)))
-            is AlbumItem -> joinByBullet(item.artists?.joinToString(" ${stringResource(R.string.and)} ") { it.name }, item.year?.toString())
+            is SongItem -> joinByBullet(item.artists.joinToString { it.name }, makeTimeString(item.duration?.times(1000L)))
+            is AlbumItem -> joinByBullet(item.artists?.joinToString { it.name }, item.year?.toString())
             is ArtistItem -> null
             is PlaylistItem -> joinByBullet(item.author?.name, item.songCountText)
             is PodcastItem -> joinByBullet(item.author?.name, item.episodeCountText)

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
@@ -510,7 +510,7 @@ fun SongListItem(
                             modifier = Modifier.weight(1f)
                         )
                         Text(
-                            text = " • ${makeTimeString(song.song.duration * 1000L)}",
+                            text = " | ${makeTimeString(song.song.duration * 1000L)}",
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.secondary,
                             maxLines = 1,
@@ -609,7 +609,7 @@ fun SongGridItem(
                     modifier = Modifier.weight(1f)
                 )
                 Text(
-                    text = " • ${makeTimeString(song.song.duration * 1000L)}",
+                    text = " | ${makeTimeString(song.song.duration * 1000L)}",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.secondary,
                     maxLines = 1,
@@ -777,7 +777,7 @@ fun AlbumListItem(
                     modifier = Modifier.weight(1f)
                 )
                 Text(
-                    text = " • ${pluralStringResource(R.plurals.n_song, album.album.songCount, album.album.songCount)}${album.album.year?.let { " • $it" } ?: ""}",
+                    text = " | ${pluralStringResource(R.plurals.n_song, album.album.songCount, album.album.songCount)}${album.album.year?.let { " | $it" } ?: ""}",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.secondary,
                     maxLines = 1,
@@ -1115,7 +1115,7 @@ fun MediaMetadataListItem(
                         modifier = Modifier.weight(1f)
                     )
                     Text(
-                        text = " • ${makeTimeString(mediaMetadata.duration * 1000L)}",
+                        text = " | ${makeTimeString(mediaMetadata.duration * 1000L)}",
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.secondary,
                         maxLines = 1,
@@ -1123,7 +1123,7 @@ fun MediaMetadataListItem(
                     )
                     if (mediaMetadata.suggestedBy != null) {
                         Text(
-                            text = " • ",
+                            text = " | ",
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.secondary,
                             maxLines = 1,
@@ -1142,9 +1142,9 @@ fun MediaMetadataListItem(
                 Text(
                     text = buildAnnotatedString {
                         append(mediaMetadata.artists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name })
-                        append(" • ")
+                        append(" | ")
                         append(makeTimeString(mediaMetadata.duration * 1000L))
-                        append(" • ")
+                        append(" | ")
                         withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
                             append(mediaMetadata.suggestedBy)
                         }

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Library.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Library.kt
@@ -13,8 +13,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
-import androidx.navigation.NavController
 import com.metrolist.innertube.models.PlaylistItem
+import com.metrolist.music.LocalNavController
 import com.metrolist.innertube.models.WatchEndpoint
 import com.metrolist.music.R
 import com.metrolist.music.db.entities.Album
@@ -28,78 +28,82 @@ import kotlinx.coroutines.CoroutineScope
 
 @Composable
 fun LibraryArtistListItem(
-    navController: NavController,
     menuState: MenuState,
     coroutineScope: CoroutineScope,
     artist: Artist,
     modifier: Modifier = Modifier
-) = ArtistListItem(
-    artist = artist,
-    trailingContent = {
-        androidx.compose.material3.IconButton(
-            onClick = {
-                menuState.show {
-                    ArtistMenu(
-                        originalArtist = artist,
-                        coroutineScope = coroutineScope,
-                        onDismiss = menuState::dismiss
-                    )
+) {
+    val navController = LocalNavController.current
+    ArtistListItem(
+        artist = artist,
+        trailingContent = {
+            androidx.compose.material3.IconButton(
+                onClick = {
+                    menuState.show {
+                        ArtistMenu(
+                            originalArtist = artist,
+                            coroutineScope = coroutineScope,
+                            onDismiss = menuState::dismiss
+                        )
+                    }
                 }
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.more_vert),
+                    contentDescription = null
+                )
             }
-        ) {
-            Icon(
-                painter = painterResource(R.drawable.more_vert),
-                contentDescription = null
-            )
-        }
-    },
-    modifier = modifier
-        .fillMaxWidth()
-        .clickable {
-            navController.navigate("artist/${artist.id}")
-        }
-)
+        },
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable {
+                navController.navigate("artist/${artist.id}")
+            }
+    )
+}
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun LibraryArtistGridItem(
-    navController: NavController,
     menuState: MenuState,
     coroutineScope: CoroutineScope,
     artist: Artist,
     modifier: Modifier = Modifier
-) = ArtistGridItem(
-    artist = artist,
-    fillMaxWidth = true,
-    modifier = modifier
-        .fillMaxWidth()
-        .combinedClickable(
-            onClick = {
-                navController.navigate("artist/${artist.id}")
-            },
-            onLongClick = {
-                menuState.show {
-                    ArtistMenu(
-                        originalArtist = artist,
-                        coroutineScope = coroutineScope,
-                        onDismiss = menuState::dismiss
-                    )
+) {
+    val navController = LocalNavController.current
+    ArtistGridItem(
+        artist = artist,
+        fillMaxWidth = true,
+        modifier = modifier
+            .fillMaxWidth()
+            .combinedClickable(
+                onClick = {
+                    navController.navigate("artist/${artist.id}")
+                },
+                onLongClick = {
+                    menuState.show {
+                        ArtistMenu(
+                            originalArtist = artist,
+                            coroutineScope = coroutineScope,
+                            onDismiss = menuState::dismiss
+                        )
                 }
             }
         )
 )
+}
 
 @Composable
 fun LibraryAlbumListItem(
     modifier: Modifier = Modifier,
-    navController: NavController,
     menuState: MenuState,
     album: Album,
     isActive: Boolean = false,
     isPlaying: Boolean = false
-) = AlbumListItem(
+) {
+    val navController = LocalNavController.current
+    AlbumListItem(
     album = album,
-    navController = navController,
     isActive = isActive,
     isPlaying = isPlaying,
     trailingContent = {
@@ -108,7 +112,6 @@ fun LibraryAlbumListItem(
                 menuState.show {
                     AlbumMenu(
                         originalAlbum = album,
-                        navController = navController,
                         onDismiss = menuState::dismiss
                     )
                 }
@@ -126,18 +129,20 @@ fun LibraryAlbumListItem(
             navController.navigate("album/${album.id}")
         }
 )
+}
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun LibraryAlbumGridItem(
     modifier: Modifier = Modifier,
-    navController: NavController,
     menuState: MenuState,
     coroutineScope: CoroutineScope,
     album: Album,
     isActive: Boolean = false,
     isPlaying: Boolean = false
-) = AlbumGridItem(
+) {
+    val navController = LocalNavController.current
+    AlbumGridItem(
     album = album,
     isActive = isActive,
     isPlaying = isPlaying,
@@ -153,22 +158,23 @@ fun LibraryAlbumGridItem(
                 menuState.show {
                     AlbumMenu(
                         originalAlbum = album,
-                        navController = navController,
                         onDismiss = menuState::dismiss
                     )
                 }
             }
         )
 )
+}
 
 @Composable
 fun LibraryPlaylistListItem(
-    navController: NavController,
     menuState: MenuState,
     coroutineScope: CoroutineScope,
     playlist: Playlist,
     modifier: Modifier = Modifier
-) = PlaylistListItem(
+) {
+    val navController = LocalNavController.current
+    PlaylistListItem(
     playlist = playlist,
     trailingContent = {
         androidx.compose.material3.IconButton(
@@ -226,16 +232,18 @@ fun LibraryPlaylistListItem(
                 navController.navigate("local_playlist/${playlist.id}")
         }
 )
+}
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun LibraryPlaylistGridItem(
-    navController: NavController,
     menuState: MenuState,
     coroutineScope: CoroutineScope,
     playlist: Playlist,
     modifier: Modifier = Modifier
-) = PlaylistGridItem(
+) {
+    val navController = LocalNavController.current
+    PlaylistGridItem(
     playlist = playlist,
     fillMaxWidth = true,
     modifier = modifier
@@ -287,3 +295,4 @@ fun LibraryPlaylistGridItem(
             }
         )
 )
+}

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Library.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Library.kt
@@ -99,6 +99,7 @@ fun LibraryAlbumListItem(
     isPlaying: Boolean = false
 ) = AlbumListItem(
     album = album,
+    navController = navController,
     isActive = isActive,
     isPlaying = isPlaying,
     trailingContent = {

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/SongDropdownSelect.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/SongDropdownSelect.kt
@@ -1,4 +1,5 @@
 package com.metrolist.music.ui.component
+import com.metrolist.music.utils.ARTIST_SEPARATOR
 
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
@@ -99,7 +100,7 @@ fun SongSelectDropdown(
                                     maxLines = 1,
                                 )
                                 Spacer(modifier = Modifier.width(8.dp))
-                                val displayArtists = song.artists.joinToString(", ") { it.name }.ifBlank { song.artistName }
+                                val displayArtists = song.artists.joinToString(ARTIST_SEPARATOR) { it.name }.ifBlank { song.artistName }
                                 displayArtists?.let {
                                     Text(
                                         text = it,

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/SongDropdownSelect.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/SongDropdownSelect.kt
@@ -1,5 +1,4 @@
 package com.metrolist.music.ui.component
-import com.metrolist.music.utils.ARTIST_SEPARATOR
 
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
@@ -100,7 +99,7 @@ fun SongSelectDropdown(
                                     maxLines = 1,
                                 )
                                 Spacer(modifier = Modifier.width(8.dp))
-                                val displayArtists = song.artists.joinToString(ARTIST_SEPARATOR) { it.name }.ifBlank { song.artistName }
+                                val displayArtists = song.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name }.ifBlank { song.artistName }
                                 displayArtists?.let {
                                     Text(
                                         text = it,

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/AlbumMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/AlbumMenu.kt
@@ -5,6 +5,7 @@
 
 package com.metrolist.music.ui.menu
 
+import com.metrolist.music.utils.ARTIST_SEPARATOR
 import android.annotation.SuppressLint
 import android.content.Intent
 import android.content.res.Configuration
@@ -462,7 +463,7 @@ fun AlbumMenu(
                                                 id = album.id,
                                                 secondaryId = album.album.playlistId,
                                                 title = album.album.title,
-                                                subtitle = album.artists.joinToString(", ") { it.name },
+                                                subtitle = album.artists.joinToString(ARTIST_SEPARATOR) { it.name },
                                                 subtitleIds = album.artists.joinToString(", ") { it.id },
                                                 thumbnailUrl = album.album.thumbnailUrl,
                                                 type = "ALBUM",

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/AlbumMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/AlbumMenu.kt
@@ -5,7 +5,7 @@
 
 package com.metrolist.music.ui.menu
 
-import com.metrolist.music.utils.ARTIST_SEPARATOR
+
 import android.annotation.SuppressLint
 import android.content.Intent
 import android.content.res.Configuration
@@ -463,7 +463,7 @@ fun AlbumMenu(
                                                 id = album.id,
                                                 secondaryId = album.album.playlistId,
                                                 title = album.album.title,
-                                                subtitle = album.artists.joinToString(ARTIST_SEPARATOR) { it.name },
+                                                subtitle = album.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
                                                 subtitleIds = album.artists.joinToString(", ") { it.id },
                                                 thumbnailUrl = album.album.thumbnailUrl,
                                                 type = "ALBUM",

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/AlbumMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/AlbumMenu.kt
@@ -64,8 +64,8 @@ import androidx.media3.exoplayer.offline.Download.STATE_QUEUED
 import androidx.media3.exoplayer.offline.Download.STATE_STOPPED
 import androidx.media3.exoplayer.offline.DownloadRequest
 import androidx.media3.exoplayer.offline.DownloadService
-import androidx.navigation.NavController
 import coil3.compose.AsyncImage
+import com.metrolist.music.LocalNavController
 import com.metrolist.innertube.YouTube
 import com.metrolist.music.LocalDatabase
 import com.metrolist.music.LocalDownloadUtil
@@ -99,9 +99,9 @@ import kotlinx.coroutines.launch
 @Composable
 fun AlbumMenu(
     originalAlbum: Album,
-    navController: NavController,
     onDismiss: () -> Unit,
 ) {
+    val navController = LocalNavController.current
     val context = LocalContext.current
     val database = LocalDatabase.current
     val downloadUtil = LocalDownloadUtil.current
@@ -215,7 +215,7 @@ fun AlbumMenu(
             }
 
             items(notAddedList) { song ->
-                SongListItem(song = song, navController = navController)
+                SongListItem(song = song)
             }
         }
     }
@@ -270,7 +270,6 @@ fun AlbumMenu(
 
     AlbumListItem(
         album = album,
-        navController = navController,
         showLikedIcon = false,
         badges = {},
         trailingContent = {

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/AlbumMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/AlbumMenu.kt
@@ -215,7 +215,7 @@ fun AlbumMenu(
             }
 
             items(notAddedList) { song ->
-                SongListItem(song = song)
+                SongListItem(song = song, navController = navController)
             }
         }
     }
@@ -270,6 +270,7 @@ fun AlbumMenu(
 
     AlbumListItem(
         album = album,
+        navController = navController,
         showLikedIcon = false,
         badges = {},
         trailingContent = {

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/AlbumMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/AlbumMenu.kt
@@ -5,7 +5,6 @@
 
 package com.metrolist.music.ui.menu
 
-
 import android.annotation.SuppressLint
 import android.content.Intent
 import android.content.res.Configuration
@@ -463,7 +462,7 @@ fun AlbumMenu(
                                                 id = album.id,
                                                 secondaryId = album.album.playlistId,
                                                 title = album.album.title,
-                                                subtitle = album.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
+                                                subtitle = album.artists.joinToString(", ") { it.name },
                                                 subtitleIds = album.artists.joinToString(", ") { it.id },
                                                 thumbnailUrl = album.album.thumbnailUrl,
                                                 type = "ALBUM",

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/PlayerMenu.kt
@@ -146,6 +146,8 @@ fun PlayerMenu(
 
     val isPinned by database.speedDialDao.isPinned(mediaMetadata.id).collectAsStateWithLifecycle(initialValue = false)
 
+    val separator = " ${stringResource(R.string.and)} "
+
     val artists =
         remember(mediaMetadata.artists) {
             mediaMetadata.artists.filter { it.id != null }
@@ -526,8 +528,8 @@ fun PlayerMenu(
                                     coroutineScope.launch(Dispatchers.IO) {
                                         if (isPinned) {
                                             database.speedDialDao.delete(mediaMetadata.id)
-                                        } else {
-                                            database.speedDialDao.insert(SpeedDialItem.fromYTItem(mediaMetadata.toYTItem()))
+                                         } else {
+                                            database.speedDialDao.insert(SpeedDialItem.fromYTItem(mediaMetadata.toYTItem(), separator))
                                         }
                                     }
                                     onDismiss()

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/PlayerMenu.kt
@@ -78,8 +78,8 @@ import androidx.media3.common.PlaybackParameters
 import androidx.media3.exoplayer.offline.Download
 import androidx.media3.exoplayer.offline.DownloadRequest
 import androidx.media3.exoplayer.offline.DownloadService
-import androidx.navigation.NavController
 import com.metrolist.innertube.YouTube
+import com.metrolist.music.LocalNavController
 import com.metrolist.music.LocalDatabase
 import com.metrolist.music.LocalDownloadUtil
 import com.metrolist.music.LocalListenTogetherManager
@@ -110,13 +110,13 @@ import kotlin.math.round
 @Composable
 fun PlayerMenu(
     mediaMetadata: MediaMetadata?,
-    navController: NavController,
     playerBottomSheetState: BottomSheetState,
     isQueueTrigger: Boolean? = false,
     onShowDetailsDialog: () -> Unit,
     onDismiss: () -> Unit,
 ) {
     mediaMetadata ?: return
+    val navController = LocalNavController.current
     val context = LocalContext.current
     val database = LocalDatabase.current
     val playerConnection = LocalPlayerConnection.current ?: return

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/PlayerMenu.kt
@@ -146,8 +146,6 @@ fun PlayerMenu(
 
     val isPinned by database.speedDialDao.isPinned(mediaMetadata.id).collectAsStateWithLifecycle(initialValue = false)
 
-    val separator = " ${stringResource(R.string.and)} "
-
     val artists =
         remember(mediaMetadata.artists) {
             mediaMetadata.artists.filter { it.id != null }
@@ -528,8 +526,8 @@ fun PlayerMenu(
                                     coroutineScope.launch(Dispatchers.IO) {
                                         if (isPinned) {
                                             database.speedDialDao.delete(mediaMetadata.id)
-                                         } else {
-                                            database.speedDialDao.insert(SpeedDialItem.fromYTItem(mediaMetadata.toYTItem(), separator))
+                                        } else {
+                                            database.speedDialDao.insert(SpeedDialItem.fromYTItem(mediaMetadata.toYTItem()))
                                         }
                                     }
                                     onDismiss()

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/QueueMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/QueueMenu.kt
@@ -185,6 +185,7 @@ fun QueueMenu(
     val isFavorite = if (isEpisode) librarySong?.song?.inLibrary != null else librarySong?.song?.liked == true
     MediaMetadataListItem(
         mediaMetadata = mediaMetadata,
+        navController = navController,
         trailingContent = {
             IconButton(
                 onClick = {

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/QueueMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/QueueMenu.kt
@@ -55,8 +55,8 @@ import androidx.core.net.toUri
 import androidx.media3.exoplayer.offline.Download
 import androidx.media3.exoplayer.offline.DownloadRequest
 import androidx.media3.exoplayer.offline.DownloadService
-import androidx.navigation.NavController
 import coil3.compose.AsyncImage
+import com.metrolist.music.LocalNavController
 import com.metrolist.innertube.YouTube
 import com.metrolist.music.LocalDatabase
 import com.metrolist.music.LocalDownloadUtil
@@ -84,12 +84,12 @@ import kotlinx.coroutines.launch
 @Composable
 fun QueueMenu(
     mediaMetadata: MediaMetadata?,
-    navController: NavController,
     playerBottomSheetState: BottomSheetState,
     onShowDetailsDialog: () -> Unit,
     onDismiss: () -> Unit,
 ) {
     mediaMetadata ?: return
+    val navController = LocalNavController.current
     val context = LocalContext.current
     val database = LocalDatabase.current
     val playerConnection = LocalPlayerConnection.current ?: return
@@ -185,7 +185,6 @@ fun QueueMenu(
     val isFavorite = if (isEpisode) librarySong?.song?.inLibrary != null else librarySong?.song?.liked == true
     MediaMetadataListItem(
         mediaMetadata = mediaMetadata,
-        navController = navController,
         trailingContent = {
             IconButton(
                 onClick = {

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/SongMenu.kt
@@ -274,7 +274,7 @@ fun SongMenu(
             }
 
             items(listOf(song)) { song ->
-                SongListItem(song = song)
+                SongListItem(song = song, navController = navController)
             }
         }
     }
@@ -425,6 +425,7 @@ fun SongMenu(
 
     SongListItem(
         song = song,
+        navController = navController,
         badges = {},
         trailingContent = {
             // For episodes, show saved state and toggle save for later

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/SongMenu.kt
@@ -65,8 +65,8 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.media3.exoplayer.offline.Download
 import androidx.media3.exoplayer.offline.DownloadRequest
 import androidx.media3.exoplayer.offline.DownloadService
-import androidx.navigation.NavController
 import coil3.compose.AsyncImage
+import com.metrolist.music.LocalNavController
 import com.metrolist.innertube.YouTube
 import com.metrolist.music.LocalDatabase
 import com.metrolist.music.LocalDownloadUtil
@@ -108,12 +108,12 @@ import java.time.LocalDateTime
 fun SongMenu(
     originalSong: Song,
     event: Event? = null,
-    navController: NavController,
     playlistSong: PlaylistSong? = null,
     playlistBrowseId: String? = null,
     onDismiss: () -> Unit,
     isFromCache: Boolean = false,
 ) {
+    val navController = LocalNavController.current
     val context = LocalContext.current
     val database = LocalDatabase.current
     val playerConnection = LocalPlayerConnection.current ?: return
@@ -274,7 +274,7 @@ fun SongMenu(
             }
 
             items(listOf(song)) { song ->
-                SongListItem(song = song, navController = navController)
+                SongListItem(song = song)
             }
         }
     }
@@ -425,7 +425,6 @@ fun SongMenu(
 
     SongListItem(
         song = song,
-        navController = navController,
         badges = {},
         trailingContent = {
             // For episodes, show saved state and toggle save for later

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/SongMenu.kt
@@ -4,6 +4,7 @@
  */
 
 package com.metrolist.music.ui.menu
+import com.metrolist.music.utils.ARTIST_SEPARATOR
 
 import android.content.Intent
 import android.content.res.Configuration
@@ -583,7 +584,7 @@ fun SongMenu(
                                         com.metrolist.music.listentogether.TrackInfo(
                                             id = song.id,
                                             title = song.song.title,
-                                            artist = orderedArtists.joinToString(", ") { it.name },
+                                            artist = orderedArtists.joinToString(ARTIST_SEPARATOR) { it.name },
                                             album = song.song.albumName,
                                             duration = durationMs,
                                             thumbnail = song.thumbnailUrl,
@@ -681,7 +682,7 @@ fun SongMenu(
                                                 SpeedDialItem(
                                                     id = song.id,
                                                     title = song.song.title,
-                                                    subtitle = song.artists.joinToString(", ") { it.name },
+                                                    subtitle = song.artists.joinToString(ARTIST_SEPARATOR) { it.name },
                                                     subtitleIds = song.artists.joinToString(", ") { it.id },
                                                     thumbnailUrl = song.song.thumbnailUrl,
                                                     type = "SONG",

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/SongMenu.kt
@@ -4,7 +4,7 @@
  */
 
 package com.metrolist.music.ui.menu
-import com.metrolist.music.utils.ARTIST_SEPARATOR
+
 
 import android.content.Intent
 import android.content.res.Configuration
@@ -584,7 +584,7 @@ fun SongMenu(
                                         com.metrolist.music.listentogether.TrackInfo(
                                             id = song.id,
                                             title = song.song.title,
-                                            artist = orderedArtists.joinToString(ARTIST_SEPARATOR) { it.name },
+                                            artist = orderedArtists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
                                             album = song.song.albumName,
                                             duration = durationMs,
                                             thumbnail = song.thumbnailUrl,
@@ -682,7 +682,7 @@ fun SongMenu(
                                                 SpeedDialItem(
                                                     id = song.id,
                                                     title = song.song.title,
-                                                    subtitle = song.artists.joinToString(ARTIST_SEPARATOR) { it.name },
+                                                    subtitle = song.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
                                                     subtitleIds = song.artists.joinToString(", ") { it.id },
                                                     thumbnailUrl = song.song.thumbnailUrl,
                                                     type = "SONG",

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/SongMenu.kt
@@ -5,7 +5,6 @@
 
 package com.metrolist.music.ui.menu
 
-
 import android.content.Intent
 import android.content.res.Configuration
 import android.widget.Toast
@@ -584,7 +583,7 @@ fun SongMenu(
                                         com.metrolist.music.listentogether.TrackInfo(
                                             id = song.id,
                                             title = song.song.title,
-                                            artist = orderedArtists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
+                                            artist = orderedArtists.joinToString(", ") { it.name },
                                             album = song.song.albumName,
                                             duration = durationMs,
                                             thumbnail = song.thumbnailUrl,
@@ -682,7 +681,7 @@ fun SongMenu(
                                                 SpeedDialItem(
                                                     id = song.id,
                                                     title = song.song.title,
-                                                    subtitle = song.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
+                                                    subtitle = song.artists.joinToString(", ") { it.name },
                                                     subtitleIds = song.artists.joinToString(", ") { it.id },
                                                     thumbnailUrl = song.song.thumbnailUrl,
                                                     type = "SONG",

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeAlbumMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeAlbumMenu.kt
@@ -98,6 +98,7 @@ fun YouTubeAlbumMenu(
     val isGuest = listenTogetherManager?.isInRoom == true && !listenTogetherManager.isHost
     val album by database.albumWithSongs(albumItem.id).collectAsStateWithLifecycle(initialValue = null)
     val isPinned by database.speedDialDao.isPinned(albumItem.id).collectAsStateWithLifecycle(initialValue = false)
+    val separator = " ${stringResource(R.string.and)} "
     val coroutineScope = rememberCoroutineScope()
 
     LaunchedEffect(Unit) {
@@ -427,7 +428,7 @@ fun YouTubeAlbumMenu(
                                     if (isPinned) {
                                         database.speedDialDao.delete(albumItem.id)
                                     } else {
-                                        database.speedDialDao.insert(SpeedDialItem.fromYTItem(albumItem))
+                                        database.speedDialDao.insert(SpeedDialItem.fromYTItem(albumItem, separator))
                                     }
                                 }
                                 onDismiss()

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeAlbumMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeAlbumMenu.kt
@@ -190,7 +190,7 @@ fun YouTubeAlbumMenu(
             }
 
             items(notAddedList) { song ->
-                SongListItem(song = song)
+                SongListItem(song = song, navController = navController)
             }
         }
     }

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeAlbumMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeAlbumMenu.kt
@@ -56,8 +56,8 @@ import androidx.core.net.toUri
 import androidx.media3.exoplayer.offline.Download
 import androidx.media3.exoplayer.offline.DownloadRequest
 import androidx.media3.exoplayer.offline.DownloadService
-import androidx.navigation.NavController
 import com.metrolist.innertube.YouTube
+import com.metrolist.music.LocalNavController
 import com.metrolist.innertube.models.AlbumItem
 import com.metrolist.music.LocalDatabase
 import com.metrolist.music.LocalDownloadUtil
@@ -87,9 +87,9 @@ import kotlinx.coroutines.launch
 @Composable
 fun YouTubeAlbumMenu(
     albumItem: AlbumItem,
-    navController: NavController,
     onDismiss: () -> Unit,
 ) {
+    val navController = LocalNavController.current
     val context = LocalContext.current
     val database = LocalDatabase.current
     val downloadUtil = LocalDownloadUtil.current
@@ -190,7 +190,7 @@ fun YouTubeAlbumMenu(
             }
 
             items(notAddedList) { song ->
-                SongListItem(song = song, navController = navController)
+                SongListItem(song = song)
             }
         }
     }

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeAlbumMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeAlbumMenu.kt
@@ -98,7 +98,6 @@ fun YouTubeAlbumMenu(
     val isGuest = listenTogetherManager?.isInRoom == true && !listenTogetherManager.isHost
     val album by database.albumWithSongs(albumItem.id).collectAsStateWithLifecycle(initialValue = null)
     val isPinned by database.speedDialDao.isPinned(albumItem.id).collectAsStateWithLifecycle(initialValue = false)
-    val separator = " ${stringResource(R.string.and)} "
     val coroutineScope = rememberCoroutineScope()
 
     LaunchedEffect(Unit) {
@@ -428,7 +427,7 @@ fun YouTubeAlbumMenu(
                                     if (isPinned) {
                                         database.speedDialDao.delete(albumItem.id)
                                     } else {
-                                        database.speedDialDao.insert(SpeedDialItem.fromYTItem(albumItem, separator))
+                                        database.speedDialDao.insert(SpeedDialItem.fromYTItem(albumItem))
                                     }
                                 }
                                 onDismiss()

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeArtistMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeArtistMenu.kt
@@ -61,6 +61,7 @@ fun YouTubeArtistMenu(
     val listenTogetherManager = LocalListenTogetherManager.current
     val isGuest = listenTogetherManager?.isInRoom == true && !listenTogetherManager.isHost
     val isPinned by database.speedDialDao.isPinned(artist.id).collectAsStateWithLifecycle(initialValue = false)
+    val separator = " ${stringResource(R.string.and)} "
     val coroutineScope = rememberCoroutineScope()
 
     YouTubeListItem(
@@ -124,7 +125,7 @@ fun YouTubeArtistMenu(
                                     if (isPinned) {
                                         database.speedDialDao.delete(artist.id)
                                     } else {
-                                        database.speedDialDao.insert(SpeedDialItem.fromYTItem(artist))
+                                        database.speedDialDao.insert(SpeedDialItem.fromYTItem(artist, separator))
                                     }
                                 }
                                 onDismiss()

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeArtistMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeArtistMenu.kt
@@ -61,7 +61,6 @@ fun YouTubeArtistMenu(
     val listenTogetherManager = LocalListenTogetherManager.current
     val isGuest = listenTogetherManager?.isInRoom == true && !listenTogetherManager.isHost
     val isPinned by database.speedDialDao.isPinned(artist.id).collectAsStateWithLifecycle(initialValue = false)
-    val separator = " ${stringResource(R.string.and)} "
     val coroutineScope = rememberCoroutineScope()
 
     YouTubeListItem(
@@ -125,7 +124,7 @@ fun YouTubeArtistMenu(
                                     if (isPinned) {
                                         database.speedDialDao.delete(artist.id)
                                     } else {
-                                        database.speedDialDao.insert(SpeedDialItem.fromYTItem(artist, separator))
+                                        database.speedDialDao.insert(SpeedDialItem.fromYTItem(artist))
                                     }
                                 }
                                 onDismiss()

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubePlaylistMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubePlaylistMenu.kt
@@ -115,6 +115,7 @@ fun YouTubePlaylistMenu(
     val isGuest = listenTogetherManager?.isInRoom == true && !listenTogetherManager.isHost
     val dbPlaylist by database.playlistByBrowseId(playlist.id).collectAsStateWithLifecycle(initialValue = null)
     val isPinned by database.speedDialDao.isPinned(playlist.id).collectAsStateWithLifecycle(initialValue = false)
+    val separator = " ${stringResource(R.string.and)} "
 
     var showChoosePlaylistDialog by rememberSaveable { mutableStateOf(false) }
     var showImportPlaylistDialog by rememberSaveable { mutableStateOf(false) }
@@ -578,7 +579,7 @@ fun YouTubePlaylistMenu(
                                     if (isPinned) {
                                         database.speedDialDao.delete(playlist.id)
                                     } else {
-                                        database.speedDialDao.insert(SpeedDialItem.fromYTItem(playlist))
+                                        database.speedDialDao.insert(SpeedDialItem.fromYTItem(playlist, separator))
                                     }
                                 }
                                 onDismiss()

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubePlaylistMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubePlaylistMenu.kt
@@ -115,7 +115,6 @@ fun YouTubePlaylistMenu(
     val isGuest = listenTogetherManager?.isInRoom == true && !listenTogetherManager.isHost
     val dbPlaylist by database.playlistByBrowseId(playlist.id).collectAsStateWithLifecycle(initialValue = null)
     val isPinned by database.speedDialDao.isPinned(playlist.id).collectAsStateWithLifecycle(initialValue = false)
-    val separator = " ${stringResource(R.string.and)} "
 
     var showChoosePlaylistDialog by rememberSaveable { mutableStateOf(false) }
     var showImportPlaylistDialog by rememberSaveable { mutableStateOf(false) }
@@ -579,7 +578,7 @@ fun YouTubePlaylistMenu(
                                     if (isPinned) {
                                         database.speedDialDao.delete(playlist.id)
                                     } else {
-                                        database.speedDialDao.insert(SpeedDialItem.fromYTItem(playlist, separator))
+                                        database.speedDialDao.insert(SpeedDialItem.fromYTItem(playlist))
                                     }
                                 }
                                 onDismiss()

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeSongMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeSongMenu.kt
@@ -5,6 +5,7 @@
 
 package com.metrolist.music.ui.menu
 
+import com.metrolist.music.utils.ARTIST_SEPARATOR
 import android.annotation.SuppressLint
 import android.content.Intent
 import android.content.res.Configuration
@@ -366,7 +367,7 @@ fun YouTubeSongMenu(
                                 val trackInfo = com.metrolist.music.listentogether.TrackInfo(
                                     id = song.id,
                                     title = song.title,
-                                    artist = artists.joinToString(", ") { it.name },
+                                    artist = artists.joinToString(ARTIST_SEPARATOR) { it.name },
                                     album = song.album?.name,
                                     duration = durationMs,
                                     thumbnail = song.thumbnail

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeSongMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeSongMenu.kt
@@ -5,7 +5,7 @@
 
 package com.metrolist.music.ui.menu
 
-import com.metrolist.music.utils.ARTIST_SEPARATOR
+
 import android.annotation.SuppressLint
 import android.content.Intent
 import android.content.res.Configuration
@@ -110,6 +110,7 @@ fun YouTubeSongMenu(
     val syncUtils = LocalSyncUtils.current
     val listenTogetherManager = LocalListenTogetherManager.current
     val isPinned by database.speedDialDao.isPinned(song.id).collectAsStateWithLifecycle(initialValue = false)
+    val separator = " ${stringResource(R.string.and)} "
     val artists = remember {
         song.artists.mapNotNull {
             it.id?.let { artistId ->
@@ -367,7 +368,7 @@ fun YouTubeSongMenu(
                                 val trackInfo = com.metrolist.music.listentogether.TrackInfo(
                                     id = song.id,
                                     title = song.title,
-                                    artist = artists.joinToString(ARTIST_SEPARATOR) { it.name },
+                                    artist = artists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
                                     album = song.album?.name,
                                     duration = durationMs,
                                     thumbnail = song.thumbnail
@@ -517,7 +518,7 @@ fun YouTubeSongMenu(
                                     if (isPinned) {
                                         database.speedDialDao.delete(song.id)
                                     } else {
-                                        database.speedDialDao.insert(SpeedDialItem.fromYTItem(song))
+                                        database.speedDialDao.insert(SpeedDialItem.fromYTItem(song, separator))
                                     }
                                 }
                                 onDismiss()

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeSongMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeSongMenu.kt
@@ -55,9 +55,9 @@ import androidx.core.net.toUri
 import androidx.media3.exoplayer.offline.Download
 import androidx.media3.exoplayer.offline.DownloadRequest
 import androidx.media3.exoplayer.offline.DownloadService
-import androidx.navigation.NavController
 import coil3.compose.AsyncImage
 import com.metrolist.innertube.YouTube
+import com.metrolist.music.LocalNavController
 import com.metrolist.innertube.models.SongItem
 import com.metrolist.music.LocalDatabase
 import com.metrolist.music.LocalDownloadUtil
@@ -96,10 +96,10 @@ import java.time.LocalDateTime
 @Composable
 fun YouTubeSongMenu(
     song: SongItem,
-    navController: NavController,
     onDismiss: () -> Unit,
     onHistoryRemoved: () -> Unit = {}
 ) {
+    val navController = LocalNavController.current
     val context = LocalContext.current
     val database = LocalDatabase.current
     val playerConnection = LocalPlayerConnection.current ?: return

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeSongMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeSongMenu.kt
@@ -5,7 +5,6 @@
 
 package com.metrolist.music.ui.menu
 
-
 import android.annotation.SuppressLint
 import android.content.Intent
 import android.content.res.Configuration
@@ -110,7 +109,6 @@ fun YouTubeSongMenu(
     val syncUtils = LocalSyncUtils.current
     val listenTogetherManager = LocalListenTogetherManager.current
     val isPinned by database.speedDialDao.isPinned(song.id).collectAsStateWithLifecycle(initialValue = false)
-    val separator = " ${stringResource(R.string.and)} "
     val artists = remember {
         song.artists.mapNotNull {
             it.id?.let { artistId ->
@@ -368,7 +366,7 @@ fun YouTubeSongMenu(
                                 val trackInfo = com.metrolist.music.listentogether.TrackInfo(
                                     id = song.id,
                                     title = song.title,
-                                    artist = artists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
+                                    artist = artists.joinToString(", ") { it.name },
                                     album = song.album?.name,
                                     duration = durationMs,
                                     thumbnail = song.thumbnail
@@ -518,7 +516,7 @@ fun YouTubeSongMenu(
                                     if (isPinned) {
                                         database.speedDialDao.delete(song.id)
                                     } else {
-                                        database.speedDialDao.insert(SpeedDialItem.fromYTItem(song, separator))
+                                        database.speedDialDao.insert(SpeedDialItem.fromYTItem(song))
                                     }
                                 }
                                 onDismiss()

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/MiniPlayer.kt
@@ -7,7 +7,6 @@
 
 package com.metrolist.music.ui.player
 
-import com.metrolist.music.utils.ARTIST_SEPARATOR
 import android.content.res.Configuration
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Animatable
@@ -671,10 +670,10 @@ private fun NewMiniPlayerSongInfo(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 if (metadata.explicit) MIcon.Explicit()
-                val displayArtists = metadata.artists.filter { it.id != null && it.name.isNotBlank() }
+                val displayArtists = metadata.artists.filter { it.name.isNotBlank() }
                 if (displayArtists.isNotEmpty()) {
                     Text(
-                        text = displayArtists.joinToString(ARTIST_SEPARATOR) { it.name },
+                        text = displayArtists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
                         color = onSurfaceColor.copy(alpha = 0.7f),
                         fontSize = 12.sp,
                         maxLines = 1,

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/MiniPlayer.kt
@@ -670,10 +670,10 @@ private fun NewMiniPlayerSongInfo(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 if (metadata.explicit) MIcon.Explicit()
-                if (metadata.artists.any { it.name.isNotBlank() }) {
-                    Text(
-                        text = metadata.artists.joinToString { it.name },
-                        color = onSurfaceColor.copy(alpha = 0.7f),
+                 if (metadata.artists.any { it.name.isNotBlank() }) {
+                     Text(
+                         text = metadata.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
+                         color = onSurfaceColor.copy(alpha = 0.7f),
                         fontSize = 12.sp,
                         maxLines = 1,
                         overflow = TextOverflow.Clip,
@@ -1031,10 +1031,10 @@ private fun LegacyMiniMediaInfo(
                 modifier = Modifier.basicMarquee(),
             )
 
-            if (mediaMetadata.artists.any { it.name.isNotBlank() }) {
-                Text(
-                    text = mediaMetadata.artists.joinToString { it.name },
-                    color = MaterialTheme.colorScheme.secondary,
+             if (mediaMetadata.artists.any { it.name.isNotBlank() }) {
+                 Text(
+                     text = mediaMetadata.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
+                     color = MaterialTheme.colorScheme.secondary,
                     fontSize = 12.sp,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/MiniPlayer.kt
@@ -7,6 +7,7 @@
 
 package com.metrolist.music.ui.player
 
+import com.metrolist.music.utils.ARTIST_SEPARATOR
 import android.content.res.Configuration
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Animatable
@@ -670,9 +671,10 @@ private fun NewMiniPlayerSongInfo(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 if (metadata.explicit) MIcon.Explicit()
-                if (metadata.artists.any { it.name.isNotBlank() }) {
+                val displayArtists = metadata.artists.filter { it.id != null && it.name.isNotBlank() }
+                if (displayArtists.isNotEmpty()) {
                     Text(
-                        text = metadata.artists.joinToString { it.name },
+                        text = displayArtists.joinToString(ARTIST_SEPARATOR) { it.name },
                         color = onSurfaceColor.copy(alpha = 0.7f),
                         fontSize = 12.sp,
                         maxLines = 1,

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/MiniPlayer.kt
@@ -670,10 +670,9 @@ private fun NewMiniPlayerSongInfo(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 if (metadata.explicit) MIcon.Explicit()
-                val displayArtists = metadata.artists.filter { it.name.isNotBlank() }
-                if (displayArtists.isNotEmpty()) {
+                if (metadata.artists.any { it.name.isNotBlank() }) {
                     Text(
-                        text = displayArtists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
+                        text = metadata.artists.joinToString { it.name },
                         color = onSurfaceColor.copy(alpha = 0.7f),
                         fontSize = 12.sp,
                         maxLines = 1,

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/MiniPlayer.kt
@@ -100,6 +100,7 @@ import com.metrolist.music.playback.CastConnectionHandler
 import com.metrolist.music.playback.PlayerConnection
 import com.metrolist.music.ui.screens.settings.DarkMode
 import com.metrolist.music.ui.utils.resize
+import com.metrolist.music.utils.joinToArtistString
 import com.metrolist.music.utils.rememberEnumPreference
 import com.metrolist.music.utils.rememberPreference
 import kotlinx.coroutines.launch
@@ -672,7 +673,7 @@ private fun NewMiniPlayerSongInfo(
                 if (metadata.explicit) MIcon.Explicit()
                  if (metadata.artists.any { it.name.isNotBlank() }) {
                      Text(
-                         text = metadata.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
+                         text = metadata.artists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name },
                          color = onSurfaceColor.copy(alpha = 0.7f),
                         fontSize = 12.sp,
                         maxLines = 1,
@@ -1033,7 +1034,7 @@ private fun LegacyMiniMediaInfo(
 
              if (mediaMetadata.artists.any { it.name.isNotBlank() }) {
                  Text(
-                     text = mediaMetadata.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
+                     text = mediaMetadata.artists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name },
                      color = MaterialTheme.colorScheme.secondary,
                     fontSize = 12.sp,
                     maxLines = 1,

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
@@ -126,6 +126,7 @@ import androidx.media3.common.Player
 import androidx.media3.common.Player.STATE_ENDED
 import androidx.navigation.NavController
 import androidx.palette.graphics.Palette
+import com.metrolist.music.LocalNavController
 import coil3.compose.AsyncImage
 import coil3.imageLoader
 import coil3.request.ImageRequest
@@ -1340,7 +1341,6 @@ fun BottomSheetPlayer(
                         } else {
                             PlayerMoreMenuButton(
                                 mediaMetadata = mediaMetadata,
-                                navController = navController,
                                 state = state,
                                 textButtonColor = textButtonColor,
                                 iconButtonColor = iconButtonColor,
@@ -1951,7 +1951,6 @@ fun BottomSheetPlayer(
             Queue(
                 state = queueSheetState,
                 playerBottomSheetState = state,
-                navController = navController,
                 background =
                     if (useBlackBackground) {
                         Color.Black
@@ -2137,7 +2136,6 @@ fun MoreActionsButton(
                     menuState.show {
                         PlayerMenu(
                             mediaMetadata = mediaMetadata,
-                            navController = navController,
                             playerBottomSheetState = state,
                             onShowDetailsDialog = {
                                 mediaMetadata.id.let {
@@ -2162,11 +2160,11 @@ fun MoreActionsButton(
 @Composable
 private fun PlayerMoreMenuButton(
     mediaMetadata: MediaMetadata,
-    navController: NavController,
     state: BottomSheetState,
     textButtonColor: Color,
     iconButtonColor: Color,
 ) {
+    val navController = LocalNavController.current
     val menuState = LocalMenuState.current
     val bottomSheetPageState = LocalBottomSheetPageState.current
 
@@ -2181,7 +2179,6 @@ private fun PlayerMoreMenuButton(
                     menuState.show {
                         PlayerMenu(
                             mediaMetadata = mediaMetadata,
-                            navController = navController,
                             playerBottomSheetState = state,
                             onShowDetailsDialog = {
                                 mediaMetadata.id.let {

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
@@ -1022,17 +1022,19 @@ fun BottomSheetPlayer(
                     ) {
                         if (mediaMetadata.explicit) MIcon.Explicit()
 
-                        if (mediaMetadata.artists.any { it.name.isNotBlank() }) {
+                        val validArtists = mediaMetadata.artists.filter { it.id != null && it.name.isNotBlank() }
+                        if (validArtists.isNotEmpty()) {
                             val annotatedString =
                                 buildAnnotatedString {
-                                    mediaMetadata.artists.forEachIndexed { index, artist ->
-                                        val tag = "artist_${artist.id.orEmpty()}"
-                                        pushStringAnnotation(tag = tag, annotation = artist.id.orEmpty())
+                                    validArtists.forEachIndexed { index, artist ->
+                                        val id = requireNotNull(artist.id)
+                                        val tag = "artist_$id"
+                                        pushStringAnnotation(tag = tag, annotation = id)
                                         withStyle(SpanStyle(color = TextBackgroundColor, fontSize = 16.sp)) {
                                             append(artist.name)
                                         }
                                         pop()
-                                        if (index != mediaMetadata.artists.lastIndex) append(", ")
+                                        if (index != validArtists.lastIndex) append(" - ")
                                     }
                                 }
 

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
@@ -1022,19 +1022,17 @@ fun BottomSheetPlayer(
                     ) {
                         if (mediaMetadata.explicit) MIcon.Explicit()
 
-                        val validArtists = mediaMetadata.artists.filter { it.id != null && it.name.isNotBlank() }
-                        if (validArtists.isNotEmpty()) {
+                        if (mediaMetadata.artists.any { it.name.isNotBlank() }) {
                             val annotatedString =
                                 buildAnnotatedString {
-                                    validArtists.forEachIndexed { index, artist ->
-                                        val id = requireNotNull(artist.id)
-                                        val tag = "artist_$id"
-                                        pushStringAnnotation(tag = tag, annotation = id)
+                                    mediaMetadata.artists.forEachIndexed { index, artist ->
+                                        val tag = "artist_${artist.id.orEmpty()}"
+                                        pushStringAnnotation(tag = tag, annotation = artist.id.orEmpty())
                                         withStyle(SpanStyle(color = TextBackgroundColor, fontSize = 16.sp)) {
                                             append(artist.name)
                                         }
                                         pop()
-                                        if (index != validArtists.lastIndex) append(" - ")
+                                        if (index != mediaMetadata.artists.lastIndex) append(", ")
                                     }
                                 }
 

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Queue.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Queue.kt
@@ -836,6 +836,7 @@ fun Queue(
                             ) {
                                 MediaMetadataListItem(
                                     mediaMetadata = window.mediaItem.metadata!!,
+                                    navController = navController,
                                     isSelected = false,
                                     isActive = isActive,
                                     isPlaying = isPlaying && isActive,
@@ -969,6 +970,7 @@ fun Queue(
                         ) {
                             MediaMetadataListItem(
                                 mediaMetadata = item.metadata!!,
+                                navController = navController,
                                 trailingContent = {
                                     if (!isListenTogetherGuest) {
                                         IconButton(

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Queue.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Queue.kt
@@ -99,7 +99,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline
 import androidx.media3.exoplayer.source.ShuffleOrder.DefaultShuffleOrder
-import androidx.navigation.NavController
+import com.metrolist.music.LocalNavController
 import com.metrolist.music.LocalListenTogetherManager
 import com.metrolist.music.LocalPlayerConnection
 import com.metrolist.music.R
@@ -149,7 +149,6 @@ import androidx.compose.material3.Button
 fun Queue(
     state: BottomSheetState,
     playerBottomSheetState: BottomSheetState,
-    navController: NavController,
     modifier: Modifier = Modifier,
     background: Color,
     onBackgroundColor: Color,
@@ -161,6 +160,7 @@ fun Queue(
     playerBackground: PlayerBackgroundStyle = PlayerBackgroundStyle.DEFAULT,
     onToggleLyrics: () -> Unit = {},
 ) {
+    val navController = LocalNavController.current
     val context = LocalContext.current
     val haptic = LocalHapticFeedback.current
     val clipboardManager = LocalClipboard.current
@@ -393,7 +393,6 @@ fun Queue(
                                     menuState.show {
                                         PlayerMenu(
                                             mediaMetadata = mediaMetadata,
-                                            navController = navController,
                                             playerBottomSheetState = playerBottomSheetState,
                                             onShowDetailsDialog = {
                                                 mediaMetadata?.id?.let {
@@ -836,7 +835,6 @@ fun Queue(
                             ) {
                                 MediaMetadataListItem(
                                     mediaMetadata = window.mediaItem.metadata!!,
-                                    navController = navController,
                                     isSelected = false,
                                     isActive = isActive,
                                     isPlaying = isPlaying && isActive,
@@ -853,7 +851,6 @@ fun Queue(
                                                         menuState.show {
                                                             QueueMenu(
                                                                 mediaMetadata = window.mediaItem.metadata!!,
-                                                                navController = navController,
                                                                 playerBottomSheetState = playerBottomSheetState,
                                                                 onShowDetailsDialog = {
                                                                     window.mediaItem.mediaId.let {
@@ -970,7 +967,6 @@ fun Queue(
                         ) {
                             MediaMetadataListItem(
                                 mediaMetadata = item.metadata!!,
-                                navController = navController,
                                 trailingContent = {
                                     if (!isListenTogetherGuest) {
                                         IconButton(
@@ -1010,7 +1006,6 @@ fun Queue(
                                                 menuState.show {
                                                     QueueMenu(
                                                         mediaMetadata = item.metadata!!,
-                                                        navController = navController,
                                                         playerBottomSheetState = playerBottomSheetState,
                                                         onShowDetailsDialog = {
                                                             item.mediaId.let {

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/AccountScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/AccountScreen.kt
@@ -164,7 +164,6 @@ fun AccountScreen(
                                         menuState.show {
                                             YouTubeAlbumMenu(
                                                 albumItem = item,
-                                                navController = navController,
                                                 onDismiss = menuState::dismiss,
                                             )
                                         }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/AlbumScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/AlbumScreen.kt
@@ -236,7 +236,6 @@ fun AlbumScreen(
                     // Artist Names - Below the album name
                     ClickableArtistText(
                         artists = albumWithSongs.artists,
-                        navController = navController,
                         style = MaterialTheme.typography.titleMedium.copy(
                             fontWeight = FontWeight.Normal,
                             color = MaterialTheme.colorScheme.secondary,
@@ -369,7 +368,6 @@ fun AlbumScreen(
                                                 albumWithSongs.album,
                                                 albumWithSongs.artists,
                                             ),
-                                        navController = navController,
                                         onDismiss = menuState::dismiss,
                                     )
                                 }
@@ -408,7 +406,6 @@ fun AlbumScreen(
 
                     SongListItem(
                         song = song,
-                        navController = navController,
                         albumIndex = index + 1,
                         isActive = song.id == mediaMetadata?.id,
                         isPlaying = isPlaying,
@@ -425,7 +422,6 @@ fun AlbumScreen(
                                         menuState.show {
                                             SongMenu(
                                                 originalSong = song,
-                                                navController = navController,
                                                 onDismiss = menuState::dismiss,
                                             )
                                         }
@@ -498,7 +494,6 @@ fun AlbumScreen(
                                                 menuState.show {
                                                     YouTubeAlbumMenu(
                                                         albumItem = item,
-                                                        navController = navController,
                                                         onDismiss = menuState::dismiss,
                                                     )
                                                 }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/AlbumScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/AlbumScreen.kt
@@ -239,6 +239,7 @@ fun AlbumScreen(
                         navController = navController,
                         style = MaterialTheme.typography.titleMedium.copy(
                             fontWeight = FontWeight.Normal,
+                            color = MaterialTheme.colorScheme.secondary,
                             textAlign = TextAlign.Center,
                         ),
                         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/AlbumScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/AlbumScreen.kt
@@ -428,6 +428,7 @@ fun AlbumScreen(
 
                     SongListItem(
                         song = song,
+                        navController = navController,
                         albumIndex = index + 1,
                         isActive = song.id == mediaMetadata?.id,
                         isPlaying = isPlaying,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/AlbumScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/AlbumScreen.kt
@@ -62,15 +62,10 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.LinkAnnotation
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.text.withLink
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.util.fastForEachIndexed
 import androidx.compose.ui.util.fastForEachReversed
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.media3.exoplayer.offline.Download
@@ -86,6 +81,7 @@ import com.metrolist.music.constants.HideExplicitKey
 import com.metrolist.music.constants.HideVideoSongsKey
 import com.metrolist.music.db.entities.Album
 import com.metrolist.music.playback.queues.LocalAlbumRadio
+import com.metrolist.music.ui.component.ClickableArtistText
 import com.metrolist.music.ui.component.IconButton
 import com.metrolist.music.ui.component.LocalMenuState
 import com.metrolist.music.ui.component.NavigationTitle
@@ -238,31 +234,14 @@ fun AlbumScreen(
                     Spacer(modifier = Modifier.height(8.dp))
 
                     // Artist Names - Below the album name
-                    Text(
-                        buildAnnotatedString {
-                            withStyle(
-                                style =
-                                    MaterialTheme.typography.titleMedium
-                                        .copy(
-                                            fontWeight = FontWeight.Normal,
-                                            color = MaterialTheme.colorScheme.onBackground,
-                                        ).toSpanStyle(),
-                            ) {
-                                albumWithSongs.artists.fastForEachIndexed { index, artist ->
-                                    val link =
-                                        LinkAnnotation.Clickable(artist.id) {
-                                            navController.navigate("artist/${artist.id}")
-                                        }
-                                    withLink(link) {
-                                        append(artist.name)
-                                    }
-                                    if (index != albumWithSongs.artists.lastIndex) {
-                                        append(", ")
-                                    }
-                                }
-                            }
-                        },
-                        textAlign = TextAlign.Center,
+                    ClickableArtistText(
+                        artists = albumWithSongs.artists,
+                        navController = navController,
+                        style = MaterialTheme.typography.titleMedium.copy(
+                            fontWeight = FontWeight.Normal,
+                            textAlign = TextAlign.Center,
+                        ),
+                        modifier = Modifier.fillMaxWidth(),
                     )
 
                     Spacer(modifier = Modifier.height(12.dp))

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/AlbumScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/AlbumScreen.kt
@@ -274,7 +274,7 @@ fun AlbumScreen(
                                         ),
                                     )
                                     if (totalDuration > 0) {
-                                        append(" • ")
+                                        append(" | ")
                                         append(makeTimeString(totalDuration * 1000L))
                                     }
                                 },

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/BrowseScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/BrowseScreen.kt
@@ -105,7 +105,6 @@ fun BrowseScreen(
                                             is AlbumItem -> {
                                                 YouTubeAlbumMenu(
                                                     albumItem = item,
-                                                    navController = navController,
                                                     onDismiss = menuState::dismiss,
                                                 )
                                             }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/ChartsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/ChartsScreen.kt
@@ -273,7 +273,6 @@ fun ChartsScreen(
                                                         menuState.show {
                                                             YouTubeSongMenu(
                                                                 song = song,
-                                                                navController = navController,
                                                                 onDismiss = menuState::dismiss,
                                                             )
                                                         }
@@ -306,7 +305,6 @@ fun ChartsScreen(
                                                             menuState.show {
                                                                 YouTubeSongMenu(
                                                                     song = song,
-                                                                    navController = navController,
                                                                     onDismiss = menuState::dismiss,
                                                                 )
                                                             }
@@ -363,7 +361,6 @@ fun ChartsScreen(
                                                         menuState.show {
                                                             YouTubeSongMenu(
                                                                 song = video,
-                                                                navController = navController,
                                                                 onDismiss = menuState::dismiss,
                                                             )
                                                         }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/ExploreScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/ExploreScreen.kt
@@ -293,7 +293,6 @@ fun ExploreScreen(
                                                 menuState.show {
                                                     YouTubeSongMenu(
                                                         song = song,
-                                                        navController = navController,
                                                         onDismiss = menuState::dismiss,
                                                     )
                                                 }
@@ -326,7 +325,6 @@ fun ExploreScreen(
                                                     menuState.show {
                                                         YouTubeSongMenu(
                                                             song = song,
-                                                            navController = navController,
                                                             onDismiss = menuState::dismiss,
                                                         )
                                                     }
@@ -371,7 +369,6 @@ fun ExploreScreen(
                                                 menuState.show {
                                                     YouTubeAlbumMenu(
                                                         albumItem = album,
-                                                        navController = navController,
                                                         onDismiss = menuState::dismiss,
                                                     )
                                                 }
@@ -421,7 +418,6 @@ fun ExploreScreen(
                                                 menuState.show {
                                                     YouTubeSongMenu(
                                                         song = video,
-                                                        navController = navController,
                                                         onDismiss = menuState::dismiss,
                                                     )
                                                 }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/HistoryScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/HistoryScreen.kt
@@ -340,6 +340,7 @@ fun HistoryScreen(
 
                         SongListItem(
                             song = event.song,
+                            navController = navController,
                             isActive = event.song.id == mediaMetadata?.id,
                             isPlaying = isPlaying,
                             showInLibraryIcon = true,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/HistoryScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/HistoryScreen.kt
@@ -269,7 +269,6 @@ fun HistoryScreen(
                                         menuState.show {
                                             YouTubeSongMenu(
                                                 song = song,
-                                                navController = navController,
                                                 onDismiss = menuState::dismiss,
                                                 onHistoryRemoved = {
                                                     viewModel.fetchRemoteHistory()
@@ -301,7 +300,6 @@ fun HistoryScreen(
                                             menuState.show {
                                                 YouTubeSongMenu(
                                                     song = song,
-                                                    navController = navController,
                                                     onDismiss = menuState::dismiss,
                                                     onHistoryRemoved = {
                                                         viewModel.fetchRemoteHistory()
@@ -340,7 +338,6 @@ fun HistoryScreen(
 
                         SongListItem(
                             song = event.song,
-                            navController = navController,
                             isActive = event.song.id == mediaMetadata?.id,
                             isPlaying = isPlaying,
                             showInLibraryIcon = true,
@@ -357,7 +354,6 @@ fun HistoryScreen(
                                                 SongMenu(
                                                     originalSong = event.song,
                                                     event = event.event,
-                                                    navController = navController,
                                                     onDismiss = menuState::dismiss,
                                                 )
                                             }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
@@ -159,6 +159,7 @@ import com.metrolist.music.ui.menu.YouTubeSongMenu
 import com.metrolist.music.ui.utils.SnapLayoutInfoProvider
 import com.metrolist.music.ui.utils.resize
 import com.metrolist.music.utils.joinByBullet
+import com.metrolist.music.utils.joinToArtistString
 import com.metrolist.music.utils.makeTimeString
 import com.metrolist.music.utils.rememberEnumPreference
 import com.metrolist.music.utils.rememberPreference
@@ -368,7 +369,7 @@ fun CommunityPlaylistCard(
                                 overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
                             )
                             Text(
-                                text = song.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
+                                text = song.artists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name },
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f),
                                 maxLines = 1,
@@ -584,7 +585,7 @@ fun DailyDiscoverCard(
                         Text(
                             text =
                                 buildString {
-                                    append((dailyDiscover.recommendation as? SongItem)?.artists?.joinToString(" ${stringResource(R.string.and)} ") { it.name } ?: "")
+                                    append((dailyDiscover.recommendation as? SongItem)?.artists?.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name } ?: "")
                                     if (playCount > 0) {
                                         append(" • $playCount $playsString")
                                     }
@@ -611,7 +612,7 @@ fun DailyDiscoverCard(
                         text =
                             stringResource(
                                 messageRes,
-                                "${dailyDiscover.seed.title} • ${dailyDiscover.seed.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name }}",
+                                "${dailyDiscover.seed.title} • ${dailyDiscover.seed.artists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name }}",
                             ),
                         style = MaterialTheme.typography.bodySmall,
                         fontWeight = androidx.compose.ui.text.font.FontWeight.Medium,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
@@ -797,6 +797,7 @@ fun HomeScreen(
             is Song -> {
                 SongGridItem(
                     song = it,
+                    navController = navController,
                     modifier =
                         Modifier
                             .fillMaxWidth()
@@ -1808,6 +1809,7 @@ fun HomeScreen(
 
                                             SongListItem(
                                                 song = song!!,
+                                                navController = navController,
                                                 showInLibraryIcon = true,
                                                 isActive = song!!.id == mediaMetadata?.id,
                                                 isPlaying = isPlaying,
@@ -2133,6 +2135,7 @@ fun HomeScreen(
 
                                             SongListItem(
                                                 song = song!!,
+                                                navController = navController,
                                                 showInLibraryIcon = true,
                                                 isActive = song!!.id == mediaMetadata?.id,
                                                 isPlaying = isPlaying,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
@@ -88,7 +88,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.navigation.NavController
+import com.metrolist.music.LocalNavController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import coil3.compose.AsyncImage
 import coil3.request.CachePolicy
@@ -498,9 +498,9 @@ fun CommunityPlaylistCard(
 fun DailyDiscoverCard(
     dailyDiscover: com.metrolist.music.viewmodels.DailyDiscoverItem,
     onClick: () -> Unit,
-    navController: NavController,
     modifier: Modifier = Modifier,
 ) {
+    val navController = LocalNavController.current
     val database = LocalDatabase.current
     val playCount by database.getLifetimePlayCount(dailyDiscover.recommendation.id).collectAsStateWithLifecycle(initialValue = 0)
     val menuState = LocalMenuState.current
@@ -522,7 +522,6 @@ fun DailyDiscoverCard(
                             menuState.show {
                                 YouTubeSongMenu(
                                     song = song,
-                                    navController = navController,
                                     onDismiss = { menuState.dismiss() },
                                 )
                             }
@@ -629,10 +628,10 @@ fun DailyDiscoverCard(
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun HomeScreen(
-    navController: NavController,
     snackbarHostState: SnackbarHostState,
     viewModel: HomeViewModel = hiltViewModel(),
 ) {
+    val navController = LocalNavController.current
     val menuState = LocalMenuState.current
     val bottomSheetPageState = LocalBottomSheetPageState.current
     val database = LocalDatabase.current
@@ -798,7 +797,6 @@ fun HomeScreen(
             is Song -> {
                 SongGridItem(
                     song = it,
-                    navController = navController,
                     modifier =
                         Modifier
                             .fillMaxWidth()
@@ -828,7 +826,6 @@ fun HomeScreen(
                                     menuState.show {
                                         SongMenu(
                                             originalSong = it,
-                                            navController = navController,
                                             onDismiss = menuState::dismiss,
                                         )
                                     }
@@ -857,7 +854,6 @@ fun HomeScreen(
                                     menuState.show {
                                         AlbumMenu(
                                             originalAlbum = it,
-                                            navController = navController,
                                             onDismiss = menuState::dismiss,
                                         )
                                     }
@@ -963,7 +959,6 @@ fun HomeScreen(
                                     is SongItem -> {
                                         YouTubeSongMenu(
                                             song = item,
-                                            navController = navController,
                                             onDismiss = menuState::dismiss,
                                         )
                                     }
@@ -971,7 +966,6 @@ fun HomeScreen(
                                     is AlbumItem -> {
                                         YouTubeAlbumMenu(
                                             albumItem = item,
-                                            navController = navController,
                                             onDismiss = menuState::dismiss,
                                         )
                                     }
@@ -1002,7 +996,6 @@ fun HomeScreen(
                                     is EpisodeItem -> {
                                         YouTubeSongMenu(
                                             song = item.asSongItem(),
-                                            navController = navController,
                                             onDismiss = menuState::dismiss,
                                         )
                                     }
@@ -1673,7 +1666,6 @@ fun HomeScreen(
                                                                                                 is SongItem -> {
                                                                                                     YouTubeSongMenu(
                                                                                                         song = item,
-                                                                                                        navController = navController,
                                                                                                         onDismiss = menuState::dismiss,
                                                                                                     )
                                                                                                 }
@@ -1681,7 +1673,6 @@ fun HomeScreen(
                                                                                                 is AlbumItem -> {
                                                                                                     YouTubeAlbumMenu(
                                                                                                         albumItem = item,
-                                                                                                        navController = navController,
                                                                                                         onDismiss = menuState::dismiss,
                                                                                                     )
                                                                                                 }
@@ -1712,7 +1703,6 @@ fun HomeScreen(
                                                                                                 is EpisodeItem -> {
                                                                                                     YouTubeSongMenu(
                                                                                                         song = item.asSongItem(),
-                                                                                                        navController = navController,
                                                                                                         onDismiss = menuState::dismiss,
                                                                                                     )
                                                                                                 }
@@ -1810,7 +1800,6 @@ fun HomeScreen(
 
                                             SongListItem(
                                                 song = song!!,
-                                                navController = navController,
                                                 showInLibraryIcon = true,
                                                 isActive = song!!.id == mediaMetadata?.id,
                                                 isPlaying = isPlaying,
@@ -1821,7 +1810,6 @@ fun HomeScreen(
                                                             menuState.show {
                                                                 SongMenu(
                                                                     originalSong = song!!,
-                                                                    navController = navController,
                                                                     onDismiss = menuState::dismiss,
                                                                 )
                                                             }
@@ -1862,7 +1850,6 @@ fun HomeScreen(
                                                                 menuState.show {
                                                                     SongMenu(
                                                                         originalSong = song!!,
-                                                                        navController = navController,
                                                                         onDismiss = menuState::dismiss,
                                                                     )
                                                                 }
@@ -1978,7 +1965,6 @@ fun HomeScreen(
                                                         }
                                                     }
                                                 },
-                                                navController = navController,
                                                 modifier = Modifier.maskClip(MaterialTheme.shapes.extraLarge),
                                             )
                                         }
@@ -2136,7 +2122,6 @@ fun HomeScreen(
 
                                             SongListItem(
                                                 song = song!!,
-                                                navController = navController,
                                                 showInLibraryIcon = true,
                                                 isActive = song!!.id == mediaMetadata?.id,
                                                 isPlaying = isPlaying,
@@ -2148,7 +2133,6 @@ fun HomeScreen(
                                                             menuState.show {
                                                                 SongMenu(
                                                                     originalSong = song!!,
-                                                                    navController = navController,
                                                                     onDismiss = menuState::dismiss,
                                                                 )
                                                             }
@@ -2189,7 +2173,6 @@ fun HomeScreen(
                                                                 menuState.show {
                                                                     SongMenu(
                                                                         originalSong = song!!,
-                                                                        navController = navController,
                                                                         onDismiss = menuState::dismiss,
                                                                     )
                                                                 }
@@ -2378,7 +2361,6 @@ fun HomeScreen(
                                                                 menuState.show {
                                                                     YouTubeSongMenu(
                                                                         song = song,
-                                                                        navController = navController,
                                                                         onDismiss = menuState::dismiss,
                                                                     )
                                                                 }
@@ -2416,7 +2398,6 @@ fun HomeScreen(
                                                                     menuState.show {
                                                                         YouTubeSongMenu(
                                                                             song = song,
-                                                                            navController = navController,
                                                                             onDismiss = menuState::dismiss,
                                                                         )
                                                                     }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
@@ -5,7 +5,6 @@
 
 package com.metrolist.music.ui.screens
 
-import com.metrolist.music.utils.ARTIST_SEPARATOR
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -369,7 +368,7 @@ fun CommunityPlaylistCard(
                                 overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
                             )
                             Text(
-                                text = song.artists.joinToString(ARTIST_SEPARATOR) { it.name },
+                                text = song.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name },
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f),
                                 maxLines = 1,
@@ -585,7 +584,7 @@ fun DailyDiscoverCard(
                         Text(
                             text =
                                 buildString {
-                                    append((dailyDiscover.recommendation as? SongItem)?.artists?.joinToString(ARTIST_SEPARATOR) { it.name } ?: "")
+                                    append((dailyDiscover.recommendation as? SongItem)?.artists?.joinToString(" ${stringResource(R.string.and)} ") { it.name } ?: "")
                                     if (playCount > 0) {
                                         append(" • $playCount $playsString")
                                     }
@@ -612,7 +611,7 @@ fun DailyDiscoverCard(
                         text =
                             stringResource(
                                 messageRes,
-                                "${dailyDiscover.seed.title} • ${dailyDiscover.seed.artists.joinToString(ARTIST_SEPARATOR) { it.name }}",
+                                "${dailyDiscover.seed.title} • ${dailyDiscover.seed.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name }}",
                             ),
                         style = MaterialTheme.typography.bodySmall,
                         fontWeight = androidx.compose.ui.text.font.FontWeight.Medium,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
@@ -5,6 +5,7 @@
 
 package com.metrolist.music.ui.screens
 
+import com.metrolist.music.utils.ARTIST_SEPARATOR
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -368,7 +369,7 @@ fun CommunityPlaylistCard(
                                 overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
                             )
                             Text(
-                                text = song.artists.joinToString(", ") { it.name },
+                                text = song.artists.joinToString(ARTIST_SEPARATOR) { it.name },
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f),
                                 maxLines = 1,
@@ -584,7 +585,7 @@ fun DailyDiscoverCard(
                         Text(
                             text =
                                 buildString {
-                                    append((dailyDiscover.recommendation as? SongItem)?.artists?.joinToString(", ") { it.name } ?: "")
+                                    append((dailyDiscover.recommendation as? SongItem)?.artists?.joinToString(ARTIST_SEPARATOR) { it.name } ?: "")
                                     if (playCount > 0) {
                                         append(" • $playCount $playsString")
                                     }
@@ -611,7 +612,7 @@ fun DailyDiscoverCard(
                         text =
                             stringResource(
                                 messageRes,
-                                "${dailyDiscover.seed.title} • ${dailyDiscover.seed.artists.joinToString(", ") { it.name }}",
+                                "${dailyDiscover.seed.title} • ${dailyDiscover.seed.artists.joinToString(ARTIST_SEPARATOR) { it.name }}",
                             ),
                         style = MaterialTheme.typography.bodySmall,
                         fontWeight = androidx.compose.ui.text.font.FontWeight.Medium,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
@@ -587,7 +587,7 @@ fun DailyDiscoverCard(
                                 buildString {
                                     append((dailyDiscover.recommendation as? SongItem)?.artists?.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name } ?: "")
                                     if (playCount > 0) {
-                                        append(" • $playCount $playsString")
+                                        append(" | $playCount $playsString")
                                     }
                                 },
                             style = MaterialTheme.typography.bodyMedium,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/NavigationBuilder.kt
@@ -74,7 +74,7 @@ fun NavGraphBuilder.navigationBuilder(
     snackbarHostState: SnackbarHostState,
 ) {
     composable(Screens.Home.route) {
-        HomeScreen(navController = navController, snackbarHostState = snackbarHostState)
+        HomeScreen(snackbarHostState = snackbarHostState)
     }
 
     composable(Screens.Search.route) { backStackEntry ->
@@ -90,14 +90,13 @@ fun NavGraphBuilder.navigationBuilder(
                 pureBlackEnabled && useDarkTheme
             }
         SearchScreen(
-            navController = navController,
             pureBlack = pureBlack,
             savedStateHandle = backStackEntry.savedStateHandle
         )
     }
 
     composable(Screens.Library.route) {
-        LibraryScreen(navController)
+        LibraryScreen()
     }
 
     composable(Screens.ListenTogether.route) {
@@ -179,7 +178,6 @@ fun NavGraphBuilder.navigationBuilder(
         },
     ) { backStackEntry ->
         OnlineSearchResult(
-            navController = navController,
             savedStateHandle = backStackEntry.savedStateHandle
         )
 
@@ -415,11 +413,11 @@ fun NavGraphBuilder.navigationBuilder(
     }
 
     composable("wrapped") {
-        WrappedScreen(navController)
+        WrappedScreen()
     }
 
     composable("equalizer") {
-        EqScreen(navController = navController)
+        EqScreen()
     }
 
     composable("eq_wizard") {

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/NewReleaseScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/NewReleaseScreen.kt
@@ -85,7 +85,6 @@ fun NewReleaseScreen(
                                 menuState.show {
                                     YouTubeAlbumMenu(
                                         albumItem = album,
-                                        navController = navController,
                                         onDismiss = menuState::dismiss,
                                     )
                                 }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/StatsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/StatsScreen.kt
@@ -496,7 +496,6 @@ fun StatsScreen(
                                                     menuState.show {
                                                         SongMenu(
                                                             originalSong = targetSong,
-                                                            navController = navController,
                                                             onDismiss = menuState::dismiss,
                                                         )
                                                     }
@@ -599,7 +598,6 @@ fun StatsScreen(
                                                     menuState.show {
                                                         AlbumMenu(
                                                             originalAlbum = album,
-                                                            navController = navController,
                                                             onDismiss = menuState::dismiss,
                                                         )
                                                     }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/YouTubeBrowseScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/YouTubeBrowseScreen.kt
@@ -148,7 +148,6 @@ fun YouTubeBrowseScreen(
                                         is SongItem -> {
                                             YouTubeSongMenu(
                                                 song = item,
-                                                navController = navController,
                                                 onDismiss = menuState::dismiss,
                                             )
                                         }
@@ -156,7 +155,6 @@ fun YouTubeBrowseScreen(
                                         is AlbumItem -> {
                                             YouTubeAlbumMenu(
                                                 albumItem = item,
-                                                navController = navController,
                                                 onDismiss = menuState::dismiss,
                                             )
                                         }
@@ -187,7 +185,6 @@ fun YouTubeBrowseScreen(
                                         is EpisodeItem -> {
                                             YouTubeSongMenu(
                                                 song = item.asSongItem(),
-                                                navController = navController,
                                                 onDismiss = menuState::dismiss,
                                             )
                                         }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistAlbumsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistAlbumsScreen.kt
@@ -131,7 +131,6 @@ fun ArtistAlbumsScreen(
                 contentType = { CONTENT_TYPE_ALBUM },
             ) { album ->
                 LibraryAlbumGridItem(
-                    navController = navController,
                     menuState = menuState,
                     coroutineScope = coroutineScope,
                     album = album,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistItemsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistItemsScreen.kt
@@ -139,7 +139,6 @@ fun ArtistItemsScreen(
                                         is SongItem -> {
                                             YouTubeSongMenu(
                                                 song = item,
-                                                navController = navController,
                                                 onDismiss = menuState::dismiss,
                                             )
                                         }
@@ -147,7 +146,6 @@ fun ArtistItemsScreen(
                                         is AlbumItem -> {
                                             YouTubeAlbumMenu(
                                                 albumItem = item,
-                                                navController = navController,
                                                 onDismiss = menuState::dismiss,
                                             )
                                         }
@@ -178,7 +176,6 @@ fun ArtistItemsScreen(
                                         is EpisodeItem -> {
                                             YouTubeSongMenu(
                                                 song = item.asSongItem(),
-                                                navController = navController,
                                                 onDismiss = menuState::dismiss,
                                             )
                                         }
@@ -320,7 +317,6 @@ fun ArtistItemsScreen(
                                             is SongItem -> {
                                                 YouTubeSongMenu(
                                                     song = item,
-                                                    navController = navController,
                                                     onDismiss = menuState::dismiss,
                                                 )
                                             }
@@ -328,7 +324,6 @@ fun ArtistItemsScreen(
                                             is AlbumItem -> {
                                                 YouTubeAlbumMenu(
                                                     albumItem = item,
-                                                    navController = navController,
                                                     onDismiss = menuState::dismiss,
                                                 )
                                             }
@@ -359,7 +354,6 @@ fun ArtistItemsScreen(
                                             is EpisodeItem -> {
                                                 YouTubeSongMenu(
                                                     song = item.asSongItem(),
-                                                    navController = navController,
                                                     onDismiss = menuState::dismiss,
                                                 )
                                             }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistScreen.kt
@@ -547,7 +547,6 @@ fun ArtistScreen(
                         ) { index, song ->
                             SongListItem(
                                 song = song,
-                                navController = navController,
                                 showInLibraryIcon = true,
                                 isActive = song.id == mediaMetadata?.id,
                                 isPlaying = isPlaying,
@@ -557,7 +556,6 @@ fun ArtistScreen(
                                             menuState.show {
                                                 SongMenu(
                                                     originalSong = song,
-                                                    navController = navController,
                                                     onDismiss = menuState::dismiss,
                                                 )
                                             }
@@ -593,7 +591,6 @@ fun ArtistScreen(
                                                 menuState.show {
                                                     SongMenu(
                                                         originalSong = song,
-                                                        navController = navController,
                                                         onDismiss = menuState::dismiss,
                                                     )
                                                 }
@@ -644,7 +641,6 @@ fun ArtistScreen(
                                                         menuState.show {
                                                             AlbumMenu(
                                                                 originalAlbum = album,
-                                                                navController = navController,
                                                                 onDismiss = menuState::dismiss,
                                                             )
                                                         }
@@ -689,7 +685,6 @@ fun ArtistScreen(
                                                 menuState.show {
                                                     YouTubeSongMenu(
                                                         song = song,
-                                                        navController = navController,
                                                         onDismiss = menuState::dismiss,
                                                     )
                                                 }
@@ -723,7 +718,6 @@ fun ArtistScreen(
                                                     menuState.show {
                                                         YouTubeSongMenu(
                                                             song = song,
-                                                            navController = navController,
                                                             onDismiss = menuState::dismiss,
                                                         )
                                                     }
@@ -802,7 +796,6 @@ fun ArtistScreen(
                                                                     is SongItem -> {
                                                                         YouTubeSongMenu(
                                                                             song = item,
-                                                                            navController = navController,
                                                                             onDismiss = menuState::dismiss,
                                                                         )
                                                                     }
@@ -810,7 +803,6 @@ fun ArtistScreen(
                                                                     is AlbumItem -> {
                                                                         YouTubeAlbumMenu(
                                                                             albumItem = item,
-                                                                            navController = navController,
                                                                             onDismiss = menuState::dismiss,
                                                                         )
                                                                     }
@@ -841,7 +833,6 @@ fun ArtistScreen(
                                                                     is EpisodeItem -> {
                                                                         YouTubeSongMenu(
                                                                             song = item.asSongItem(),
-                                                                            navController = navController,
                                                                             onDismiss = menuState::dismiss,
                                                                         )
                                                                     }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistScreen.kt
@@ -538,6 +538,7 @@ fun ArtistScreen(
                         ) { index, song ->
                             SongListItem(
                                 song = song,
+                                navController = navController,
                                 showInLibraryIcon = true,
                                 isActive = song.id == mediaMetadata?.id,
                                 isPlaying = isPlaying,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistScreen.kt
@@ -187,7 +187,7 @@ fun ArtistScreen(
             state = lazyListState,
             contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues(),
         ) {
-            if (artistPage == null && !showLocal) {
+            if (artistPage == null && !showLocal && libraryArtist == null) {
                 item(key = "shimmer") {
                     ShimmerHost(
                         modifier =
@@ -510,6 +510,15 @@ fun ArtistScreen(
                                     )
                                 }
                             }
+                        }
+                    }
+                }
+
+                // Show loading shimmer for sections when API hasn't returned yet
+                if (artistPage == null && !showLocal) {
+                    item(key = "section_shimmer") {
+                        ShimmerHost {
+                            repeat(4) { ListItemPlaceHolder() }
                         }
                     }
                 }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistSongsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistSongsScreen.kt
@@ -131,7 +131,6 @@ fun ArtistSongsScreen(
             ) { index, song ->
                 SongListItem(
                     song = song,
-                    navController = navController,
                     showInLibraryIcon = true,
                     isActive = song.id == mediaMetadata?.id,
                     isPlaying = isPlaying,
@@ -141,7 +140,6 @@ fun ArtistSongsScreen(
                                 menuState.show {
                                     SongMenu(
                                         originalSong = song,
-                                        navController = navController,
                                         onDismiss = menuState::dismiss,
                                     )
                                 }
@@ -175,7 +173,6 @@ fun ArtistSongsScreen(
                                     menuState.show {
                                         SongMenu(
                                             originalSong = song,
-                                            navController = navController,
                                             onDismiss = menuState::dismiss,
                                         )
                                     }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistSongsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistSongsScreen.kt
@@ -131,6 +131,7 @@ fun ArtistSongsScreen(
             ) { index, song ->
                 SongListItem(
                     song = song,
+                    navController = navController,
                     showInLibraryIcon = true,
                     isActive = song.id == mediaMetadata?.id,
                     isPlaying = isPlaying,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/equalizer/EqScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/equalizer/EqScreen.kt
@@ -45,7 +45,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.navigation.NavController
+import com.metrolist.music.LocalNavController
 import com.metrolist.music.LocalPlayerAwareWindowInsets
 import com.metrolist.music.R
 import com.metrolist.music.eq.data.SavedEQProfile
@@ -57,9 +57,9 @@ import timber.log.Timber
 @SuppressLint("LocalContextGetResourceValueCall")
 @Composable
 fun EqScreen(
-    navController: NavController,
     viewModel: EQViewModel = hiltViewModel(),
 ) {
+    val navController = LocalNavController.current
     val state by viewModel.state.collectAsStateWithLifecycle()
     val context = LocalContext.current
 

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryAlbumsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryAlbumsScreen.kt
@@ -292,7 +292,6 @@ fun LibraryAlbumsScreen(
                             contentType = { CONTENT_TYPE_ALBUM },
                         ) { album ->
                             LibraryAlbumListItem(
-                                navController = navController,
                                 menuState = menuState,
                                 album = album,
                                 isActive = album.id == mediaMetadata?.album?.id,
@@ -351,7 +350,6 @@ fun LibraryAlbumsScreen(
                             contentType = { CONTENT_TYPE_ALBUM },
                         ) { album ->
                             LibraryAlbumGridItem(
-                                navController = navController,
                                 menuState = menuState,
                                 coroutineScope = coroutineScope,
                                 album = album,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryArtistsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryArtistsScreen.kt
@@ -276,7 +276,6 @@ fun LibraryArtistsScreen(
                             contentType = { CONTENT_TYPE_ARTIST },
                         ) { artist ->
                             LibraryArtistListItem(
-                                navController = navController,
                                 menuState = menuState,
                                 coroutineScope = coroutineScope,
                                 modifier = Modifier.animateItem(),
@@ -336,7 +335,6 @@ fun LibraryArtistsScreen(
                             contentType = { CONTENT_TYPE_ARTIST },
                         ) { artist ->
                             LibraryArtistGridItem(
-                                navController = navController,
                                 menuState = menuState,
                                 coroutineScope = coroutineScope,
                                 modifier = Modifier.animateItem(),

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryMixScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryMixScreen.kt
@@ -623,6 +623,7 @@ fun LibraryMixScreen(
                             is Song -> {
                                 SongListItem(
                                     song = item,
+                                    navController = navController,
                                     showInLibraryIcon = true,
                                     isActive = item.id == mediaMetadata?.id,
                                     isPlaying = isPlaying,
@@ -722,6 +723,7 @@ fun LibraryMixScreen(
                             is Album -> {
                                 AlbumListItem(
                                     album = item,
+                                    navController = navController,
                                     isActive = item.id == mediaMetadata?.album?.id,
                                     isPlaying = isPlaying,
                                     trailingContent = {
@@ -953,6 +955,7 @@ fun LibraryMixScreen(
                             is Song -> {
                                 SongGridItem(
                                     song = item,
+                                    navController = navController,
                                     showInLibraryIcon = true,
                                     isActive = item.id == mediaMetadata?.id,
                                     isPlaying = isPlaying,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryMixScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryMixScreen.kt
@@ -623,7 +623,6 @@ fun LibraryMixScreen(
                             is Song -> {
                                 SongListItem(
                                     song = item,
-                                    navController = navController,
                                     showInLibraryIcon = true,
                                     isActive = item.id == mediaMetadata?.id,
                                     isPlaying = isPlaying,
@@ -633,7 +632,6 @@ fun LibraryMixScreen(
                                                 menuState.show {
                                                     SongMenu(
                                                         originalSong = item,
-                                                        navController = navController,
                                                         onDismiss = menuState::dismiss,
                                                     )
                                                 }
@@ -668,7 +666,6 @@ fun LibraryMixScreen(
                                                     menuState.show {
                                                         SongMenu(
                                                             originalSong = item,
-                                                            navController = navController,
                                                             onDismiss = menuState::dismiss,
                                                         )
                                                     }
@@ -723,7 +720,6 @@ fun LibraryMixScreen(
                             is Album -> {
                                 AlbumListItem(
                                     album = item,
-                                    navController = navController,
                                     isActive = item.id == mediaMetadata?.album?.id,
                                     isPlaying = isPlaying,
                                     trailingContent = {
@@ -732,7 +728,6 @@ fun LibraryMixScreen(
                                                 menuState.show {
                                                     AlbumMenu(
                                                         originalAlbum = item,
-                                                        navController = navController,
                                                         onDismiss = menuState::dismiss,
                                                     )
                                                 }
@@ -756,7 +751,6 @@ fun LibraryMixScreen(
                                                     menuState.show {
                                                         AlbumMenu(
                                                             originalAlbum = item,
-                                                            navController = navController,
                                                             onDismiss = menuState::dismiss,
                                                         )
                                                     }
@@ -955,7 +949,6 @@ fun LibraryMixScreen(
                             is Song -> {
                                 SongGridItem(
                                     song = item,
-                                    navController = navController,
                                     showInLibraryIcon = true,
                                     isActive = item.id == mediaMetadata?.id,
                                     isPlaying = isPlaying,
@@ -983,7 +976,6 @@ fun LibraryMixScreen(
                                                     menuState.show {
                                                         SongMenu(
                                                             originalSong = item,
-                                                            navController = navController,
                                                             onDismiss = menuState::dismiss,
                                                         )
                                                     }
@@ -1037,7 +1029,6 @@ fun LibraryMixScreen(
                                                     menuState.show {
                                                         AlbumMenu(
                                                             originalAlbum = item,
-                                                            navController = navController,
                                                             onDismiss = menuState::dismiss,
                                                         )
                                                     }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryPlaylistsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryPlaylistsScreen.kt
@@ -458,7 +458,6 @@ fun LibraryPlaylistsScreen(
                             )
                         } else {
                             LibraryPlaylistListItem(
-                                navController = navController,
                                 menuState = menuState,
                                 coroutineScope = coroutineScope,
                                 playlist = item.playlist,
@@ -530,7 +529,6 @@ fun LibraryPlaylistsScreen(
                             )
                         } else {
                             LibraryPlaylistGridItem(
-                                navController = navController,
                                 menuState = menuState,
                                 coroutineScope = coroutineScope,
                                 playlist = item.playlist,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryPodcastsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryPodcastsScreen.kt
@@ -402,7 +402,6 @@ fun LibraryPodcastsScreen(
                             )
                         SongListItem(
                             song = episode,
-                            navController = navController,
                             showInLibraryIcon = false,
                             isActive = episode.id == mediaMetadata?.id,
                             isPlaying = isPlaying,
@@ -415,7 +414,6 @@ fun LibraryPodcastsScreen(
                                         menuState.show {
                                             SongMenu(
                                                 originalSong = episode,
-                                                navController = navController,
                                                 onDismiss = menuState::dismiss,
                                             )
                                         }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryPodcastsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryPodcastsScreen.kt
@@ -402,6 +402,7 @@ fun LibraryPodcastsScreen(
                             )
                         SongListItem(
                             song = episode,
+                            navController = navController,
                             showInLibraryIcon = false,
                             isActive = episode.id == mediaMetadata?.id,
                             isPlaying = isPlaying,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryPodcastsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryPodcastsScreen.kt
@@ -551,7 +551,7 @@ private fun AutoPlaylistCard(
                     buildString {
                         append(stringResource(R.string.auto_playlist))
                         if (!episodeCount.isNullOrBlank()) {
-                            append(" • ")
+                            append(" | ")
                             append(episodeCount)
                         }
                     },

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryScreen.kt
@@ -13,7 +13,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.navigation.NavController
+import com.metrolist.music.LocalNavController
 import com.metrolist.music.R
 import com.metrolist.music.constants.ChipSortTypeKey
 import com.metrolist.music.constants.LibraryFilter
@@ -21,7 +21,8 @@ import com.metrolist.music.ui.component.ChipsRow
 import com.metrolist.music.utils.rememberEnumPreference
 
 @Composable
-fun LibraryScreen(navController: NavController) {
+fun LibraryScreen() {
+    val navController = LocalNavController.current
     var filterType by rememberEnumPreference(ChipSortTypeKey, LibraryFilter.LIBRARY)
 
     val filterContent = @Composable {

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibrarySongsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibrarySongsScreen.kt
@@ -464,6 +464,7 @@ fun LibrarySongsScreen(
             ) { index, song ->
                 SongListItem(
                     song = song,
+                    navController = navController,
                     showInLibraryIcon = true,
                     isActive = song.id == mediaMetadata?.id,
                     isPlaying = isPlaying,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibrarySongsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibrarySongsScreen.kt
@@ -464,7 +464,6 @@ fun LibrarySongsScreen(
             ) { index, song ->
                 SongListItem(
                     song = song,
-                    navController = navController,
                     showInLibraryIcon = true,
                     isActive = song.id == mediaMetadata?.id,
                     isPlaying = isPlaying,
@@ -476,7 +475,6 @@ fun LibrarySongsScreen(
                                 menuState.show {
                                     SongMenu(
                                         originalSong = song,
-                                        navController = navController,
                                         onDismiss = menuState::dismiss,
                                     )
                                 }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -600,7 +600,6 @@ fun AutoPlaylistScreen(
 
                         SongListItem(
                             song = song,
-                            navController = navController,
                             isActive = song.song.id == mediaMetadata?.id,
                             isPlaying = isPlaying,
                             showInLibraryIcon = true,
@@ -616,7 +615,6 @@ fun AutoPlaylistScreen(
                                             menuState.show {
                                                 SongMenu(
                                                     originalSong = song,
-                                                    navController = navController,
                                                     onDismiss = menuState::dismiss,
                                                 )
                                             }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -600,6 +600,7 @@ fun AutoPlaylistScreen(
 
                         SongListItem(
                             song = song,
+                            navController = navController,
                             isActive = song.song.id == mediaMetadata?.id,
                             isPlaying = isPlaying,
                             showInLibraryIcon = true,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -929,7 +929,7 @@ private fun AutoPlaylistHeader(
                 buildString {
                     append(pluralStringResource(R.plurals.n_song, songs.size, songs.size))
                     if (likeLength > 0) {
-                        append(" • ")
+                        append(" | ")
                         append(makeTimeString(likeLength * 1000L))
                     }
                 },

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/CachePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/CachePlaylistScreen.kt
@@ -264,6 +264,7 @@ fun CachePlaylistScreen(
 
                     SongListItem(
                         song = song,
+                        navController = navController,
                         isActive = song.id == mediaMetadata?.id,
                         isPlaying = isPlaying,
                         showInLibraryIcon = true,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/CachePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/CachePlaylistScreen.kt
@@ -264,7 +264,6 @@ fun CachePlaylistScreen(
 
                     SongListItem(
                         song = song,
-                        navController = navController,
                         isActive = song.id == mediaMetadata?.id,
                         isPlaying = isPlaying,
                         showInLibraryIcon = true,
@@ -279,7 +278,6 @@ fun CachePlaylistScreen(
                                     menuState.show {
                                         SongMenu(
                                             originalSong = song,
-                                            navController = navController,
                                             onDismiss = menuState::dismiss,
                                             isFromCache = true,
                                         )

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -624,6 +624,7 @@ fun LocalPlaylistScreen(
                     val content: @Composable () -> Unit = {
                         SongListItem(
                             song = song.song,
+                            navController = navController,
                             isActive = song.song.id == mediaMetadata?.id,
                             isPlaying = isPlaying,
                             showInLibraryIcon = true,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -108,6 +108,7 @@ import com.metrolist.innertube.models.SongItem
 import com.metrolist.innertube.utils.completed
 import com.metrolist.music.LocalDatabase
 import com.metrolist.music.LocalDownloadUtil
+import com.metrolist.music.LocalNavController
 import com.metrolist.music.LocalPlayerAwareWindowInsets
 import com.metrolist.music.LocalPlayerConnection
 import com.metrolist.music.LocalSyncUtils
@@ -498,7 +499,6 @@ fun LocalPlaylistScreen(
                                 playlist = playlist,
                                 songs = songs,
                                 onlinePlaylist = onlinePlaylist,
-                                navController = navController,
                                 onShowEditDialog = { showEditDialog = true },
                                 onShowRemoveDownloadDialog = { showRemoveDownloadDialog = true },
                                 onshowDeletePlaylistDialog = { showDeletePlaylistDialog = true },
@@ -624,7 +624,6 @@ fun LocalPlaylistScreen(
                     val content: @Composable () -> Unit = {
                         SongListItem(
                             song = song.song,
-                            navController = navController,
                             isActive = song.song.id == mediaMetadata?.id,
                             isPlaying = isPlaying,
                             showInLibraryIcon = true,
@@ -642,7 +641,6 @@ fun LocalPlaylistScreen(
                                                     originalSong = song.song,
                                                     playlistSong = song,
                                                     playlistBrowseId = playlist?.playlist?.browseId,
-                                                    navController = navController,
                                                     onDismiss = menuState::dismiss,
                                                 )
                                             }
@@ -876,7 +874,6 @@ fun LocalPlaylistHeader(
     playlist: Playlist,
     songs: List<PlaylistSong>,
     onlinePlaylist: PlaylistItem?,
-    navController: NavController,
     onShowEditDialog: () -> Unit,
     onShowRemoveDownloadDialog: () -> Unit,
     onshowDeletePlaylistDialog: () -> Unit,
@@ -884,6 +881,7 @@ fun LocalPlaylistHeader(
     snackbarHostState: SnackbarHostState,
     modifier: Modifier,
 ) {
+    val navController = LocalNavController.current
     val playerConnection = LocalPlayerConnection.current ?: return
     val context = LocalContext.current
     val database = LocalDatabase.current

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -1268,7 +1268,7 @@ fun LocalPlaylistHeader(
         val metadataString = buildString {
             append(nSongs)
             if (durationText != null) {
-                append(" • ")
+                append(" | ")
                 append(durationText)
             }
         }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/OnlinePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/OnlinePlaylistScreen.kt
@@ -82,6 +82,7 @@ import com.metrolist.innertube.models.PlaylistItem
 import com.metrolist.innertube.models.SongItem
 import com.metrolist.music.LocalDatabase
 import com.metrolist.music.LocalListenTogetherManager
+import com.metrolist.music.LocalNavController
 import com.metrolist.music.LocalPlayerAwareWindowInsets
 import com.metrolist.music.LocalPlayerConnection
 import com.metrolist.music.LocalSyncUtils
@@ -252,7 +253,6 @@ fun OnlinePlaylistScreen(
                                 playlist = playlist,
                                 songs = songs,
                                 dbPlaylist = dbPlaylist,
-                                navController = navController,
                                 coroutineScope = coroutineScope,
                                 continuation = viewModel.continuation,
                                 isPodcastPlaylist = isPodcastPlaylist,
@@ -332,7 +332,7 @@ fun OnlinePlaylistScreen(
                                 } else {
                                     IconButton(onClick = {
                                         menuState.show {
-                                            YouTubeSongMenu(songItem, navController, menuState::dismiss)
+                                            YouTubeSongMenu(songItem, menuState::dismiss)
                                         }
                                     }) {
                                         Icon(painterResource(R.drawable.more_vert), null)
@@ -486,12 +486,12 @@ private fun OnlinePlaylistHeader(
     playlist: PlaylistItem,
     songs: List<SongItem>,
     dbPlaylist: Playlist?,
-    navController: NavController,
     coroutineScope: CoroutineScope,
     continuation: String?,
     isPodcastPlaylist: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
+    val navController = LocalNavController.current
     val playerConnection = LocalPlayerConnection.current ?: return
     val listenTogetherManager = LocalListenTogetherManager.current
     val isListenTogetherGuest = listenTogetherManager?.let { it.isInRoom && !it.isHost } ?: false

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/OnlinePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/OnlinePlaylistScreen.kt
@@ -586,7 +586,7 @@ private fun OnlinePlaylistHeader(
         val metadataText = buildString {
             append(nSongs)
             if (durationText != null) {
-                append(" • ")
+                append(" | ")
                 append(durationText)
             }
         }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/TopPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/TopPlaylistScreen.kt
@@ -317,7 +317,6 @@ fun TopPlaylistScreen(
 
                         SongListItem(
                             song = song,
-                            navController = navController,
                             albumIndex = index + 1,
                             isActive = song.song.id == mediaMetadata?.id,
                             isPlaying = isPlaying,
@@ -334,7 +333,6 @@ fun TopPlaylistScreen(
                                             menuState.show {
                                                 SongMenu(
                                                     originalSong = song,
-                                                    navController = navController,
                                                     onDismiss = menuState::dismiss,
                                                 )
                                             }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/TopPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/TopPlaylistScreen.kt
@@ -317,6 +317,7 @@ fun TopPlaylistScreen(
 
                         SongListItem(
                             song = song,
+                            navController = navController,
                             albumIndex = index + 1,
                             isActive = song.song.id == mediaMetadata?.id,
                             isPlaying = isPlaying,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/TopPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/TopPlaylistScreen.kt
@@ -584,7 +584,7 @@ private fun TopPlaylistHeader(
             text = buildString {
                 append(pluralStringResource(R.plurals.n_song, songs.size, songs.size))
                 if (likeLength > 0) {
-                    append(" • ")
+                    append(" | ")
                     append(makeTimeString(likeLength * 1000L))
                 }
             },

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/podcast/OnlinePodcastScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/podcast/OnlinePodcastScreen.kt
@@ -214,7 +214,7 @@ fun OnlinePodcastScreen(
                                     onLongClick = {
                                         haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                                         menuState.show {
-                                            YouTubeSongMenu(episode.asSongItem(), navController, menuState::dismiss)
+                                            YouTubeSongMenu(episode.asSongItem(), menuState::dismiss)
                                         }
                                     }
                                 )
@@ -222,7 +222,7 @@ fun OnlinePodcastScreen(
                             trailingContent = {
                                 IconButton(onClick = {
                                     menuState.show {
-                                        YouTubeSongMenu(episode.asSongItem(), navController, menuState::dismiss)
+                                        YouTubeSongMenu(episode.asSongItem(), menuState::dismiss)
                                     }
                                 }) {
                                     Icon(painterResource(R.drawable.more_vert), null)

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/search/LocalSearchScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/search/LocalSearchScreen.kt
@@ -45,7 +45,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.navigation.NavController
+import com.metrolist.music.LocalNavController
 import com.metrolist.music.LocalPlayerConnection
 import com.metrolist.music.R
 import com.metrolist.music.constants.CONTENT_TYPE_LIST
@@ -72,12 +72,12 @@ import kotlinx.coroutines.flow.drop
 @Composable
 fun LocalSearchScreen(
     query: String,
-    navController: NavController,
     onDismiss: () -> Unit,
     isFromCache: Boolean = false,
     pureBlack: Boolean,
     viewModel: LocalSearchViewModel = hiltViewModel(),
 ) {
+    val navController = LocalNavController.current
     val queueSearchedSongsStr = stringResource(R.string.queue_searched_songs)
     val keyboardController = LocalSoftwareKeyboardController.current
     val menuState = LocalMenuState.current
@@ -187,7 +187,6 @@ fun LocalSearchScreen(
                         is Song -> {
                             SongListItem(
                                 song = item,
-                                navController = navController,
                                 showInLibraryIcon = true,
                                 isActive = item.id == mediaMetadata?.id,
                                 isPlaying = isPlaying,
@@ -197,7 +196,6 @@ fun LocalSearchScreen(
                                             menuState.show {
                                                 SongMenu(
                                                     originalSong = item,
-                                                    navController = navController,
                                                     onDismiss = {
                                                         onDismiss()
                                                         menuState.dismiss()
@@ -238,7 +236,6 @@ fun LocalSearchScreen(
                                                 menuState.show {
                                                     SongMenu(
                                                         originalSong = item,
-                                                        navController = navController,
                                                         onDismiss = {
                                                             onDismiss()
                                                             menuState.dismiss()
@@ -254,7 +251,6 @@ fun LocalSearchScreen(
                         is Album -> {
                             AlbumListItem(
                                 album = item,
-                                navController = navController,
                                 isActive = item.id == mediaMetadata?.album?.id,
                                 isPlaying = isPlaying,
                                 modifier =

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/search/LocalSearchScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/search/LocalSearchScreen.kt
@@ -187,6 +187,7 @@ fun LocalSearchScreen(
                         is Song -> {
                             SongListItem(
                                 song = item,
+                                navController = navController,
                                 showInLibraryIcon = true,
                                 isActive = item.id == mediaMetadata?.id,
                                 isPlaying = isPlaying,
@@ -253,6 +254,7 @@ fun LocalSearchScreen(
                         is Album -> {
                             AlbumListItem(
                                 album = item,
+                                navController = navController,
                                 isActive = item.id == mediaMetadata?.album?.id,
                                 isPlaying = isPlaying,
                                 modifier =

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/search/OnlineSearchResult.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/search/OnlineSearchResult.kt
@@ -64,7 +64,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.SavedStateHandle
-import androidx.navigation.NavController
+import com.metrolist.music.LocalNavController
 import com.metrolist.innertube.YouTube.SearchFilter.Companion.FILTER_ALBUM
 import com.metrolist.innertube.YouTube.SearchFilter.Companion.FILTER_ARTIST
 import com.metrolist.innertube.YouTube.SearchFilter.Companion.FILTER_COMMUNITY_PLAYLIST
@@ -118,11 +118,11 @@ import java.net.URLEncoder
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun OnlineSearchResult(
-    navController: NavController,
     viewModel: OnlineSearchViewModel = hiltViewModel(),
     pureBlack: Boolean = false,
     savedStateHandle: SavedStateHandle? = null
 ) {
+    val navController = LocalNavController.current
     val database = LocalDatabase.current
     val menuState = LocalMenuState.current
     val playerConnection = LocalPlayerConnection.current ?: return
@@ -244,7 +244,6 @@ fun OnlineSearchResult(
                     is SongItem -> {
                         YouTubeSongMenu(
                             song = item,
-                            navController = navController,
                             onDismiss = menuState::dismiss,
                         )
                     }
@@ -252,7 +251,6 @@ fun OnlineSearchResult(
                     is AlbumItem -> {
                         YouTubeAlbumMenu(
                             albumItem = item,
-                            navController = navController,
                             onDismiss = menuState::dismiss,
                         )
                     }
@@ -283,7 +281,6 @@ fun OnlineSearchResult(
                     is EpisodeItem -> {
                         YouTubeSongMenu(
                             song = item.asSongItem(),
-                            navController = navController,
                             onDismiss = menuState::dismiss,
                         )
                     }
@@ -568,7 +565,6 @@ fun OnlineSearchResult(
                 OnlineSearchScreen(
                     query = query.text,
                     onQueryChange = { query = it },
-                    navController = navController,
                     onSearch = onSearch,
                     onDismiss = {
                         isSearchFocused = false

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/search/OnlineSearchScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/search/OnlineSearchScreen.kt
@@ -53,7 +53,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.navigation.NavController
+import com.metrolist.music.LocalNavController
 import com.metrolist.innertube.models.AlbumItem
 import com.metrolist.innertube.models.ArtistItem
 import com.metrolist.innertube.models.EpisodeItem
@@ -87,12 +87,12 @@ import kotlinx.coroutines.flow.drop
 fun OnlineSearchScreen(
     query: String,
     onQueryChange: (TextFieldValue) -> Unit,
-    navController: NavController,
     onSearch: (String) -> Unit,
     onDismiss: () -> Unit,
     pureBlack: Boolean,
     viewModel: OnlineSearchSuggestionViewModel = hiltViewModel(),
 ) {
+    val navController = LocalNavController.current
     val database = LocalDatabase.current
     val keyboardController = LocalSoftwareKeyboardController.current
     val menuState = LocalMenuState.current
@@ -169,7 +169,6 @@ fun OnlineSearchScreen(
                                         is SongItem -> {
                                             YouTubeSongMenu(
                                                 song = item,
-                                                navController = navController,
                                                 onDismiss = {
                                                     menuState.dismiss()
                                                     onDismiss()
@@ -180,7 +179,6 @@ fun OnlineSearchScreen(
                                         is AlbumItem -> {
                                             YouTubeAlbumMenu(
                                                 albumItem = item,
-                                                navController = navController,
                                                 onDismiss = {
                                                     menuState.dismiss()
                                                     onDismiss()
@@ -223,7 +221,6 @@ fun OnlineSearchScreen(
                                         is EpisodeItem -> {
                                             YouTubeSongMenu(
                                                 song = item.asSongItem(),
-                                                navController = navController,
                                                 onDismiss = {
                                                     menuState.dismiss()
                                                     onDismiss()
@@ -302,7 +299,6 @@ fun OnlineSearchScreen(
                                             is SongItem -> {
                                                 YouTubeSongMenu(
                                                     song = item,
-                                                    navController = navController,
                                                     onDismiss = {
                                                         menuState.dismiss()
                                                         onDismiss()
@@ -313,7 +309,6 @@ fun OnlineSearchScreen(
                                             is AlbumItem -> {
                                                 YouTubeAlbumMenu(
                                                     albumItem = item,
-                                                    navController = navController,
                                                     onDismiss = {
                                                         menuState.dismiss()
                                                         onDismiss()
@@ -356,7 +351,6 @@ fun OnlineSearchScreen(
                                             is EpisodeItem -> {
                                                 YouTubeSongMenu(
                                                     song = item.asSongItem(),
-                                                    navController = navController,
                                                     onDismiss = {
                                                         menuState.dismiss()
                                                         onDismiss()
@@ -448,7 +442,6 @@ fun OnlineSearchScreen(
                                     is SongItem -> {
                                         YouTubeSongMenu(
                                             song = item,
-                                            navController = navController,
                                             onDismiss = {
                                                 menuState.dismiss()
                                                 onDismiss()
@@ -459,7 +452,6 @@ fun OnlineSearchScreen(
                                     is AlbumItem -> {
                                         YouTubeAlbumMenu(
                                             albumItem = item,
-                                            navController = navController,
                                             onDismiss = {
                                                 menuState.dismiss()
                                                 onDismiss()
@@ -502,7 +494,6 @@ fun OnlineSearchScreen(
                                     is EpisodeItem -> {
                                         YouTubeSongMenu(
                                             song = item.asSongItem(),
-                                            navController = navController,
                                             onDismiss = {
                                                 menuState.dismiss()
                                                 onDismiss()
@@ -581,7 +572,6 @@ fun OnlineSearchScreen(
                                         is SongItem -> {
                                             YouTubeSongMenu(
                                                 song = item,
-                                                navController = navController,
                                                 onDismiss = {
                                                     menuState.dismiss()
                                                     onDismiss()
@@ -592,7 +582,6 @@ fun OnlineSearchScreen(
                                         is AlbumItem -> {
                                             YouTubeAlbumMenu(
                                                 albumItem = item,
-                                                navController = navController,
                                                 onDismiss = {
                                                     menuState.dismiss()
                                                     onDismiss()
@@ -635,7 +624,6 @@ fun OnlineSearchScreen(
                                         is EpisodeItem -> {
                                             YouTubeSongMenu(
                                                 song = item.asSongItem(),
-                                                navController = navController,
                                                 onDismiss = {
                                                     menuState.dismiss()
                                                     onDismiss()

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/search/SearchScreen.kt
@@ -51,7 +51,7 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.SavedStateHandle
-import androidx.navigation.NavController
+import com.metrolist.music.LocalNavController
 import com.metrolist.innertube.models.WatchEndpoint
 import com.metrolist.innertube.utils.YouTubeUrlParser
 import com.metrolist.music.LocalDatabase
@@ -74,10 +74,10 @@ import java.net.URLEncoder
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SearchScreen(
-    navController: NavController,
     pureBlack: Boolean,
     savedStateHandle: SavedStateHandle,
 ) {
+    val navController = LocalNavController.current
     val database = LocalDatabase.current
     val coroutineScope = rememberCoroutineScope()
     val focusManager = LocalFocusManager.current
@@ -297,7 +297,6 @@ fun SearchScreen(
                     SearchSource.LOCAL -> {
                         LocalSearchScreen(
                             query = query.text,
-                            navController = navController,
                             onDismiss = { navController.navigateUp() },
                             pureBlack = pureBlack,
                         )
@@ -307,7 +306,6 @@ fun SearchScreen(
                         OnlineSearchScreen(
                             query = query.text,
                             onQueryChange = { query = it },
-                            navController = navController,
                             onSearch = onSearchFromSuggestion,
                             onDismiss = { /* Don't dismiss when searching from suggestions */ },
                             pureBlack = pureBlack,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AlarmSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AlarmSettings.kt
@@ -213,7 +213,7 @@ fun AlarmSettingsSection(showTitle: Boolean = true) {
                             }
                         val description = buildString {
                             append(playlistTitle)
-                            append(" • ")
+                            append(" | ")
                             append(if (alarm.randomSong) randomEnabledText else randomDisabledText)
                             append("\n")
                             append(stringResource(R.string.alarm_next_prefix, triggerText))

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/WrappedScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/WrappedScreen.kt
@@ -39,7 +39,7 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
-import androidx.navigation.NavController
+import com.metrolist.music.LocalNavController
 import com.metrolist.music.R
 import com.metrolist.music.ui.screens.wrapped.pages.ConclusionPage
 import com.metrolist.music.ui.screens.wrapped.pages.PlaylistPage
@@ -89,18 +89,20 @@ sealed class WrappedScreenType {
 }
 
 @Composable
-fun WrappedScreen(navController: NavController) {
+fun WrappedScreen() {
+    val navController = LocalNavController.current
     val context = LocalContext.current
     val manager = remember { provideWrappedManager(context) }
 
     CompositionLocalProvider(LocalWrappedManager provides manager) {
-        WrappedScreenContent(navController = navController)
+        WrappedScreenContent()
     }
 }
 
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
-fun WrappedScreenContent(navController: NavController) {
+fun WrappedScreenContent() {
+    val navController = LocalNavController.current
     val onClose: () -> Unit = {
         navController.previousBackStackEntry?.savedStateHandle?.set("wrapped_seen", true)
         navController.popBackStack()

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/pages/WrappedTop5SongsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/pages/WrappedTop5SongsScreen.kt
@@ -4,6 +4,7 @@
  */
 
 package com.metrolist.music.ui.screens.wrapped.pages
+import com.metrolist.music.utils.ARTIST_SEPARATOR
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
@@ -115,7 +116,7 @@ fun WrappedTop5SongsScreen(topSongs: List<SongWithStats>, isVisible: Boolean) {
                                     fontSize = 16.sp
                                 )
                                 Text(
-                                    text = song.artists.joinToString(", ") { it.name }.ifBlank { song.artistName.orEmpty() },
+                                    text = song.artists.joinToString(ARTIST_SEPARATOR) { it.name }.ifBlank { song.artistName.orEmpty() },
                                     color = Color.White.copy(alpha = 0.7f),
                                     fontSize = 14.sp
                                 )

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/pages/WrappedTop5SongsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/pages/WrappedTop5SongsScreen.kt
@@ -4,7 +4,7 @@
  */
 
 package com.metrolist.music.ui.screens.wrapped.pages
-import com.metrolist.music.utils.ARTIST_SEPARATOR
+
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
@@ -116,7 +116,7 @@ fun WrappedTop5SongsScreen(topSongs: List<SongWithStats>, isVisible: Boolean) {
                                     fontSize = 16.sp
                                 )
                                 Text(
-                                    text = song.artists.joinToString(ARTIST_SEPARATOR) { it.name }.ifBlank { song.artistName.orEmpty() },
+                                    text = song.artists.joinToString(" ${stringResource(R.string.and)} ") { it.name }.ifBlank { song.artistName.orEmpty() },
                                     color = Color.White.copy(alpha = 0.7f),
                                     fontSize = 14.sp
                                 )

--- a/app/src/main/kotlin/com/metrolist/music/utils/PlaylistExporter.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/PlaylistExporter.kt
@@ -1,4 +1,5 @@
 package com.metrolist.music.utils
+import com.metrolist.music.utils.ARTIST_SEPARATOR
 
 import android.content.ContentValues
 import android.content.Context
@@ -129,7 +130,7 @@ fun exportYouTubePlaylistAsM3U(
                 // Add each song as M3U entry
                 songs.forEach { songItem ->
                     append("#EXTINF:${songItem.duration},")
-                    append("${songItem.artists.joinToString(" - ") { it.name }} - ${songItem.title}")
+                    append("${songItem.artists.joinToString(ARTIST_SEPARATOR) { it.name }} - ${songItem.title}")
                     append("\n")
                     // For M3U, we would typically include a URL, but since we don't have direct URLs,
                     // we'll use a placeholder that indicates this is a YouTube Music track

--- a/app/src/main/kotlin/com/metrolist/music/utils/PlaylistExporter.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/PlaylistExporter.kt
@@ -1,5 +1,4 @@
 package com.metrolist.music.utils
-import com.metrolist.music.utils.ARTIST_SEPARATOR
 
 import android.content.ContentValues
 import android.content.Context
@@ -130,7 +129,7 @@ fun exportYouTubePlaylistAsM3U(
                 // Add each song as M3U entry
                 songs.forEach { songItem ->
                     append("#EXTINF:${songItem.duration},")
-                    append("${songItem.artists.joinToString(ARTIST_SEPARATOR) { it.name }} - ${songItem.title}")
+                    append("${songItem.artists.joinToString(getArtistSeparator(context)) { it.name }} - ${songItem.title}")
                     append("\n")
                     // For M3U, we would typically include a URL, but since we don't have direct URLs,
                     // we'll use a placeholder that indicates this is a YouTube Music track

--- a/app/src/main/kotlin/com/metrolist/music/utils/PlaylistExporter.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/PlaylistExporter.kt
@@ -129,7 +129,7 @@ fun exportYouTubePlaylistAsM3U(
                 // Add each song as M3U entry
                 songs.forEach { songItem ->
                     append("#EXTINF:${songItem.duration},")
-                    append("${songItem.artists.joinToString(getArtistSeparator(context)) { it.name }} - ${songItem.title}")
+                    append("${songItem.artists.joinToString(" - ") { it.name }} - ${songItem.title}")
                     append("\n")
                     // For M3U, we would typically include a URL, but since we don't have direct URLs,
                     // we'll use a placeholder that indicates this is a YouTube Music track

--- a/app/src/main/kotlin/com/metrolist/music/utils/StringUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/StringUtils.kt
@@ -25,4 +25,4 @@ fun joinByBullet(vararg str: String?) =
     str
         .filterNot {
             it.isNullOrEmpty()
-        }.joinToString(separator = " • ")
+        }.joinToString(separator = " | ")

--- a/app/src/main/kotlin/com/metrolist/music/utils/Utils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/Utils.kt
@@ -9,6 +9,8 @@ import android.content.Context
 import android.content.res.Configuration
 import java.util.Locale
 
+const val ARTIST_SEPARATOR = " e "
+
 fun reportException(throwable: Throwable) {
     throwable.printStackTrace()
 }

--- a/app/src/main/kotlin/com/metrolist/music/utils/Utils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/Utils.kt
@@ -7,7 +7,10 @@ package com.metrolist.music.utils
 
 import android.content.Context
 import android.content.res.Configuration
+import com.metrolist.music.R
 import java.util.Locale
+
+fun getArtistSeparator(context: Context): String = " ${context.getString(R.string.and)} "
 
 fun reportException(throwable: Throwable) {
     throwable.printStackTrace()

--- a/app/src/main/kotlin/com/metrolist/music/utils/Utils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/Utils.kt
@@ -7,9 +7,10 @@ package com.metrolist.music.utils
 
 import android.content.Context
 import android.content.res.Configuration
+import com.metrolist.music.R
 import java.util.Locale
 
-const val ARTIST_SEPARATOR = " e "
+fun getArtistSeparator(context: Context): String = " ${context.getString(R.string.and)} "
 
 fun reportException(throwable: Throwable) {
     throwable.printStackTrace()

--- a/app/src/main/kotlin/com/metrolist/music/utils/Utils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/Utils.kt
@@ -12,6 +12,16 @@ import java.util.Locale
 
 fun getArtistSeparator(context: Context): String = " ${context.getString(R.string.and)} "
 
+fun <T> List<T>.joinToArtistString(
+    conjunction: String,
+    transform: (T) -> String,
+): String = when (size) {
+    0 -> ""
+    1 -> transform(this[0])
+    2 -> "${transform(this[0])}$conjunction${transform(this[1])}"
+    else -> dropLast(1).joinToString(", ") { transform(it) } + "$conjunction${transform(last())}"
+}
+
 fun reportException(throwable: Throwable) {
     throwable.printStackTrace()
 }

--- a/app/src/main/kotlin/com/metrolist/music/utils/Utils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/Utils.kt
@@ -7,10 +7,7 @@ package com.metrolist.music.utils
 
 import android.content.Context
 import android.content.res.Configuration
-import com.metrolist.music.R
 import java.util.Locale
-
-fun getArtistSeparator(context: Context): String = " ${context.getString(R.string.and)} "
 
 fun reportException(throwable: Throwable) {
     throwable.printStackTrace()

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/ArtistViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/ArtistViewModel.kt
@@ -158,7 +158,7 @@ class ArtistViewModel @Inject constructor(
                     viewModelScope.launch(Dispatchers.IO) {
                         try {
                             val cachedJson = serializeArtistPage(
-                                sections = filteredSections,
+                                sections = resolvedPage.sections,
                                 description = resolvedPage.description,
                                 subscriberCountText = resolvedPage.subscriberCountText,
                                 monthlyListenerCount = resolvedPage.monthlyListenerCount,

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/ArtistViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/ArtistViewModel.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -121,6 +122,30 @@ class ArtistViewModel @Inject constructor(
                         .filter { section -> section.items.isNotEmpty() }
 
                     artistPage = resolvedPage.copy(sections = filteredSections)
+                    // Persist artist thumbnail for offline/persistent use
+                    resolvedPage.artist?.let { apiArtist ->
+                        viewModelScope.launch(Dispatchers.IO) {
+                            val existingArtist = database.artist(artistId).firstOrNull()?.artist
+                            if (existingArtist != null) {
+                                database.update(
+                                    existingArtist.copy(
+                                        name = apiArtist.title,
+                                        channelId = apiArtist.channelId,
+                                        thumbnailUrl = apiArtist.thumbnail,
+                                    )
+                                )
+                            } else {
+                                database.insert(
+                                    ArtistEntity(
+                                        id = artistId,
+                                        name = apiArtist.title,
+                                        channelId = apiArtist.channelId,
+                                        thumbnailUrl = apiArtist.thumbnail,
+                                    )
+                                )
+                            }
+                        }
+                    }
                     // Store API subscription state
                     _apiSubscribed.value = resolvedPage.isSubscribed
                 }.onFailure {

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/ArtistViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/ArtistViewModel.kt
@@ -22,6 +22,9 @@ import com.metrolist.music.constants.HideVideoSongsKey
 import com.metrolist.music.constants.HideYoutubeShortsKey
 import com.metrolist.music.db.MusicDatabase
 import com.metrolist.music.db.entities.ArtistEntity
+import com.metrolist.music.db.entities.deserializeArtistPage
+import com.metrolist.music.db.entities.serializeArtistPage
+import com.metrolist.music.db.entities.toArtistPage
 import com.metrolist.music.extensions.filterExplicit
 import com.metrolist.music.extensions.filterExplicitAlbums
 import com.metrolist.music.utils.SyncUtils
@@ -87,7 +90,12 @@ class ArtistViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
 
     init {
-        // Load artist page and reload when hide explicit setting changes
+        // Load cached page first for instant display
+        viewModelScope.launch {
+            loadCachedPage()
+        }
+
+        // Then listen for settings changes and fetch fresh data
         viewModelScope.launch {
             context.dataStore.data
                 .map {
@@ -101,6 +109,30 @@ class ArtistViewModel @Inject constructor(
                 .collect {
                     fetchArtistsFromYTM()
                 }
+        }
+    }
+
+    private suspend fun loadCachedPage() {
+        try {
+            val cachedJson = database.artist(artistId).firstOrNull()?.artist?.cachedPageJson
+            if (cachedJson != null) {
+                val cachedDto = deserializeArtistPage(cachedJson)
+                val page = cachedDto.toArtistPage()
+                val hideExplicit = context.dataStore.get(HideExplicitKey, false)
+                val hideVideoSongs = context.dataStore.get(HideVideoSongsKey, false)
+                val hideYoutubeShorts = context.dataStore.get(HideYoutubeShortsKey, false)
+
+                val filteredSections = page.sections
+                    .map { section ->
+                        section.copy(items = section.items.filterExplicit(hideExplicit).filterVideoSongs(hideVideoSongs).filterYoutubeShorts(hideYoutubeShorts))
+                    }
+                    .filter { section -> section.items.isNotEmpty() }
+
+                artistPage = page.copy(sections = filteredSections)
+                _apiSubscribed.value = page.isSubscribed
+            }
+        } catch (e: Exception) {
+            reportException(e)
         }
     }
 
@@ -122,28 +154,41 @@ class ArtistViewModel @Inject constructor(
                         .filter { section -> section.items.isNotEmpty() }
 
                     artistPage = resolvedPage.copy(sections = filteredSections)
-                    // Persist artist thumbnail for offline/persistent use
-                    resolvedPage.artist?.let { apiArtist ->
-                        viewModelScope.launch(Dispatchers.IO) {
+                    // Cache page data + persist artist metadata
+                    viewModelScope.launch(Dispatchers.IO) {
+                        try {
+                            val cachedJson = serializeArtistPage(
+                                sections = filteredSections,
+                                description = resolvedPage.description,
+                                subscriberCountText = resolvedPage.subscriberCountText,
+                                monthlyListenerCount = resolvedPage.monthlyListenerCount,
+                                isSubscribed = resolvedPage.isSubscribed,
+                                artist = resolvedPage.artist,
+                            )
                             val existingArtist = database.artist(artistId).firstOrNull()?.artist
                             if (existingArtist != null) {
                                 database.update(
                                     existingArtist.copy(
-                                        name = apiArtist.title,
-                                        channelId = apiArtist.channelId,
-                                        thumbnailUrl = apiArtist.thumbnail,
+                                        name = resolvedPage.artist.title,
+                                        channelId = resolvedPage.artist.channelId ?: existingArtist.channelId,
+                                        thumbnailUrl = resolvedPage.artist.thumbnail ?: existingArtist.thumbnailUrl,
+                                        cachedPageJson = cachedJson,
                                     )
                                 )
                             } else {
+                                val apiArtist = resolvedPage.artist
                                 database.insert(
                                     ArtistEntity(
                                         id = artistId,
                                         name = apiArtist.title,
                                         channelId = apiArtist.channelId,
                                         thumbnailUrl = apiArtist.thumbnail,
+                                        cachedPageJson = cachedJson,
                                     )
                                 )
                             }
+                        } catch (e: Exception) {
+                            reportException(e)
                         }
                     }
                     // Store API subscription state

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/ArtistViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/ArtistViewModel.kt
@@ -90,13 +90,10 @@ class ArtistViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
 
     init {
-        // Load cached page first for instant display
         viewModelScope.launch {
+            // Load cached page first for instant display, then fetch fresh data
             loadCachedPage()
-        }
 
-        // Then listen for settings changes and fetch fresh data
-        viewModelScope.launch {
             context.dataStore.data
                 .map {
                     Triple(

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/BackupRestoreViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/BackupRestoreViewModel.kt
@@ -5,6 +5,7 @@
 
 package com.metrolist.music.viewmodels
 
+import com.metrolist.music.utils.ARTIST_SEPARATOR
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -455,7 +456,7 @@ class BackupRestoreViewModel @Inject constructor(
 
                                 val logEntry = ConvertedSongLog(
                                     title = title,
-                                    artists = artists.joinToString(", ") { it.name },
+                                    artists = artists.joinToString(ARTIST_SEPARATOR) { it.name },
                                 )
                                 recentLogs.add(0, logEntry)
                                 if (recentLogs.size > 3) {

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/BackupRestoreViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/BackupRestoreViewModel.kt
@@ -5,7 +5,7 @@
 
 package com.metrolist.music.viewmodels
 
-import com.metrolist.music.utils.ARTIST_SEPARATOR
+import com.metrolist.music.utils.getArtistSeparator
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -456,7 +456,7 @@ class BackupRestoreViewModel @Inject constructor(
 
                                 val logEntry = ConvertedSongLog(
                                     title = title,
-                                    artists = artists.joinToString(ARTIST_SEPARATOR) { it.name },
+                                    artists = artists.joinToString(getArtistSeparator(context)) { it.name },
                                 )
                                 recentLogs.add(0, logEntry)
                                 if (recentLogs.size > 3) {
@@ -513,8 +513,8 @@ class BackupRestoreViewModel @Inject constructor(
                 if (lines.isNotEmpty() && lines.first().startsWith("#EXTM3U")) {
                     lines.forEachIndexed { _, rawLine ->
                         if (rawLine.startsWith("#EXTINF:")) {
-                            val artists =
-                                rawLine.substringAfter("#EXTINF:").substringAfter(',').substringBefore(" - ").split(';')
+                             val artists =
+                                 rawLine.substringAfter("#EXTINF:").substringAfter(',').substringBefore(" - ").split(getArtistSeparator(context))
                             val title = rawLine.substringAfter("#EXTINF:").substringAfter(',').substringAfter(" - ")
 
                             val mockSong = Song(

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/BackupRestoreViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/BackupRestoreViewModel.kt
@@ -5,7 +5,6 @@
 
 package com.metrolist.music.viewmodels
 
-import com.metrolist.music.utils.getArtistSeparator
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -456,7 +455,7 @@ class BackupRestoreViewModel @Inject constructor(
 
                                 val logEntry = ConvertedSongLog(
                                     title = title,
-                                    artists = artists.joinToString(getArtistSeparator(context)) { it.name },
+                                    artists = artists.joinToString(", ") { it.name },
                                 )
                                 recentLogs.add(0, logEntry)
                                 if (recentLogs.size > 3) {
@@ -513,8 +512,8 @@ class BackupRestoreViewModel @Inject constructor(
                 if (lines.isNotEmpty() && lines.first().startsWith("#EXTM3U")) {
                     lines.forEachIndexed { _, rawLine ->
                         if (rawLine.startsWith("#EXTINF:")) {
-                             val artists =
-                                 rawLine.substringAfter("#EXTINF:").substringAfter(',').substringBefore(" - ").split(getArtistSeparator(context))
+                            val artists =
+                                rawLine.substringAfter("#EXTINF:").substringAfter(',').substringBefore(" - ").split(';')
                             val title = rawLine.substringAfter("#EXTINF:").substringAfter(',').substringAfter(" - ")
 
                             val mockSong = Song(

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/HomeViewModel.kt
@@ -64,6 +64,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import javax.inject.Inject
 import kotlin.random.Random
+import com.metrolist.music.utils.getArtistSeparator
 
 data class DailyDiscoverItem(
     val seed: Song,
@@ -121,7 +122,7 @@ class HomeViewModel @Inject constructor(
             keepListening,
             quickPicks
         ) { pinned, keepListening, quick ->
-            val pinnedItems = pinned.map { it.toYTItem() }
+            val pinnedItems = pinned.map { it.toYTItem(getArtistSeparator(context)) }
             val filled = pinnedItems.toMutableList()
             val targetSize = 27
 
@@ -267,7 +268,7 @@ class HomeViewModel @Inject constructor(
 
     fun togglePin(item: YTItem) {
         viewModelScope.launch(Dispatchers.IO) {
-            val speedDialItem = SpeedDialItem.fromYTItem(item)
+            val speedDialItem = SpeedDialItem.fromYTItem(item, getArtistSeparator(context))
             val isPinned = database.speedDialDao.isPinned(speedDialItem.id).first()
             if (isPinned) {
                 database.speedDialDao.delete(speedDialItem.id)

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/HomeViewModel.kt
@@ -64,7 +64,6 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import javax.inject.Inject
 import kotlin.random.Random
-import com.metrolist.music.utils.getArtistSeparator
 
 data class DailyDiscoverItem(
     val seed: Song,
@@ -122,7 +121,7 @@ class HomeViewModel @Inject constructor(
             keepListening,
             quickPicks
         ) { pinned, keepListening, quick ->
-            val pinnedItems = pinned.map { it.toYTItem(getArtistSeparator(context)) }
+            val pinnedItems = pinned.map { it.toYTItem() }
             val filled = pinnedItems.toMutableList()
             val targetSize = 27
 
@@ -268,7 +267,7 @@ class HomeViewModel @Inject constructor(
 
     fun togglePin(item: YTItem) {
         viewModelScope.launch(Dispatchers.IO) {
-            val speedDialItem = SpeedDialItem.fromYTItem(item, getArtistSeparator(context))
+            val speedDialItem = SpeedDialItem.fromYTItem(item)
             val isPinned = database.speedDialDao.isPinned(speedDialItem.id).first()
             if (isPinned) {
                 database.speedDialDao.delete(speedDialItem.id)

--- a/innertube/src/main/kotlin/com/metrolist/innertube/models/Runs.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/models/Runs.kt
@@ -41,9 +41,12 @@ fun List<Run>.splitArtistsByConjunction(): List<Run> {
             val parts = text.split(conjunctionPattern)
             parts.forEachIndexed { index, part ->
                 if (part.isNotBlank()) {
-                    result.add(Run(part.trim(), run.navigationEndpoint))
+                    result.add(Run(part.trim(), if (index == 0) run.navigationEndpoint else null))
                 }
             }
+        } else if (text.trim().equals("&", ignoreCase = true) ||
+                words.any { text.trim().equals(it, ignoreCase = true) }
+        ) {
         } else {
             result.add(run)
         }

--- a/innertube/src/main/kotlin/com/metrolist/innertube/models/Runs.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/models/Runs.kt
@@ -41,7 +41,7 @@ fun List<Run>.splitArtistsByConjunction(): List<Run> {
             val parts = text.split(conjunctionPattern)
             parts.forEachIndexed { index, part ->
                 if (part.isNotBlank()) {
-                    result.add(Run(part.trim(), run.navigationEndpoint))
+                    result.add(Run(part.trim(), if (index == 0) run.navigationEndpoint else null))
                 }
             }
         } else if (text.trim().equals("&", ignoreCase = true) ||

--- a/innertube/src/main/kotlin/com/metrolist/innertube/models/Runs.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/models/Runs.kt
@@ -41,7 +41,7 @@ fun List<Run>.splitArtistsByConjunction(): List<Run> {
             val parts = text.split(conjunctionPattern)
             parts.forEachIndexed { index, part ->
                 if (part.isNotBlank()) {
-                    result.add(Run(part.trim(), if (index == 0) run.navigationEndpoint else null))
+                    result.add(Run(part.trim(), run.navigationEndpoint))
                 }
             }
         } else if (text.trim().equals("&", ignoreCase = true) ||

--- a/innertube/src/main/kotlin/com/metrolist/innertube/models/Runs.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/models/Runs.kt
@@ -33,7 +33,8 @@ fun List<Run>.splitArtistsByConjunction(): List<Run> {
     val words = ArtistConjunctions.conjunctions
     val conjunctionPattern = Regex(
         if (words.isNotEmpty()) " (${words.joinToString("|") { Regex.escape(it) }}) | & "
-        else " & "
+        else " & ",
+        RegexOption.IGNORE_CASE
     )
     forEach { run ->
         val text = run.text

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/ArtistItemsPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/ArtistItemsPage.kt
@@ -107,17 +107,12 @@ data class ArtistItemsPage(
                     SongItem(
                         id = renderer.navigationEndpoint.watchEndpoint?.videoId ?: return null,
                         title = renderer.title.runs?.firstOrNull()?.text ?: return null,
-                        artists = artistRuns.filter { 
-                            it.navigationEndpoint?.browseEndpoint?.browseId?.startsWith("UC") == true ||
-                            it.navigationEndpoint?.browseEndpoint != null
-                        }.map {
+                        artists = artistRuns.map { run ->
                             Artist(
-                                name = it.text.trim(),
-                                id = it.navigationEndpoint?.browseEndpoint?.browseId
+                                name = run.text.trim(),
+                                id = run.navigationEndpoint?.browseEndpoint?.browseId
                             )
-                        }.ifEmpty {
-                            artistRuns.map { Artist(name = it.text.trim(), id = null) }
-                        },
+                        }.ifEmpty { null } ?: return null,
                         album = null,
                         duration = null,
                         musicVideoType = renderer.musicVideoType,

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/ArtistPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/ArtistPage.kt
@@ -140,17 +140,12 @@ data class ArtistPage(
                     SongItem(
                         id = renderer.navigationEndpoint.watchEndpoint?.videoId ?: return null,
                         title = renderer.title.runs?.firstOrNull()?.text ?: return null,
-                        artists = artistRuns.filter { 
-                            it.navigationEndpoint?.browseEndpoint?.browseId?.startsWith("UC") == true ||
-                            it.navigationEndpoint?.browseEndpoint != null
-                        }.map {
+                        artists = artistRuns.map { run ->
                             Artist(
-                                name = it.text.trim(),
-                                id = it.navigationEndpoint?.browseEndpoint?.browseId
+                                name = run.text.trim(),
+                                id = run.navigationEndpoint?.browseEndpoint?.browseId
                             )
-                        }.ifEmpty {
-                            artistRuns.map { Artist(name = it.text.trim(), id = null) }
-                        },
+                        }.ifEmpty { null } ?: return null,
                         album = null,
                         duration = null,
                         musicVideoType = renderer.musicVideoType,


### PR DESCRIPTION
## Problem

Artist names joined by conjunctions (e.g., "Tiziano Ferro e Ariete") were not split correctly. Conjunction words like "e" (Italian for "and") appeared as separate clickable artists. Additionally:
- When splitting a single run, all split parts received the same `navigationEndpoint`, making the second artist navigate to the wrong page (e.g., clicking "Ariete" opened Tiziano Ferro)
- `mapNotNull` in `fromMusicTwoRowItemRenderer` filtered out artists with `null` IDs before `resolveArtistIds()` could resolve them
- Artists were plain text across all list components — not individually tappable like in Spotify
- Artist thumbnails on the artist page were not persisted in the database — they relied solely on the API response, causing them to appear late or flicker when navigating from a clickable artist name
- DB version bump from 37→38 with manual migration crashed at runtime due to Room auto-migration conflict
- With 3+ artists, every pair was separated by a conjunction (e.g., "A & B & C") instead of proper comma+conjunction formatting

## Cause

- `splitArtistsByConjunction()` only checked for standalone conjunction runs but did not split runs containing conjunction words
- When splitting a single run, all split parts received the same `navigationEndpoint`
- No mechanism existed to make artist names clickable with per-artist navigation
- `ArtistEntity` was only created/updated when subscribing to an artist, not when simply viewing the artist page
- Manual `MIGRATION_37_38` conflicted with Room's auto-migration system; Room could not resolve the migration path from 37 to 38
- `ClickableArtistText` and plain-text fallbacks used a single separator for all pairs, producing "A & B & C" for 3+ artists

## Solution

### Navigation fix (ef84c0a)
- Split single runs like "Artist1 e Artist2" into separate runs
- Only the first split part retains the original `navigationEndpoint`; subsequent parts get `null` so `resolveArtistIds()` handles them
- Replaced `mapNotNull` with `.map` in `fromMusicTwoRowItemRenderer` so null-ID artists are preserved
- Restored localized separator from `metrolist_strings.xml` via `getArtistSeparator()` instead of hardcoded strings

### Clickable artists (5703c42)
- Added `ClickableArtistText` composable in `Items.kt` with two overloads (`ArtistEntity`, `MediaMetadata.Artist`)
- Builds an `AnnotatedString` with `pushStringAnnotation("artist_$id", id)` and renders via `ClickableText`
- On tap, navigates to `artist/${id}` via `NavController`
- Uses the localized separator from `stringResource(R.string.and)`
- Uses `LocalNavController` CompositionLocal (following project's existing pattern) instead of threading `navController` through 40+ files
- Updated `SongListItem`, `SongGridItem`, `AlbumListItem`, `MediaMetadataListItem` to render clickable artists via `LocalNavController`
- Also converted menu composables (`SongMenu`, `AlbumMenu`, `YouTubeSongMenu`, `QueueMenu`, `PlayerMenu`, `Library.kt`, `Dialog.kt`) and screen composables to `LocalNavController.current`, removing ~177 lines of `navController` parameter boilerplate

### Persistent artist thumbnails (9373e83)
- In `ArtistViewModel.fetchArtistsFromYTM()`, save/update the `ArtistEntity` in the local database with thumbnail, name, and channelId after each successful API call
- Ensures the artist image is immediately available from the database on subsequent visits, preventing thumbnail flicker

### DB migration fix (9abbce6)
- Replaced manual `MIGRATION_37_38` with `AutoMigration(from = 37, to = 38)` — Room natively handles adding a nullable column with DEFAULT
- Resolves the crash "A migration from 37 to 38 was required but not found"

### Comma+conjunction for 3+ artists (077c89d)
- `ClickableArtistText` now renders "A, B & C" for 3+ artists, "A & B" for 2, and just "A" for 1
- Added `joinToArtistString()` extension function in `Utils.kt` for uniform string-based formatting
- Updated `MiniPlayer`, `MusicService`, `MediaLibrarySessionCallback`, `ListenTogetherManager` to use the new formatter

### Album page artist color (a3c5790)
- `ClickableArtistText` on AlbumScreen now uses `colorScheme.secondary` instead of default `onSurface`, matching song item styling

### CodeRabbit review fixes (a3c5790)
- **ArtistPageCache**: `toYTItem()` now uses `thumbnail.takeIf { it.isNotBlank() }` for nullable thumbnail fields (playlist, artist, podcast), preserving null semantics for absent thumbnails
- **Items.kt/HomaScreen.kt**: all plain-text artist fallback branches now use `joinToArtistString()` instead of raw `joinToString()`, ensuring consistent "A, B & C" formatting everywhere
- **ArtistViewModel**: cache now stores unfiltered sections (`resolvedPage.sections`) instead of `filteredSections`, so hide-* settings toggles don't break offline cache content

## Testing

- Build: `./gradlew :app:assembleFossDebug` — SUCCESS
- APK: `app/build/outputs/apk/foss/debug/app-foss-debug.apk`
- Verification: tapping individual artist names navigates to the correct artist page with correct thumbnail


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Artist pages are now cached for faster loading and offline access.

* **Improvements**
  * Artist names rendered as clickable links in many lists and detail views.
  * Artist lists and playback displays use localized conjunctions (e.g., "Artist1 and Artist2") app-wide.
  * Metadata separators updated from "•" to "|" for clearer display.

* **Chores**
  * Database schema version bumped with an automatic migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->