### PR TITLE
fix(innertube): fallback playlist song parsing when playlistItemData …

### DIFF
--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/PlaylistPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/PlaylistPage.kt
@@ -29,7 +29,15 @@ data class PlaylistPage(
                 ?.splitBySeparator()
 
             return SongItem(
-                id = renderer.playlistItemData?.videoId ?: return null,
+                id = renderer.playlistItemData?.videoId ?: renderer.navigationEndpoint?.watchEndpoint?.videoId
+                ?: renderer.overlay?.musicItemThumbnailOverlayRenderer
+                    ?.content?.musicPlayButtonRenderer
+                    ?.playNavigationEndpoint?.watchEndpoint?.videoId
+                ?: renderer.flexColumns.firstOrNull()
+                    ?.musicResponsiveListItemFlexColumnRenderer
+                    ?.text?.runs?.firstOrNull()
+                    ?.navigationEndpoint?.watchEndpoint?.videoId
+                ?: return null,
                 title = renderer.flexColumns.firstOrNull()
                     ?.musicResponsiveListItemFlexColumnRenderer?.text
                     ?.runs?.firstOrNull()?.text ?: return null,
@@ -52,7 +60,15 @@ data class PlaylistPage(
                     it.musicInlineBadgeRenderer?.icon?.iconType == "MUSIC_EXPLICIT_BADGE"
                 } != null,
                 endpoint = renderer.overlay?.musicItemThumbnailOverlayRenderer?.content?.musicPlayButtonRenderer?.playNavigationEndpoint?.watchEndpoint,
-                setVideoId = renderer.playlistItemData.playlistSetVideoId ?: return null,
+                setVideoId = renderer.playlistItemData?.playlistSetVideoId ?: renderer.navigationEndpoint?.watchEndpoint?.playlistSetVideoId
+                ?: renderer.overlay?.musicItemThumbnailOverlayRenderer
+                    ?.content?.musicPlayButtonRenderer
+                    ?.playNavigationEndpoint?.watchEndpoint?.playlistSetVideoId
+                ?: renderer.flexColumns.firstOrNull()
+                    ?.musicResponsiveListItemFlexColumnRenderer
+                    ?.text?.runs?.firstOrNull()
+                    ?.navigationEndpoint?.watchEndpoint?.playlistSetVideoId
+                ?: return null,
                 libraryAddToken = libraryTokens.addToken,
                 libraryRemoveToken = libraryTokens.removeToken,
                 isEpisode = renderer.isEpisode


### PR DESCRIPTION
…is missing

YouTube API responses no longer always include playlistItemData on playlist tracks. Add fallback sources for videoId and playlistSetVideoId so playlist pages can still load their song list.

## Problem
<!-- Describe the issue or limitation this PR addresses  
DO NOT PR NEW FEATURES, WE'RE ON A FEATURE FREEZE!!! -->

## Cause
<!-- Explain the root cause of the problem -->

## Solution
<!-- List the changes made to fix the issue -->
- 

## Testing
<!-- Describe how the changes were tested -->

## Related Issues
<!-- List any related issues or PRs -->
- Closes #
- Related to #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced playlist functionality with improved data recovery logic, ensuring songs are properly identified and displayed even when certain data sources are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->