### PR TITLE
fix(playback): support playing songs with mp4a codec

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -73,6 +73,7 @@ import androidx.media3.exoplayer.source.ShuffleOrder.DefaultShuffleOrder
 import androidx.media3.extractor.ExtractorsFactory
 import androidx.media3.extractor.mkv.MatroskaExtractor
 import androidx.media3.extractor.mp4.FragmentedMp4Extractor
+import androidx.media3.extractor.mp4.Mp4Extractor
 import androidx.media3.session.CommandButton
 import androidx.media3.session.DefaultMediaNotificationProvider
 import androidx.media3.session.MediaController
@@ -3521,7 +3522,7 @@ class MusicService :
         DefaultMediaSourceFactory(
             createDataSourceFactory(),
             ExtractorsFactory {
-                arrayOf(MatroskaExtractor(), FragmentedMp4Extractor())
+                arrayOf(MatroskaExtractor(), FragmentedMp4Extractor(), Mp4Extractor())
             },
         )
 


### PR DESCRIPTION
## Problem
The app crashes or becomes unresponsive when attempting to play or skip to songs using the `mp4a` codec (e.g. standard MP4 audio streams on YouTube Music).

## Cause
`MusicService` defines a custom `ExtractorsFactory` which only includes `MatroskaExtractor` and `FragmentedMp4Extractor`. When a song stream has standard (non-fragmented) MP4 format with `mp4a` audio, ExoPlayer fails to find a suitable extractor, leading to playback failure and app unresponsiveness.

## Solution
- Added `Mp4Extractor` to the custom `ExtractorsFactory` in [MusicService.kt](file:///var/home/alessio.attilio/git/metrolist/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt) to allow standard MP4/AAC streams to be parsed and played successfully.

## Testing
- Verified that the application compiles successfully with `./gradlew :app:assembleFossDebug`.

## Related Issues
- Closes #3826

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MP4 audio format support to the music playback service, enabling MP4 streams to be properly parsed and played.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MetrolistGroup/Metrolist/pull/3828?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->