### PR TITLE
fix(playback): restore correct domain for history sync

### DIFF
--- a/innertube/src/main/kotlin/com/metrolist/innertube/InnerTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/InnerTube.kt
@@ -261,6 +261,7 @@ class InnerTube {
             ytClient(client, true)
             parameter("c", client.clientName)
             parameter("cpn", cpn)
+            parameter("ver", "2")
 
             if (playlistId != null) {
                 parameter("list", playlistId)

--- a/innertube/src/main/kotlin/com/metrolist/innertube/InnerTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/InnerTube.kt
@@ -38,6 +38,10 @@ import kotlin.io.encoding.ExperimentalEncodingApi
 class InnerTube {
     private var httpClient = createClient()
 
+    private companion object {
+        const val PLAYBACK_TELEMETRY_VER = "2"
+    }
+
     var locale = YouTubeLocale(
         gl = Locale.getDefault().country,
         hl = Locale.getDefault().toLanguageTag()
@@ -261,7 +265,7 @@ class InnerTube {
             ytClient(client, true)
             parameter("c", client.clientName)
             parameter("cpn", cpn)
-            parameter("ver", "2")
+            parameter("ver", PLAYBACK_TELEMETRY_VER)
 
             if (playlistId != null) {
                 parameter("list", playlistId)

--- a/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
@@ -2806,14 +2806,8 @@ object YouTube {
                     ]
                 }.joinToString("")
 
-        val playbackUrl =
-            playbackTracking.replace(
-                "https://s.youtube.com",
-                "https://music.youtube.com",
-            )
-
         innerTube.registerPlayback(
-            url = playbackUrl,
+            url = playbackTracking,
             playlistId = playlistId,
             cpn = cpn,
         )


### PR DESCRIPTION
## Problem
Played songs appear in local history but do not in remote history because the history tracking endpoint is rewritten to `music.youtube.com`, which silently drops playback stats.

## Cause
A recently introduced workaround arbitrarily replaced `s.youtube.com` with `music.youtube.com` in the playback tracking URL payload coming from the YouTube Player API response. This breaks the API expected behavior since playback stats rely on the `s.youtube.com` domain.

## Solution
- Removed the domain substitution in `registerPlayback`, falling back to the original `playbackTracking` URL that's fully capable of recording stats to YouTube's history.

## Testing
Tested history sync locally and verified it works.

## Related Issues
- Related to #3756, #3848


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback tracking reliability by sending the original playback tracking URL unchanged.
  * Included a telemetry version parameter in playback tracking requests to ensure consistent tracking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->