### PR TITLE
fix(innertube): handle singleColumnBrowseResultsRenderer for system auto-playlists to fix NPE on Liked Music and Sounds from Shorts

### DIFF
--- a/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
@@ -1000,6 +1000,11 @@ object YouTube {
                     if (name != null) return@run Artist(name = name, id = browseId)
                 }
 
+                val fromMusicHeaderStrapline = response.header?.musicHeaderRenderer
+                    ?.straplineTextOne?.runs?.firstOrNull()
+                    ?.let { Artist(name = it.text, id = it.navigationEndpoint?.browseEndpoint?.browseId) }
+                if (fromMusicHeaderStrapline != null) return@run fromMusicHeaderStrapline
+
                 null
             }
 
@@ -1013,14 +1018,13 @@ object YouTube {
                     PlaylistItem(
                         id = playlistId,
                         title =
-                            header
-                                ?.title
-                                ?.runs
-                                ?.firstOrNull()
-                                ?.text!!,
+                            header?.title?.runs?.firstOrNull()?.text
+                                ?: response.header?.musicHeaderRenderer?.title?.runs?.firstOrNull()?.text
+                                ?: "",
                         author = author,
                         songCountText =
-                            header.secondSubtitle
+                            (header?.secondSubtitle
+                                ?: response.header?.musicHeaderRenderer?.secondSubtitle)
                                 ?.runs
                                 ?.findLast {
                                     it.text.any { c -> c.isDigit() } &&
@@ -1029,68 +1033,90 @@ object YouTube {
                                         !it.text.contains("minute", ignoreCase = true)
                                 }?.text,
                         thumbnail =
-                            header.thumbnail
+                            header?.thumbnail
                                 ?.musicThumbnailRenderer
                                 ?.thumbnail
                                 ?.thumbnails
                                 ?.lastOrNull()
-                                ?.url!!,
+                                ?.url
+                                ?: response.header
+                                    ?.musicHeaderRenderer
+                                    ?.thumbnail
+                                    ?.musicThumbnailRenderer
+                                    ?.thumbnails
+                                    ?.lastOrNull()
+                                    ?.url
+                                ?: "",
                         playEndpoint = null,
                         shuffleEndpoint =
-                            header.buttons
-                                .lastOrNull()
-                                ?.menuRenderer
-                                ?.items
-                                ?.firstOrNull()
-                                ?.menuNavigationItemRenderer
-                                ?.navigationEndpoint
-                                ?.watchPlaylistEndpoint!!,
+                            header?.buttons?.lastOrNull()
+                                ?.menuRenderer?.items?.firstOrNull()
+                                ?.menuNavigationItemRenderer?.navigationEndpoint?.watchPlaylistEndpoint
+                                ?: response.header?.musicHeaderRenderer?.buttons?.lastOrNull()
+                                    ?.menuRenderer?.items?.firstOrNull()
+                                    ?.menuNavigationItemRenderer?.navigationEndpoint?.watchPlaylistEndpoint,
                         radioEndpoint =
-                            header.buttons
-                                .getOrNull(2)
-                                ?.menuRenderer
-                                ?.items
-                                ?.find {
+                            header?.buttons?.getOrNull(2)
+                                ?.menuRenderer?.items?.find {
                                     it.menuNavigationItemRenderer?.icon?.iconType == "MIX"
-                                }?.menuNavigationItemRenderer
-                                ?.navigationEndpoint
-                                ?.watchPlaylistEndpoint,
+                                }?.menuNavigationItemRenderer?.navigationEndpoint?.watchPlaylistEndpoint
+                                ?: response.header?.musicHeaderRenderer?.buttons?.getOrNull(2)
+                                    ?.menuRenderer?.items?.find {
+                                        it.menuNavigationItemRenderer?.icon?.iconType == "MIX"
+                                    }?.menuNavigationItemRenderer?.navigationEndpoint?.watchPlaylistEndpoint,
                         isEditable = editable,
                         description = description,
                         authorAvatarUrl = authorAvatarUrl,
                     ),
-                songs =
-                    response.contents
-                        ?.twoColumnBrowseResultsRenderer
-                        ?.secondaryContents
-                        ?.sectionListRenderer
-                        ?.contents
-                        ?.firstOrNull()
-                        ?.musicPlaylistShelfRenderer
-                        ?.contents
-                        ?.getItems()
-                        ?.mapNotNull {
-                            PlaylistPage.fromMusicResponsiveListItemRenderer(it)
-                        } ?: emptyList(),
-                songsContinuation =
-                    response.contents
-                        ?.twoColumnBrowseResultsRenderer
-                        ?.secondaryContents
-                        ?.sectionListRenderer
-                        ?.contents
-                        ?.firstOrNull()
-                        ?.musicPlaylistShelfRenderer
-                        ?.contents
-                        ?.getContinuation()
-                        ?: response.contents
+                songs = run {
+                    val twoColShelf =
+                        response.contents
                             ?.twoColumnBrowseResultsRenderer
                             ?.secondaryContents
                             ?.sectionListRenderer
                             ?.contents
                             ?.firstOrNull()
                             ?.musicPlaylistShelfRenderer
-                            ?.continuations
-                            ?.getContinuation(),
+                    val singleColShelf =
+                        response.contents
+                            ?.singleColumnBrowseResultsRenderer
+                            ?.tabs
+                            ?.firstOrNull()
+                            ?.tabRenderer
+                            ?.content
+                            ?.sectionListRenderer
+                            ?.contents
+                            ?.firstOrNull()
+                            ?.musicPlaylistShelfRenderer
+                    (twoColShelf ?: singleColShelf)
+                        ?.contents
+                        ?.getItems()
+                        ?.mapNotNull { PlaylistPage.fromMusicResponsiveListItemRenderer(it) }
+                        ?: emptyList()
+                },
+                songsContinuation = run {
+                    val twoColShelf =
+                        response.contents
+                            ?.twoColumnBrowseResultsRenderer
+                            ?.secondaryContents
+                            ?.sectionListRenderer
+                            ?.contents
+                            ?.firstOrNull()
+                            ?.musicPlaylistShelfRenderer
+                    val singleColShelf =
+                        response.contents
+                            ?.singleColumnBrowseResultsRenderer
+                            ?.tabs
+                            ?.firstOrNull()
+                            ?.tabRenderer
+                            ?.content
+                            ?.sectionListRenderer
+                            ?.contents
+                            ?.firstOrNull()
+                            ?.musicPlaylistShelfRenderer
+                    val shelf = twoColShelf ?: singleColShelf
+                    shelf?.contents?.getContinuation() ?: shelf?.continuations?.getContinuation()
+                },
                 continuation =
                     response.contents
                         ?.twoColumnBrowseResultsRenderer


### PR DESCRIPTION
## Problem
Opening "Liked Music" or "Sounds from Shorts" (YouTube system auto-playlists) immediately crashes with a NullPointerException, showing `Failed to load playlist` to the user.

## Cause
System auto-playlists use a different InnerTube response structure than regular playlists:
- Regular playlists → `twoColumnBrowseResultsRenderer` + `musicResponsiveHeaderRenderer` in `contents`
- System auto-playlists → `singleColumnBrowseResultsRenderer` in `contents` + `musicHeaderRenderer` in the top-level `header`

The `playlist()` function in `YouTube.kt` only handled the regular path and used non-null assertion operators (`!!`) on `header`, `thumbnail`, `shuffleEndpoint`, and the song shelf — all of which are `null` for system auto-playlists, causing the NPE at line ~894.

## Solution
- Made all accesses to `header` null-safe (replaced `!!` with `?.` and fallback chains)
- Added fallback to `response.header?.musicHeaderRenderer` for `title`, `thumbnail`, `secondSubtitle`, `shuffleEndpoint`, and `radioEndpoint`
- Added a fallback path for `songs` and `songsContinuation` that reads from `singleColumnBrowseResultsRenderer` when `twoColumnBrowseResultsRenderer` yields no shelf

## Testing
- Built successfully with `./gradlew :app:assembleFossDebug` (BUILD SUCCESSFUL, 0 errors)
- Code paths verified against the InnerTube response structures described in the issue logs and `ytmusicapi` behavior

## Related Issues
- Closes #3849

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing for system auto-playlists with better author/channel detection.
  * Added resilient title and song-count handling with sensible fallbacks to avoid missing text.
  * Added fallback support for alternative playlist layouts so songs load from multiple page formats.
  * Fixed null-safety in thumbnail and shuffle/radio endpoint extraction for more reliable playlist rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->