### PR TITLE
fix(ui): handle recycled bitmap crash in CoilBitmapLoader

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/utils/CoilBitmapLoader.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/CoilBitmapLoader.kt
@@ -35,9 +35,15 @@ class CoilBitmapLoader(
 
     private fun Bitmap.createIndependentCopy(): Bitmap {
         if (isRecycled) return createFallbackBitmap()
-        val copy = copy(Bitmap.Config.ARGB_8888, false)
-        if (copy != null) return copy
-        return createFallbackBitmap()
+        return try {
+            val copy = createBitmap(width, height)
+            val canvas = android.graphics.Canvas(copy)
+            canvas.drawBitmap(this, 0f, 0f, null)
+            copy
+        } catch (e: Exception) {
+            Timber.tag("CoilBitmapLoader").w(e, "Failed to create independent copy")
+            createFallbackBitmap()
+        }
     }
 
     override fun decodeBitmap(data: ByteArray): ListenableFuture<Bitmap> =


### PR DESCRIPTION
## Problem
Avoid crash when `Bitmap.copy()` is called on a recycled bitmap during playback.

## Cause
`Bitmap.copy()` throws an exception if the source bitmap has been recycled, which can happen during image loading in Coil.

## Solution
Replace `Bitmap.copy()` with `createBitmap()` + `Canvas.drawBitmap()`, which handles recycled bitmaps gracefully. Wrapped in a try-catch as a safety net.

## Testing
Built and verified the app compiles successfully.

## Related Issues
- Closes #
- Related to #3760

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of bitmap image handling with enhanced error recovery; the app now uses a fallback mechanism when image processing encounters issues, preventing potential crashes during image loading.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MetrolistGroup/Metrolist/pull/3836?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->