### PR TITLE
chore: add AI agent directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,11 @@ app/src/main/java/com/metrolist/music/listentogether/proto/*
 # FFTW third-party library build artifacts
 .build-fftw
 app/src/main/cpp/coverart/
+
+# Agents dir
+.claude
+.antigravity*
+.gemini
+.opencode
+.cursor*
+.codeium


### PR DESCRIPTION
## Problem
The project lacks a standard ignore configuration for directories generated by various AI agents and tools.

## Cause
Various AI coding tools generate local configuration files or directories (like `.claude`, `.cursor`, `.gemini`, etc.) that can accidentally be committed if not ignored.

## Solution
- Added common AI agent and coding tool directories (e.g. `.claude`, `.cursor`, `.gemini`, `.codeium`, `.opencode`) to `.gitignore` under a new `# Agents dir` section.

## Testing
Verified `.gitignore` syntax and checked that the expected directories are successfully ignored locally.

## Related Issues
- N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated version control ignore rules to exclude additional developer and AI agent/editor-related directories and tool cache/config files so they are no longer tracked.
  * Minor housekeeping to reduce repository noise and prevent accidental commits of local or tool-specific artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->