### PR TITLE
fix(service): resolve UninitializedPropertyAccessException in onGetSession

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -371,8 +371,8 @@ class MusicService :
     private var fadingPlayer: ExoPlayer? = null
     private var isCrossfading = false
     private var crossfadeJob: Job? = null
-
-    private lateinit var mediaSession: MediaLibrarySession
+    private var isRunning = false
+    private var mediaSession: MediaLibrarySession? = null
 
     // Tracks if player has been properly initilized
     private val playerInitialized = MutableStateFlow(false)
@@ -907,7 +907,7 @@ class MusicService :
                 sleepTimer.player = newPlayer
 
                 try {
-                    (mediaSession as MediaSession).player = newPlayer
+                    mediaSession?.let { (it as MediaSession).player = newPlayer }
                 } catch (e: Exception) {
                     Timber.tag(TAG).e(e, "Failed to swap player in MediaSession")
                 }
@@ -1408,7 +1408,7 @@ class MusicService :
     }
 
     private fun updateNotification() {
-        mediaSession.setCustomLayout(
+        mediaSession?.setCustomLayout(
             listOf(
                 CommandButton
                     .Builder()
@@ -3824,7 +3824,7 @@ class MusicService :
         abandonAudioFocus()
         closeAudioEffectSession()
         mediaLibrarySessionCallback.release()
-        mediaSession.release()
+        mediaSession?.release()
         player.removeListener(this)
         player.removeListener(sleepTimer)
         playerSilenceProcessors.remove(player)
@@ -4403,7 +4403,7 @@ class MusicService :
         sleepTimer.player = player
 
         try {
-            (mediaSession as MediaSession).player = player
+            mediaSession?.let { (it as MediaSession).player = player }
         } catch (e: Exception) {
             timber.log.Timber.e(e, "Failed to swap player in MediaSession")
         }


### PR DESCRIPTION
## Problem
Users were experiencing app crashes and playback failures due to an `UninitializedPropertyAccessException` in `MusicService.onGetSession`.

## Cause
`MusicService.onCreate()` could legitimately abort early due to `ensureStartedAsForegroundOrStop()`. When this happens, `mediaSession` (a `lateinit var`) was never initialized. However, the service could still be bound by Media3, causing `onGetSession` to be called and throwing the crash when trying to access the uninitialized property.

## Solution
- Changed `mediaSession` from `lateinit var` to a properly modelled `MediaLibrarySession? = null`.
- Added safe call operators (`?.`) across all usages of `mediaSession`.
- `onGetSession` now safely returns `null` when the service is stopped prematurely, correctly signaling Media3 to reject the controller connection without crashing.

## Testing
- Verified successful compilation (`./gradlew :app:assembleFossDebug`).
- Confirmed correct null-safety semantics according to the Media3 library specifications.

## Related Issues
- Closes #3811


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stability of the music playback service through improved session state management and more robust lifecycle handling. This prevents potential crashes that could occur during player transitions, audio preference changes, notification display updates, and service shutdown operations. Playback reliability is now improved across all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->