### PR TITLE
[fixed] fix(crossfade): prevent ArithmeticException when crossfading

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -662,7 +662,15 @@ class MusicService :
         // Keep a connected controller so that notification works
         val sessionToken = SessionToken(this, ComponentName(this, MusicService::class.java))
         controllerFuture = MediaController.Builder(this, sessionToken).buildAsync()
-        controllerFuture?.addListener({ controllerFuture?.get() }, MoreExecutors.directExecutor())
+        controllerFuture?.addListener({
+            try {
+                controllerFuture?.get()
+            } catch (e: Exception) {
+                Timber.tag(TAG).e(e, "Failed to initialize MediaController")
+                controllerFuture = null
+                stopSelf()
+            }
+        }, MoreExecutors.directExecutor())
 
         connectivityManager = getSystemService()!!
         connectivityObserver = NetworkConnectivityObserver(this)

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -396,7 +396,7 @@ class MusicService :
 
     private var isAudioEffectSessionOpened = false
     private var openedAudioEffectSessionId: Int = C.AUDIO_SESSION_ID_UNSET
-    private val volumeNormalizationProcessor = VolumeNormalizationAudioProcessor()
+    private val playerVolumeProcessors = HashMap<androidx.media3.common.Player, VolumeNormalizationAudioProcessor>()
 
     private var loudnessSetupJob: Job? = null
     private var loudnessSetupGeneration: Long = 0L
@@ -922,6 +922,8 @@ class MusicService :
                 player.removeListener(this)
                 player.removeListener(sleepTimer)
                 playerSilenceProcessors.remove(player)
+        playerVolumeProcessors.remove(player)
+                playerVolumeProcessors.remove(player)
                 player.release()
 
                 val newPlayer = createExoPlayer()
@@ -1244,6 +1246,10 @@ class MusicService :
 
         val silenceProcessor = SilenceDetectorAudioProcessor { handleLongSilenceDetected() }
 
+        val volumeProcessor = VolumeNormalizationAudioProcessor()
+        volumeProcessor.enabled = cachedNormalizationEnabled
+        cachedNormalizationGainMb?.let { volumeProcessor.setTargetGain(it) }
+
         // Set initial state
         val useAudioTrackPlaybackParams = runBlocking {
             val skipSilence = dataStore.get(SkipSilenceKey, false)
@@ -1256,7 +1262,7 @@ class MusicService :
             ExoPlayer
                 .Builder(this)
                 .setMediaSourceFactory(createMediaSourceFactory())
-                .setRenderersFactory(createRenderersFactory(eqProcessor, silenceProcessor, useAudioTrackPlaybackParams))
+                .setRenderersFactory(createRenderersFactory(volumeProcessor, eqProcessor, silenceProcessor, useAudioTrackPlaybackParams))
                 .setHandleAudioBecomingNoisy(true)
                 .setWakeMode(C.WAKE_MODE_NETWORK)
                 .setAudioAttributes(
@@ -1272,6 +1278,7 @@ class MusicService :
                 .build()
 
         playerSilenceProcessors[player] = silenceProcessor
+        playerVolumeProcessors[player] = volumeProcessor
 
         player.apply {
             runBlocking {
@@ -2120,14 +2127,14 @@ class MusicService :
         try {
             val gain = cachedNormalizationGainMb
             if (cachedNormalizationEnabled && gain != null) {
-                volumeNormalizationProcessor.setTargetGain(gain)
-                volumeNormalizationProcessor.enabled = true
+                playerVolumeProcessors.values.forEach { it.setTargetGain(gain) }
+                playerVolumeProcessors.values.forEach { it.enabled = true }
             } else {
-                volumeNormalizationProcessor.enabled = false
+                playerVolumeProcessors.values.forEach { it.enabled = false }
             }
         } catch (e: Exception) {
             reportException(e)
-            volumeNormalizationProcessor.enabled = false
+            playerVolumeProcessors.values.forEach { it.enabled = false }
         }
     }
 
@@ -2167,8 +2174,8 @@ class MusicService :
 
                                 cachedNormalizationGainMb = clampedGain
                                 cachedNormalizationEnabled = true
-                                volumeNormalizationProcessor.setTargetGain(clampedGain)
-                                volumeNormalizationProcessor.enabled = true
+                                playerVolumeProcessors.values.forEach { it.setTargetGain(clampedGain) }
+                                playerVolumeProcessors.values.forEach { it.enabled = true }
                             }
                             format == null -> {
                                 Timber.tag(TAG).d("Loudness row not ready yet; keeping cached normalization state")
@@ -2176,7 +2183,7 @@ class MusicService :
                             else -> {
                                 cachedNormalizationGainMb = null
                                 cachedNormalizationEnabled = false
-                                volumeNormalizationProcessor.enabled = false
+                                playerVolumeProcessors.values.forEach { it.enabled = false }
                             }
                         }
                     }
@@ -2185,14 +2192,14 @@ class MusicService :
                         if (!isActive || requestGeneration != loudnessSetupGeneration) return@withContext
                         cachedNormalizationGainMb = null
                         cachedNormalizationEnabled = false
-                        volumeNormalizationProcessor.enabled = false
+                        playerVolumeProcessors.values.forEach { it.enabled = false }
                     }
                 }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
                 reportException(e)
-                volumeNormalizationProcessor.enabled = false
+                playerVolumeProcessors.values.forEach { it.enabled = false }
             }
         }
     }
@@ -3581,6 +3588,7 @@ class MusicService :
         )
 
     private fun createRenderersFactory(
+        volumeProcessor: VolumeNormalizationAudioProcessor,
         eqProcessor: CustomEqualizerAudioProcessor,
         silenceProcessor: SilenceDetectorAudioProcessor,
         useAudioTrackPlaybackParams: Boolean,
@@ -3597,7 +3605,7 @@ class MusicService :
                 DefaultAudioSink.DefaultAudioProcessorChain(
                     // 2. Inject processor into audio pipeline
                     arrayOf(
-                        volumeNormalizationProcessor,
+                        volumeProcessor,
                         eqProcessor,
                         silenceProcessor,
                     ),
@@ -3864,6 +3872,7 @@ class MusicService :
         player.removeListener(this)
         player.removeListener(sleepTimer)
         playerSilenceProcessors.remove(player)
+        playerVolumeProcessors.remove(player)
         // Note: equalizerService audio processors are cleared in equalizerService.release() if needed,
         // or we can't easily reference the specific processor created in createExoPlayer here without storing it.
         // But since we are destroying the service, it's fine.

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -922,7 +922,6 @@ class MusicService :
                 player.removeListener(this)
                 player.removeListener(sleepTimer)
                 playerSilenceProcessors.remove(player)
-        playerVolumeProcessors.remove(player)
                 playerVolumeProcessors.remove(player)
                 player.release()
 

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -380,6 +380,7 @@ class MusicService :
     private var crossfadeJob: Job? = null
     private var isRunning = false
     private var mediaSession: MediaLibrarySession? = null
+    private var controllerFuture: com.google.common.util.concurrent.ListenableFuture<MediaController>? = null
 
     // Tracks if player has been properly initilized
     private val playerInitialized = MutableStateFlow(false)
@@ -660,8 +661,8 @@ class MusicService :
 
         // Keep a connected controller so that notification works
         val sessionToken = SessionToken(this, ComponentName(this, MusicService::class.java))
-        val controllerFuture = MediaController.Builder(this, sessionToken).buildAsync()
-        controllerFuture.addListener({ controllerFuture.get() }, MoreExecutors.directExecutor())
+        controllerFuture = MediaController.Builder(this, sessionToken).buildAsync()
+        controllerFuture?.addListener({ controllerFuture?.get() }, MoreExecutors.directExecutor())
 
         connectivityManager = getSystemService()!!
         connectivityObserver = NetworkConnectivityObserver(this)
@@ -3858,6 +3859,8 @@ class MusicService :
         // Note: equalizerService audio processors are cleared in equalizerService.release() if needed,
         // or we can't easily reference the specific processor created in createExoPlayer here without storing it.
         // But since we are destroying the service, it's fine.
+        controllerFuture?.let { MediaController.releaseFuture(it) }
+        controllerFuture = null
         player.release()
         scope.cancel()
         super.onDestroy()
@@ -3879,11 +3882,15 @@ class MusicService :
                 }
                 player.stop()
                 ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
+                controllerFuture?.let { MediaController.releaseFuture(it) }
+                controllerFuture = null
                 // Media3: coordinates notification/foreground teardown and stopSelf; required when
                 // playback was ongoing (default super.onTaskRemoved keeps the service alive).
                 pauseAllPlayersAndStopSelf()
             }.onFailure { e ->
                 Timber.tag(TAG).e(e, "Failed to stop playback on task clear")
+                controllerFuture?.let { MediaController.releaseFuture(it) }
+                controllerFuture = null
                 runCatching { pauseAllPlayersAndStopSelf() }.onFailure { stopSelf() }
             }
             return


### PR DESCRIPTION
## Problem
Autoplay doesn't work when using crossfade. An unexpected runtime error `Divide by zero Code: UNSPECIFIED (1000)` occurs when the player attempts to crossfade into the next song.

## Cause
The `VolumeNormalizationAudioProcessor` was instantiated as a single class-level field in `MusicService` and shared across multiple `ExoPlayer` instances (the primary fading player and the secondary crossfading player). When the fading player was cleaned up and its processor chain was reset, `bytesPerSample` was set to 0. Concurrently, the new crossfading player attempted to use the same processor, resulting in a divide-by-zero exception during the calculation `inputSize / bytesPerSample`.

## Solution
- Replaced the single `volumeNormalizationProcessor` field with a `HashMap<Player, VolumeNormalizationAudioProcessor>` to manage a separate processor instance for each `ExoPlayer`, similar to how `SilenceDetectorAudioProcessor` is handled.
- Updated `MusicService` logic to apply target gain and enable states to all active volume processors.

## Testing
- Built the project locally (`./gradlew :app:assembleFossDebug`).
- Verified that crossfading into a new song works correctly without the divide-by-zero crash.

## Related Issues
- Closes #3883


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Audio normalization now runs per player instance so loudness adjustments are applied and updated independently across players.
  * Playback controller lifecycle handling improved for safer async startup and deterministic cleanup to avoid lingering resources.

* **Bug Fixes**
  * Prevents stuck playback service and reduces crashes by ensuring proper shutdown when controller startup fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->