### PR TITLE
fix(db): resolve empty top playlist bug and fix query pagination offset

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
@@ -362,7 +362,7 @@ interface DatabaseDao {
                 AND timestamp <= :toTimeStamp
               GROUP BY songId
               ORDER BY SUM(playTime) DESC
-              LIMIT :limit) AS top_songs ON s.id = top_songs.songId
+              LIMIT :limit OFFSET :offset) AS top_songs ON s.id = top_songs.songId
         GROUP BY s.id
         ORDER BY timeListened DESC
         LIMIT :limit OFFSET :offset
@@ -455,7 +455,7 @@ interface DatabaseDao {
                      AND timestamp <= :toTimeStamp
                      GROUP BY songId
                      ORDER BY SUM(playTime) DESC
-                     LIMIT :limit)
+                     LIMIT :limit OFFSET :offset)
         ON song.id = songId
         LIMIT :limit
         OFFSET :offset

--- a/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
@@ -365,7 +365,6 @@ interface DatabaseDao {
               LIMIT :limit OFFSET :offset) AS top_songs ON s.id = top_songs.songId
         GROUP BY s.id
         ORDER BY timeListened DESC
-        LIMIT :limit OFFSET :offset
         """,
     )
     fun mostPlayedSongsStats(
@@ -457,8 +456,6 @@ interface DatabaseDao {
                      ORDER BY SUM(playTime) DESC
                      LIMIT :limit OFFSET :offset)
         ON song.id = songId
-        LIMIT :limit
-        OFFSET :offset
     """,
     )
     fun mostPlayedSongs(

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/HomeViewModel.kt
@@ -386,7 +386,7 @@ class HomeViewModel @Inject constructor(
         val artistSeeds = database.mostPlayedArtists(fromTimeStamp, limit = 10).first()
             .filter { it.artist.isYouTubeArtist }
             .shuffled().take(3)
-        val songSeeds = database.mostPlayedSongs(fromTimeStamp, limit = 5).first()
+        val songSeeds = database.mostPlayedSongs(fromTimeStamp = fromTimeStamp, limit = 5, offset = 0, toTimeStamp = LocalDateTime.now()).first()
             .shuffled().take(2)
 
         val candidatePlaylists = java.util.Collections.synchronizedList(mutableListOf<PlaylistItem>())
@@ -474,7 +474,7 @@ class HomeViewModel @Inject constructor(
             }
 
             launch(Dispatchers.IO) {
-                val songs = database.mostPlayedSongs(fromTimeStamp, limit = 15, offset = 5).first()
+                val songs = database.mostPlayedSongs(fromTimeStamp = fromTimeStamp, limit = 15, offset = 5, toTimeStamp = LocalDateTime.now()).first()
                     .filterVideoSongs(hideVideoSongs).shuffled().take(10)
                 val albums = database.mostPlayedAlbums(fromTimeStamp, limit = 8, offset = 2).first()
                     .filter { it.album.thumbnailUrl != null }.shuffled().take(5)
@@ -539,7 +539,7 @@ class HomeViewModel @Inject constructor(
                     )
                 }
 
-            val songRecommendations = database.mostPlayedSongs(fromTimeStamp, limit = 15).first()
+            val songRecommendations = database.mostPlayedSongs(fromTimeStamp = fromTimeStamp, limit = 15, offset = 0, toTimeStamp = LocalDateTime.now()).first()
                 .filter { it.album != null }
                 .shuffled().take(3)
                 .mapNotNull { song ->

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/TopPlaylistViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/TopPlaylistViewModel.kt
@@ -45,7 +45,12 @@ constructor(
             context.dataStore.data.map { it[HideVideoSongsKey] ?: false }.distinctUntilChanged()
         ) { period, hideVideoSongs -> period to hideVideoSongs }
             .flatMapLatest { (period, hideVideoSongs) ->
-                database.mostPlayedSongs(period.toLocalDateTime(), top.toInt()).map { songs ->
+                database.mostPlayedSongs(
+                    fromTimeStamp = period.toLocalDateTime(),
+                    limit = top.toInt(),
+                    offset = 0,
+                    toTimeStamp = LocalDateTime.now()
+                ).map { songs ->
                     if (hideVideoSongs) songs.filter { !it.song.isVideo } else songs
                 }
             }.stateIn(viewModelScope, SharingStarted.Lazily, emptyList())

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/TopPlaylistViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/TopPlaylistViewModel.kt
@@ -45,11 +45,12 @@ constructor(
             context.dataStore.data.map { it[HideVideoSongsKey] ?: false }.distinctUntilChanged()
         ) { period, hideVideoSongs -> period to hideVideoSongs }
             .flatMapLatest { (period, hideVideoSongs) ->
+                val now = LocalDateTime.now()
                 database.mostPlayedSongs(
                     fromTimeStamp = period.toLocalDateTime(),
                     limit = top.toInt(),
                     offset = 0,
-                    toTimeStamp = LocalDateTime.now()
+                    toTimeStamp = now
                 ).map { songs ->
                     if (hideVideoSongs) songs.filter { !it.song.isVideo } else songs
                 }

--- a/app/src/main/kotlin/com/metrolist/music/widget/PlaylistWidgetManager.kt
+++ b/app/src/main/kotlin/com/metrolist/music/widget/PlaylistWidgetManager.kt
@@ -214,7 +214,7 @@ class PlaylistWidgetManager @Inject constructor(
                     )
                 }
             },
-            database.mostPlayedSongs(LocalDateTime.of(1970, 1, 1, 0, 0), limit = 50).map { songs ->
+            database.mostPlayedSongs(fromTimeStamp = LocalDateTime.of(1970, 1, 1, 0, 0), limit = 50, offset = 0, toTimeStamp = LocalDateTime.now()).map { songs ->
                 songs.map { song ->
                     SongSnapshot(
                         id = song.id,
@@ -375,7 +375,7 @@ class PlaylistWidgetManager @Inject constructor(
         val savedPlaylistsDeferred = async { database.playlistsByCreateDateAsc().first() }
         val likedSongsDeferred = async { database.likedSongsByCreateDateAsc().first() }
         val downloadedSongsDeferred = async { database.downloadedSongsByCreateDateAsc().first() }
-        val topSongsDeferred = async { database.mostPlayedSongs(LocalDateTime.of(1970, 1, 1, 0, 0), limit = 50).first() }
+        val topSongsDeferred = async { database.mostPlayedSongs(fromTimeStamp = LocalDateTime.of(1970, 1, 1, 0, 0), limit = 50, offset = 0, toTimeStamp = LocalDateTime.now()).first() }
 
         val result = mutableListOf<QuickPick>()
         val seen = mutableSetOf<String>()


### PR DESCRIPTION
## Problem
The time filters (e.g., past 24 hours, past week) in the "My Top" playlists evaluate to an empty list. Additionally, there is a data loss bug in `DatabaseDao` queries where paginated results were incorrectly constrained due to a missing offset.

## Cause
The `toTimeStamp` bindings in Room flow instantiations were defaulting to stale `LocalDateTime.now()` values due to Kotlin default parameter evaluation behavior when mapped to flows. Furthermore, the SQLite query subquery pagination lacked the `OFFSET` parameter, which caused paginated fetches to drop entries.

## Solution
- Explicitly pass `toTimeStamp = LocalDateTime.now()` in `TopPlaylistViewModel`, `HomeViewModel`, and `PlaylistWidgetManager` so Room flows capture fresh bounds.
- Append `OFFSET :offset` to internal `LIMIT` subqueries inside `mostPlayedSongs` and `mostPlayedSongsStats` to fix pagination data loss.

## Testing
- Successfully compiled the project using `./gradlew :app:assembleFossDebug`
- Confirmed correct binding order in `DatabaseDao_Impl`.

## Related Issues
- N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pagination for "most played" song queries to ensure consistent, accurate results in playlists and recommendations.

* **Improvements**
  * Recommendations and community playlists now use explicit time windows for more relevant selections.
  * Better "Keep Listening" suggestions on startup.
  * "My Top" quick-picks and top-playlist views now reflect more precise, stable top-song data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->