### PR TITLE
fix(ui): Fix discord integration's Activity name field validation

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/integrations/DiscordSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/integrations/DiscordSettings.kt
@@ -35,9 +35,7 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.LinearWavyProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
@@ -46,7 +44,6 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -68,6 +65,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.net.toUri
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.media3.common.Player.STATE_READY
 import androidx.navigation.NavController
 import coil3.compose.AsyncImage
@@ -90,6 +88,8 @@ import com.metrolist.music.constants.DiscordUseDetailsKey
 import com.metrolist.music.constants.DiscordUsernameKey
 import com.metrolist.music.constants.EnableDiscordRPCKey
 import com.metrolist.music.db.entities.Song
+import com.metrolist.music.discordrpc.DiscordRpcConnection
+import com.metrolist.music.discordrpc.SuperProperties
 import com.metrolist.music.ui.component.EnumDialog
 import com.metrolist.music.ui.component.IconButton
 import com.metrolist.music.ui.component.InfoLabel
@@ -97,8 +97,6 @@ import com.metrolist.music.ui.component.Material3SettingsGroup
 import com.metrolist.music.ui.component.Material3SettingsItem
 import com.metrolist.music.ui.component.TextFieldDialog
 import com.metrolist.music.ui.utils.backToMain
-import com.metrolist.music.discordrpc.DiscordRpcConnection
-import com.metrolist.music.discordrpc.SuperProperties
 import com.metrolist.music.utils.DiscordRPC
 import com.metrolist.music.utils.makeTimeString
 import com.metrolist.music.utils.rememberPreference
@@ -354,6 +352,7 @@ fun DiscordSettings(
             extraContent = {
                 InfoLabel(text = stringResource(R.string.discord_activity_name_description))
             },
+            isInputValid = { true }
         )
     }
 

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/integrations/DiscordSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/integrations/DiscordSettings.kt
@@ -344,7 +344,7 @@ fun DiscordSettings(
         TextFieldDialog(
             onDismiss = { showActivityNameDialog = false },
             onDone = {
-                activityName = it
+                activityName = it.trim()
                 showActivityNameDialog = false
             },
             singleLine = true,


### PR DESCRIPTION
## Problem
<!-- Describe the issue or limitation this PR addresses  
DO NOT PR NEW FEATURES, WE'RE ON A FEATURE FREEZE!!! -->
No way to set the discord integration's "Activity name" field to be an empty value

## Cause
<!-- Explain the root cause of the problem -->
The Dialog informs the user that the text field can be left empty to use the default value. The text field would try to evaluate if the text is empty or not, which is not possible due to input validation

## Solution
<!-- List the changes made to fix the issue -->
- Change the input validation to always be true, even when empty

## Testing
<!-- Describe how the changes were tested -->
- Successfully compiled the application
- The feature now works as intended, screenshots attached

Before the change
<img width="452" height="276" alt="image" src="https://github.com/user-attachments/assets/7aaf5080-eddd-49fe-968c-d65de3fa7f60" />
After the change
<img width="428" height="275" alt="image" src="https://github.com/user-attachments/assets/c0d4c44d-0cf0-4b8a-bacd-1d722cef457b" />


## Related Issues
<!-- List any related issues or PRs -->
- None, could not find any


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Discord activity name input now trims leading/trailing whitespace and reliably accepts entries; the dialog’s Done action is consistently enabled so names are saved as entered, preventing accidental blank or whitespace-only activity names.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MetrolistGroup/Metrolist/pull/3825?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->