### PR TITLE
[replaced] fix(db): resolve timezone mismatch in statistics queries

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
@@ -373,42 +373,34 @@ enum class MyTopFilter {
     YEAR,
     ;
 
-    fun toTimeMillis(): Long =
+    fun toLocalDateTime(): LocalDateTime =
         when (this) {
             DAY -> {
                 LocalDateTime
                     .now()
                     .minusDays(1)
-                    .toInstant(ZoneOffset.UTC)
-                    .toEpochMilli()
             }
 
             WEEK -> {
                 LocalDateTime
                     .now()
                     .minusWeeks(1)
-                    .toInstant(ZoneOffset.UTC)
-                    .toEpochMilli()
             }
 
             MONTH -> {
                 LocalDateTime
                     .now()
                     .minusMonths(1)
-                    .toInstant(ZoneOffset.UTC)
-                    .toEpochMilli()
             }
 
             YEAR -> {
                 LocalDateTime
                     .now()
                     .minusMonths(12)
-                    .toInstant(ZoneOffset.UTC)
-                    .toEpochMilli()
             }
 
             ALL_TIME -> {
-                0
+                LocalDateTime.of(1970, 1, 1, 0, 0)
             }
         }
 }

--- a/app/src/main/kotlin/com/metrolist/music/constants/StatPeriod.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/StatPeriod.kt
@@ -18,59 +18,47 @@ enum class StatPeriod {
     ALL,
     ;
 
-    fun toTimeMillis(): Long =
+    fun toLocalDateTime(): LocalDateTime =
         when (this) {
             WEEK_1 ->
                 LocalDateTime
                     .now()
                     .minusWeeks(1)
-                    .toInstant(ZoneOffset.UTC)
-                    .toEpochMilli()
 
             MONTH_1 ->
                 LocalDateTime
                     .now()
                     .minusMonths(1)
-                    .toInstant(ZoneOffset.UTC)
-                    .toEpochMilli()
 
             MONTH_3 ->
                 LocalDateTime
                     .now()
                     .minusMonths(3)
-                    .toInstant(ZoneOffset.UTC)
-                    .toEpochMilli()
 
             MONTH_6 ->
                 LocalDateTime
                     .now()
                     .minusMonths(6)
-                    .toInstant(ZoneOffset.UTC)
-                    .toEpochMilli()
 
             YEAR_1 ->
                 LocalDateTime
                     .now()
                     .minusMonths(12)
-                    .toInstant(ZoneOffset.UTC)
-                    .toEpochMilli()
 
-            ALL -> 0
+            ALL -> LocalDateTime.of(1970, 1, 1, 0, 0)
         }
 }
 
 fun statToPeriod(
     selection: OptionStats,
     test: Int,
-): Long =
+): LocalDateTime =
     when (selection) {
         OptionStats.WEEKS -> {
             LocalDateTime
                 .now()
                 .minusWeeks(test.toLong())
                 .minusDays(1)
-                .toInstant(ZoneOffset.UTC)
-                .toEpochMilli()
         }
 
         OptionStats.MONTHS -> {
@@ -78,8 +66,6 @@ fun statToPeriod(
                 .now()
                 .withDayOfMonth(1)
                 .minusMonths(test.toLong())
-                .toInstant(ZoneOffset.UTC)
-                .toEpochMilli()
         }
 
         OptionStats.YEARS -> {
@@ -88,13 +74,10 @@ fun statToPeriod(
                 .withDayOfMonth(1)
                 .withMonth(1)
                 .minusYears(test.toLong())
-                .toInstant(
-                    ZoneOffset.UTC,
-                ).toEpochMilli()
         }
 
         OptionStats.CONTINUOUS -> {
             val index = if (test >= StatPeriod.entries.size) 0 else test
-            StatPeriod.entries[index].toTimeMillis()
+            StatPeriod.entries[index].toLocalDateTime()
         }
     }

--- a/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
@@ -225,8 +225,8 @@ interface DatabaseDao {
         artistId: String,
         sortType: ArtistSongSortType,
         descending: Boolean,
-        fromTimeStamp: Long? = null,
-        toTimeStamp: Long? = null,
+        fromTimeStamp: LocalDateTime? = null,
+        toTimeStamp: LocalDateTime? = null,
         limit: Int = -1
     ): Flow<List<Song>> {
         val songsFlow = when (sortType) {
@@ -269,7 +269,7 @@ interface DatabaseDao {
         ORDER BY play_times.totalPlayTime DESC
         """
     )
-    fun mostPlayedSongsByArtist(artistId: String, fromTimeStamp: Long, toTimeStamp: Long): Flow<List<Song>>
+    fun mostPlayedSongsByArtist(artistId: String, fromTimeStamp: LocalDateTime, toTimeStamp: LocalDateTime): Flow<List<Song>>
 
     @Transaction
     @Query(
@@ -369,10 +369,10 @@ interface DatabaseDao {
         """,
     )
     fun mostPlayedSongsStats(
-        fromTimeStamp: Long,
+        fromTimeStamp: LocalDateTime,
         limit: Int = 6,
         offset: Int = 0,
-        toTimeStamp: Long? = LocalDateTime.now().toInstant(ZoneOffset.UTC).toEpochMilli(),
+        toTimeStamp: LocalDateTime? = LocalDateTime.now(),
     ): Flow<List<SongWithStats>>
 
     // Time Transfer
@@ -462,10 +462,10 @@ interface DatabaseDao {
     """,
     )
     fun mostPlayedSongs(
-        fromTimeStamp: Long,
+        fromTimeStamp: LocalDateTime,
         limit: Int = 6,
         offset: Int = 0,
-        toTimeStamp: Long? = LocalDateTime.now().toInstant(ZoneOffset.UTC).toEpochMilli(),
+        toTimeStamp: LocalDateTime? = LocalDateTime.now(),
     ): Flow<List<Song>>
 
     @Transaction
@@ -500,10 +500,10 @@ interface DatabaseDao {
     """,
     )
     fun mostPlayedArtists(
-        fromTimeStamp: Long,
+        fromTimeStamp: LocalDateTime,
         limit: Int = 6,
         offset: Int = 0,
-        toTimeStamp: Long? = LocalDateTime.now().toInstant(ZoneOffset.UTC).toEpochMilli(),
+        toTimeStamp: LocalDateTime? = LocalDateTime.now(),
     ): Flow<List<Artist>>
 
     @Transaction
@@ -541,20 +541,20 @@ interface DatabaseDao {
     """
     )
     fun mostPlayedAlbums(
-        fromTimeStamp: Long,
+        fromTimeStamp: LocalDateTime,
         limit: Int = 6,
         offset: Int = 0,
-        toTimeStamp: Long? = LocalDateTime.now().toInstant(ZoneOffset.UTC).toEpochMilli(),
+        toTimeStamp: LocalDateTime? = LocalDateTime.now(),
     ): Flow<List<Album>>
 
     @Query("SELECT SUM(playTime) FROM event WHERE timestamp >= :fromTimeStamp AND timestamp <= :toTimeStamp")
-    fun getTotalPlayTimeInRange(fromTimeStamp: Long, toTimeStamp: Long): Flow<Long?>
+    fun getTotalPlayTimeInRange(fromTimeStamp: LocalDateTime, toTimeStamp: LocalDateTime): Flow<Long?>
 
     @Query("SELECT SUM(playTime) FROM event WHERE songId = :songId")
     fun getTotalPlayTimeForSong(songId: String): Long?
 
     @Query("SELECT COUNT(DISTINCT songId) FROM event WHERE timestamp >= :fromTimeStamp AND timestamp <= :toTimeStamp")
-    fun getUniqueSongCountInRange(fromTimeStamp: Long, toTimeStamp: Long): Flow<Int>
+    fun getUniqueSongCountInRange(fromTimeStamp: LocalDateTime, toTimeStamp: LocalDateTime): Flow<Int>
 
     @Query(
         """
@@ -564,7 +564,7 @@ interface DatabaseDao {
         WHERE timestamp >= :fromTimeStamp AND timestamp <= :toTimeStamp
     """
     )
-    fun getUniqueArtistCountInRange(fromTimeStamp: Long, toTimeStamp: Long): Flow<Int>
+    fun getUniqueArtistCountInRange(fromTimeStamp: LocalDateTime, toTimeStamp: LocalDateTime): Flow<Int>
 
     @Query(
         """
@@ -574,7 +574,7 @@ interface DatabaseDao {
         WHERE timestamp >= :fromTimeStamp AND timestamp <= :toTimeStamp
     """
     )
-    fun getUniqueAlbumCountInRange(fromTimeStamp: Long, toTimeStamp: Long): Flow<Int>
+    fun getUniqueAlbumCountInRange(fromTimeStamp: LocalDateTime, toTimeStamp: LocalDateTime): Flow<Int>
 
     @Transaction
     @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -4019,7 +4019,7 @@ class MusicService :
 
             PlaylistWidgetReceiver.TARGET_TYPE_TOP -> {
                 val limit = targetId.toIntOrNull() ?: 50
-                val songs = database.mostPlayedSongs(0L, limit = limit).first()
+                val songs = database.mostPlayedSongs(LocalDateTime.of(1970, 1, 1, 0, 0), limit = limit).first()
                 if (songs.isEmpty()) return null
                 ListQueue(
                     title = getString(R.string.my_top),

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/WrappedManager.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/wrapped/WrappedManager.kt
@@ -56,12 +56,8 @@ class WrappedManager(
         scope.launch {
             try {
                 withContext(Dispatchers.IO) {
-                    val fromTimestamp = Calendar.getInstance().apply {
-                        set(WrappedConstants.YEAR, Calendar.JANUARY, 1, 0, 0, 0)
-                    }.timeInMillis
-                    val toTimestamp = Calendar.getInstance().apply {
-                        set(WrappedConstants.YEAR, Calendar.DECEMBER, 31, 23, 59, 59)
-                    }.timeInMillis
+                    val fromTimestamp = LocalDateTime.of(WrappedConstants.YEAR, 1, 1, 0, 0, 0)
+                    val toTimestamp = LocalDateTime.of(WrappedConstants.YEAR, 12, 31, 23, 59, 59)
                     val allSongs = databaseDao.mostPlayedSongsStats(fromTimestamp, toTimeStamp = toTimestamp, limit = -1).first()
 
                     val playlistId = UUID.randomUUID().toString()
@@ -136,12 +132,8 @@ class WrappedManager(
 
             // Artist Part: Top artist's song with specific rule
             val topArtist = topArtists.firstOrNull()
-            val fromTimestamp = Calendar.getInstance().apply {
-                set(WrappedConstants.YEAR, Calendar.JANUARY, 1, 0, 0, 0)
-            }.timeInMillis
-            val toTimestamp = Calendar.getInstance().apply {
-                set(WrappedConstants.YEAR, Calendar.DECEMBER, 31, 23, 59, 59)
-            }.timeInMillis
+            val fromTimestamp = LocalDateTime.of(WrappedConstants.YEAR, 1, 1, 0, 0, 0)
+            val toTimestamp = LocalDateTime.of(WrappedConstants.YEAR, 12, 31, 23, 59, 59)
 
             val artistSong = topArtist?.let { artist ->
                 val artistTopSongs = databaseDao.artistSongs(
@@ -184,13 +176,8 @@ class WrappedManager(
         if (_state.value.isDataReady) return
         Timber.tag("WrappedManager").d("Starting Wrapped data preparation")
 
-        val fromTimestamp = Calendar.getInstance().apply {
-            set(WrappedConstants.YEAR, Calendar.JANUARY, 1, 0, 0, 0)
-        }.timeInMillis
-
-        val toTimestamp = Calendar.getInstance().apply {
-            set(WrappedConstants.YEAR, Calendar.DECEMBER, 31, 23, 59, 59)
-        }.timeInMillis
+        val fromTimestamp = LocalDateTime.of(WrappedConstants.YEAR, 1, 1, 0, 0, 0)
+        val toTimestamp = LocalDateTime.of(WrappedConstants.YEAR, 12, 31, 23, 59, 59)
 
         withContext(Dispatchers.IO) {
             val accountInfoDeferred = async { YouTube.accountInfo().getOrNull() }

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/HomeViewModel.kt
@@ -61,6 +61,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.time.LocalDate
+import java.time.LocalDateTime
 import javax.inject.Inject
 import kotlin.random.Random
 
@@ -381,7 +382,7 @@ class HomeViewModel @Inject constructor(
     }
 
     private suspend fun getCommunityPlaylists() {
-        val fromTimeStamp = System.currentTimeMillis() - 86400000L * 7 * 4
+        val fromTimeStamp = LocalDateTime.now().minusWeeks(4)
         val artistSeeds = database.mostPlayedArtists(fromTimeStamp, limit = 10).first()
             .filter { it.artist.isYouTubeArtist }
             .shuffled().take(3)
@@ -460,7 +461,7 @@ class HomeViewModel @Inject constructor(
         val hideExplicit = context.dataStore.get(HideExplicitKey, false)
         val hideVideoSongs = context.dataStore.get(HideVideoSongsKey, false)
         val hideYoutubeShorts = context.dataStore.get(HideYoutubeShortsKey, false)
-        val fromTimeStamp = System.currentTimeMillis() - 86400000L * 7 * 2
+        val fromTimeStamp = LocalDateTime.now().minusWeeks(2)
 
         // Phase 1: Load essential sections in parallel — local DB (fast) + YouTube home page.
         // isLoading is set to false as soon as all Phase 1 tasks complete so the UI appears quickly.

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/StatsViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/StatsViewModel.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.launch
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDateTime
+import java.time.ZoneId
 import java.time.ZoneOffset
 import javax.inject.Inject
 import kotlinx.coroutines.sync.Mutex
@@ -77,11 +78,7 @@ constructor(
                         limit = -1,
                         toTimeStamp =
                         if (selection == OptionStats.CONTINUOUS || t == 0) {
-                            LocalDateTime
-                                .now()
-                                .toInstant(
-                                    ZoneOffset.UTC,
-                                ).toEpochMilli()
+                            LocalDateTime.now()
                         } else {
                             statToPeriod(selection, t - 1)
                         },
@@ -103,11 +100,7 @@ constructor(
                         limit = -1,
                         toTimeStamp =
                         if (selection == OptionStats.CONTINUOUS || t == 0) {
-                            LocalDateTime
-                                .now()
-                                .toInstant(
-                                    ZoneOffset.UTC,
-                                ).toEpochMilli()
+                            LocalDateTime.now()
                         } else {
                             statToPeriod(selection, t - 1)
                         },
@@ -128,11 +121,7 @@ constructor(
                         limit = -1,
                         toTimeStamp =
                         if (selection == OptionStats.CONTINUOUS || t == 0) {
-                            LocalDateTime
-                                .now()
-                                .toInstant(
-                                    ZoneOffset.UTC,
-                                ).toEpochMilli()
+                            LocalDateTime.now()
                         } else {
                             statToPeriod(selection, t - 1)
                         },
@@ -152,11 +141,7 @@ constructor(
                     limit = -1,
                     toTimeStamp =
                     if (selection == OptionStats.CONTINUOUS || t == 0) {
-                        LocalDateTime
-                            .now()
-                            .toInstant(
-                                ZoneOffset.UTC,
-                            ).toEpochMilli()
+                        LocalDateTime.now()
                     } else {
                         statToPeriod(selection, t - 1)
                     },
@@ -257,8 +242,8 @@ constructor(
     fun syncMostPlaylistsIfNeeded(force: Boolean = false) {
         viewModelScope.launch(Dispatchers.IO) {
             periodicMostPlaylistSyncMutex.withLock {
-                val now = LocalDateTime.now(ZoneOffset.UTC)
-                val nowEpochMillis = now.toInstant(ZoneOffset.UTC).toEpochMilli()
+                val now = LocalDateTime.now()
+                val nowEpochMillis = System.currentTimeMillis()
                 val preferences = context.dataStore.data.first()
                 val hideVideoSongs = preferences[HideVideoSongsKey] ?: false
                 val shouldShowMostStatsPlaylists = preferences[ShowMostStatsPlaylistsKey] ?: true
@@ -292,7 +277,7 @@ constructor(
                     syncMostPlaylist(
                         playlistId = PlaylistEntity.WEEKLY_MOST_PLAYLIST_ID,
                         playlistName = context.getString(R.string.weekly_most_playlist_name),
-                        fromTimeStamp = StatPeriod.WEEK_1.toTimeMillis(),
+                        fromTimeStamp = StatPeriod.WEEK_1.toLocalDateTime(),
                         hideVideoSongs = hideVideoSongs,
                         now = now,
                     )
@@ -302,7 +287,7 @@ constructor(
                     syncMostPlaylist(
                         playlistId = PlaylistEntity.MONTHLY_MOST_PLAYLIST_ID,
                         playlistName = context.getString(R.string.monthly_most_playlist_name),
-                        fromTimeStamp = StatPeriod.MONTH_1.toTimeMillis(),
+                        fromTimeStamp = StatPeriod.MONTH_1.toLocalDateTime(),
                         hideVideoSongs = hideVideoSongs,
                         now = now,
                     )
@@ -344,7 +329,7 @@ constructor(
     ): Boolean {
         if (lastSyncMillis == null || lastSyncMillis <= 0L) return true
 
-        val lastSyncAt = LocalDateTime.ofInstant(Instant.ofEpochMilli(lastSyncMillis), ZoneOffset.UTC)
+        val lastSyncAt = LocalDateTime.ofInstant(Instant.ofEpochMilli(lastSyncMillis), ZoneId.systemDefault())
         return !lastSyncAt.plusWeeks(1).isAfter(now)
     }
 
@@ -354,14 +339,14 @@ constructor(
     ): Boolean {
         if (lastSyncMillis == null || lastSyncMillis <= 0L) return true
 
-        val lastSyncAt = LocalDateTime.ofInstant(Instant.ofEpochMilli(lastSyncMillis), ZoneOffset.UTC)
+        val lastSyncAt = LocalDateTime.ofInstant(Instant.ofEpochMilli(lastSyncMillis), ZoneId.systemDefault())
         return !lastSyncAt.plusMonths(1).isAfter(now)
     }
 
     private suspend fun syncMostPlaylist(
         playlistId: String,
         playlistName: String,
-        fromTimeStamp: Long,
+        fromTimeStamp: LocalDateTime,
         hideVideoSongs: Boolean,
         now: LocalDateTime,
     ) {
@@ -370,7 +355,7 @@ constructor(
                 .mostPlayedSongs(
                     fromTimeStamp = fromTimeStamp,
                     limit = -1,
-                    toTimeStamp = now.toInstant(ZoneOffset.UTC).toEpochMilli(),
+                    toTimeStamp = now,
                 ).first()
                 .let { mostPlayedSongs ->
                     if (hideVideoSongs) {

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/TopPlaylistViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/TopPlaylistViewModel.kt
@@ -13,6 +13,7 @@ import com.metrolist.music.constants.HideVideoSongsKey
 import com.metrolist.music.constants.MyTopFilter
 import com.metrolist.music.db.MusicDatabase
 import com.metrolist.music.utils.dataStore
+import java.time.LocalDateTime
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -44,7 +45,7 @@ constructor(
             context.dataStore.data.map { it[HideVideoSongsKey] ?: false }.distinctUntilChanged()
         ) { period, hideVideoSongs -> period to hideVideoSongs }
             .flatMapLatest { (period, hideVideoSongs) ->
-                database.mostPlayedSongs(period.toTimeMillis(), top.toInt()).map { songs ->
+                database.mostPlayedSongs(period.toLocalDateTime(), top.toInt()).map { songs ->
                     if (hideVideoSongs) songs.filter { !it.song.isVideo } else songs
                 }
             }.stateIn(viewModelScope, SharingStarted.Lazily, emptyList())

--- a/app/src/main/kotlin/com/metrolist/music/widget/PlaylistWidgetManager.kt
+++ b/app/src/main/kotlin/com/metrolist/music/widget/PlaylistWidgetManager.kt
@@ -44,6 +44,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.debounce
+import java.time.LocalDateTime
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -213,7 +214,7 @@ class PlaylistWidgetManager @Inject constructor(
                     )
                 }
             },
-            database.mostPlayedSongs(0L, limit = 50).map { songs ->
+            database.mostPlayedSongs(LocalDateTime.of(1970, 1, 1, 0, 0), limit = 50).map { songs ->
                 songs.map { song ->
                     SongSnapshot(
                         id = song.id,
@@ -374,7 +375,7 @@ class PlaylistWidgetManager @Inject constructor(
         val savedPlaylistsDeferred = async { database.playlistsByCreateDateAsc().first() }
         val likedSongsDeferred = async { database.likedSongsByCreateDateAsc().first() }
         val downloadedSongsDeferred = async { database.downloadedSongsByCreateDateAsc().first() }
-        val topSongsDeferred = async { database.mostPlayedSongs(0L, limit = 50).first() }
+        val topSongsDeferred = async { database.mostPlayedSongs(LocalDateTime.of(1970, 1, 1, 0, 0), limit = 50).first() }
 
         val result = mutableListOf<QuickPick>()
         val seen = mutableSetOf<String>()


### PR DESCRIPTION
## Problem

Selecting period filters ( DAY , WEEK , MONTH , YEAR ) in the "My Top" screen displays an empty playlist.

## Cause

Database event insertions record timestamps using LocalDateTime.now() (local time), which Room's TypeConverter converts to epoch milliseconds treating the local time figures as UTC.
However, range queries calculated thresholds via System.currentTimeMillis() or LocalDateTime.now(ZoneOffset.UTC) , introducing a timezone offset shift.
This mismatch caused statistics queries to return empty results.

## Solution

Refactored all statistics and range queries in DatabaseDao to accept LocalDateTime / LocalDateTime? instead of raw Long values. This delegates the conversion logic to Room, which consistently applies the same custom TypeConverter to query parameters as it does to stored columns.

• Updated DatabaseDao.kt query methods and parameters, including artistSongs.
• Replaced toTimeMillis() helpers with toLocalDateTime() in StatPeriod.kt and PreferenceKeys.kt.
• Updated all viewmodels, service layer, widgets, and wrapped manager calls to use LocalDateTime.

## Testing
• Successfully compiled the Foss debug flavor using Gradle:
  ./gradlew :app:assembleFossDebug


## Related Issues

• Related to #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated internal time handling for statistics, playlists, and synchronization features
  * Enhanced time-zone support across the app for improved accuracy in time-range calculations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MetrolistGroup/Metrolist/pull/3829?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->