### PR TITLE
fix(innertube): parse all renderer types in browse carousel sections

### DIFF
--- a/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
@@ -1678,6 +1678,29 @@ object YouTube {
                                 }
 
                                 content.musicCarouselShelfRenderer != null -> {
+                                    val carouselItems = mutableListOf<YTItem>()
+
+                                    content.musicCarouselShelfRenderer.contents
+                                        .mapNotNull(MusicCarouselShelfRenderer.Content::musicTwoRowItemRenderer)
+                                        .mapNotNull { renderer ->
+                                            LibraryPage.fromMusicTwoRowItemRenderer(renderer)
+                                                ?: RelatedPage.fromMusicTwoRowItemRenderer(renderer)
+                                        }
+                                        .let { carouselItems.addAll(it) }
+
+                                    content.musicCarouselShelfRenderer.contents
+                                        .mapNotNull(MusicCarouselShelfRenderer.Content::musicMultiRowListItemRenderer)
+                                        .mapNotNull { PodcastPage.fromMusicMultiRowListItemRenderer(it) }
+                                        .let { carouselItems.addAll(it) }
+
+                                    content.musicCarouselShelfRenderer.contents
+                                        .mapNotNull(MusicCarouselShelfRenderer.Content::musicResponsiveListItemRenderer)
+                                        .mapNotNull { renderer ->
+                                            LibraryPage.fromMusicResponsiveListItemRenderer(renderer)
+                                                ?: RelatedPage.fromMusicResponsiveListItemRenderer(renderer)
+                                        }
+                                        .let { carouselItems.addAll(it) }
+
                                     BrowseResult.Item(
                                         title =
                                             content.musicCarouselShelfRenderer.header
@@ -1686,13 +1709,7 @@ object YouTube {
                                                 ?.runs
                                                 ?.firstOrNull()
                                                 ?.text,
-                                        items =
-                                            content.musicCarouselShelfRenderer.contents
-                                                .mapNotNull(MusicCarouselShelfRenderer.Content::musicTwoRowItemRenderer)
-                                                .mapNotNull { renderer ->
-                                                    LibraryPage.fromMusicTwoRowItemRenderer(renderer)
-                                                        ?: RelatedPage.fromMusicTwoRowItemRenderer(renderer)
-                                                },
+                                        items = carouselItems,
                                     )
                                 }
 

--- a/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
@@ -9,6 +9,7 @@ import com.metrolist.innertube.models.EpisodeItem
 import com.metrolist.innertube.models.GridRenderer
 import com.metrolist.innertube.models.MediaInfo
 import com.metrolist.innertube.models.MusicCarouselShelfRenderer
+import com.metrolist.innertube.models.MusicMultiRowListItemRenderer
 import com.metrolist.innertube.models.MusicResponsiveListItemRenderer
 import com.metrolist.innertube.models.MusicShelfRenderer
 import com.metrolist.innertube.models.MusicTwoRowItemRenderer
@@ -1678,29 +1679,6 @@ object YouTube {
                                 }
 
                                 content.musicCarouselShelfRenderer != null -> {
-                                    val carouselItems = mutableListOf<YTItem>()
-
-                                    content.musicCarouselShelfRenderer.contents
-                                        .mapNotNull(MusicCarouselShelfRenderer.Content::musicTwoRowItemRenderer)
-                                        .mapNotNull { renderer ->
-                                            LibraryPage.fromMusicTwoRowItemRenderer(renderer)
-                                                ?: RelatedPage.fromMusicTwoRowItemRenderer(renderer)
-                                        }
-                                        .let { carouselItems.addAll(it) }
-
-                                    content.musicCarouselShelfRenderer.contents
-                                        .mapNotNull(MusicCarouselShelfRenderer.Content::musicMultiRowListItemRenderer)
-                                        .mapNotNull { PodcastPage.fromMusicMultiRowListItemRenderer(it) }
-                                        .let { carouselItems.addAll(it) }
-
-                                    content.musicCarouselShelfRenderer.contents
-                                        .mapNotNull(MusicCarouselShelfRenderer.Content::musicResponsiveListItemRenderer)
-                                        .mapNotNull { renderer ->
-                                            LibraryPage.fromMusicResponsiveListItemRenderer(renderer)
-                                                ?: RelatedPage.fromMusicResponsiveListItemRenderer(renderer)
-                                        }
-                                        .let { carouselItems.addAll(it) }
-
                                     BrowseResult.Item(
                                         title =
                                             content.musicCarouselShelfRenderer.header
@@ -1709,7 +1687,18 @@ object YouTube {
                                                 ?.runs
                                                 ?.firstOrNull()
                                                 ?.text,
-                                        items = carouselItems,
+                                        items =
+                                            content.musicCarouselShelfRenderer.contents.mapNotNull { content ->
+                                                content.musicTwoRowItemRenderer?.let { renderer ->
+                                                    LibraryPage.fromMusicTwoRowItemRenderer(renderer)
+                                                        ?: RelatedPage.fromMusicTwoRowItemRenderer(renderer)
+                                                } ?: content.musicMultiRowListItemRenderer?.let { renderer ->
+                                                    PodcastPage.fromMusicMultiRowListItemRenderer(renderer)
+                                                } ?: content.musicResponsiveListItemRenderer?.let { renderer ->
+                                                    LibraryPage.fromMusicResponsiveListItemRenderer(renderer)
+                                                        ?: RelatedPage.fromMusicResponsiveListItemRenderer(renderer)
+                                                }
+                                            },
                                     )
                                 }
 
@@ -2315,9 +2304,15 @@ object YouTube {
                         }
 
                         content.musicCarouselShelfRenderer != null -> {
-                            content.musicCarouselShelfRenderer.contents
-                                .mapNotNull(MusicCarouselShelfRenderer.Content::musicTwoRowItemRenderer)
-                                .mapNotNull { LibraryPage.fromMusicTwoRowItemRenderer(it) }
+                            content.musicCarouselShelfRenderer.contents.mapNotNull { content ->
+                                content.musicTwoRowItemRenderer?.let { renderer ->
+                                    LibraryPage.fromMusicTwoRowItemRenderer(renderer)
+                                } ?: content.musicMultiRowListItemRenderer?.let { renderer ->
+                                    PodcastPage.fromMusicMultiRowListItemRenderer(renderer)
+                                } ?: content.musicResponsiveListItemRenderer?.let { renderer ->
+                                    LibraryPage.fromMusicResponsiveListItemRenderer(renderer)
+                                }
+                            }
                         }
 
                         else -> {


### PR DESCRIPTION
## Problem
In browse sections (like "Top 50" and other categories), only 3-4 items were displayed instead of the full list.

## Cause
In `YouTube.browse()`, the `MusicCarouselShelfRenderer` parsing only extracted `musicTwoRowItemRenderer` items, ignoring `musicResponsiveListItemRenderer` and `musicMultiRowListItemRenderer`. Items using those renderers were silently dropped.

## Solution
- Added parsing for `musicMultiRowListItemRenderer` (podcast episodes) via `PodcastPage.fromMusicMultiRowListItemRenderer`
- Added parsing for `musicResponsiveListItemRenderer` (songs, artists, etc.) via `LibraryPage.fromMusicResponsiveListItemRenderer` and `RelatedPage.fromMusicResponsiveListItemRenderer`
- This mirrors the same approach already used by `HomePage.Section.fromMusicCarouselShelfRenderer` for the home screen

## Testing
- Built successfully with `./gradlew :app:assembleFossDebug`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved carousel parsing so all supported item formats are consolidated and displayed correctly, preventing missing entries in browse carousels.
  * Podcast channel carousels now recognize additional item formats, ensuring fuller and more accurate listings for podcast channels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MetrolistGroup/Metrolist/pull/3827?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->