### PR TITLE
fix(search): remove auth from search requests to fix empty results when signed in

### DIFF
--- a/innertube/src/main/kotlin/com/metrolist/innertube/InnerTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/InnerTube.kt
@@ -197,13 +197,13 @@ class InnerTube {
         continuation: String? = null,
     ) = withRetry {
         httpClient.post("search") {
-            ytClient(client, setLogin = useLoginForBrowse)
+            ytClient(client, setLogin = false)
             setBody(
                 SearchBody(
                     context = client.toContext(
                         locale,
                         visitorData,
-                        if (useLoginForBrowse) dataSyncId else null
+                        null
                     ),
                     query = query,
                     params = params


### PR DESCRIPTION
## Problem
When signed in with a Google account, search shows only the top result and similar songs, with no categorized results (Songs, Albums, Artists, etc.). Switching to other filter tabs displays "no results found". The issue is specific to authenticated sessions — logging out makes search work correctly.

Reported in #3781.

## Cause
YouTube's InnerTube search API returns a different response structure when the request includes authentication cookies and an `onBehalfOfUser` context. The current parsing code cannot handle this authenticated response format, causing most items to silently return `null` and be dropped. Only the top result (`musicCardShelfRenderer`) and any titled `musicShelfRenderer` (e.g., "Similar songs") survive.

The root cause is that `InnerTube.search()` used `setLogin = useLoginForBrowse` and passed `dataSyncId` as `onBehalfOfUser`, making the search request authenticated. While other endpoints (player, browse) may benefit from auth, the search endpoint returns a format incompatible with the parser when authenticated.

## Solution
Removed authentication from search requests in `InnerTube.kt`: changed `ytClient(client, setLogin = useLoginForBrowse)` to `ytClient(client, setLogin = false)` and always pass `null` for `onBehalfOfUser`. This ensures the search API always returns the parsable unauthenticated response format.

Search is a read-only endpoint that doesn't require auth — the existing `getSearchSuggestions` endpoint already uses `setLogin = false` for the same reason.

## Testing
- Built successfully with `./gradlew :app:assembleFossDebug`
- No compilation errors or warnings

## Related Issues
- Closes #3781


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated search request handling to ensure consistent authentication behavior across all search queries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MetrolistGroup/Metrolist/pull/3844?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->