### PR TITLE
fix(search): preserve encoded query literals

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
@@ -848,11 +848,9 @@ class MainActivity : ComponentActivity() {
                 LaunchedEffect(navBackStackEntry) {
                     if (inSearchScreen) {
                         val searchQuery =
-                            withContext(Dispatchers.IO) {
-                                SearchRoutes.decodeQuery(
-                                    navBackStackEntry?.arguments?.getString("query").orEmpty(),
-                                )
-                            }
+                            SearchRoutes.decodeQuery(
+                                navBackStackEntry?.arguments?.getString("query").orEmpty(),
+                            )
                         onQueryChange(
                             TextFieldValue(
                                 searchQuery,

--- a/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
@@ -189,6 +189,7 @@ import com.metrolist.music.ui.theme.MetrolistTheme
 import com.metrolist.music.ui.theme.extractThemeColor
 import com.metrolist.music.ui.utils.appBarScrollBehavior
 import com.metrolist.music.ui.utils.resetHeightOffset
+import com.metrolist.music.utils.SearchRoutes
 import com.metrolist.music.utils.SyncUtils
 import com.metrolist.music.utils.Updater
 import com.metrolist.music.discord.DiscordSdkHelper
@@ -211,8 +212,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
-import java.net.URLDecoder
-import java.net.URLEncoder
 import java.util.Locale
 import javax.inject.Inject
 
@@ -749,7 +748,7 @@ class MainActivity : ComponentActivity() {
                     remember {
                         { searchQuery ->
                             if (searchQuery.isNotEmpty()) {
-                                navController.navigate("search/${URLEncoder.encode(searchQuery, "UTF-8")}")
+                                navController.navigate(SearchRoutes.resultRoute(searchQuery))
 
                                 if (dataStore[PauseSearchHistoryKey] != true) {
                                     lifecycleScope.launch(Dispatchers.IO) {
@@ -850,12 +849,9 @@ class MainActivity : ComponentActivity() {
                     if (inSearchScreen) {
                         val searchQuery =
                             withContext(Dispatchers.IO) {
-                                val rawQuery = navBackStackEntry?.arguments?.getString("query")!!
-                                try {
-                                    URLDecoder.decode(rawQuery, "UTF-8")
-                                } catch (e: IllegalArgumentException) {
-                                    rawQuery
-                                }
+                                SearchRoutes.decodeQuery(
+                                    navBackStackEntry?.arguments?.getString("query").orEmpty(),
+                                )
                             }
                         onQueryChange(
                             TextFieldValue(
@@ -1110,7 +1106,7 @@ class MainActivity : ComponentActivity() {
                                             val targetEntry =
                                                 try {
                                                     val route = navController.currentBackStackEntry?.destination?.route
-                                                    if (route == "search/{query}" || route == "search_input") {
+                                                    if (route == SearchRoutes.ROUTE || route == "search_input") {
                                                         // For search screens, use search_input entry
                                                         navController.getBackStackEntry("search_input")
                                                     } else {
@@ -1517,7 +1513,7 @@ class MainActivity : ComponentActivity() {
 
             "search" -> {
                 uri.getQueryParameter("q")?.let {
-                    navController.navigate("search/${URLEncoder.encode(it, "UTF-8")}")
+                    navController.navigate(SearchRoutes.resultRoute(it))
                 }
             }
 

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/recognition/RecognitionHistoryScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/recognition/RecognitionHistoryScreen.kt
@@ -60,6 +60,7 @@ import com.metrolist.music.ui.component.DefaultDialog
 import com.metrolist.music.ui.component.IconButton
 import com.metrolist.music.ui.component.LocalMenuState
 import com.metrolist.music.ui.utils.backToMain
+import com.metrolist.music.utils.SearchRoutes
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.time.format.DateTimeFormatter
@@ -218,7 +219,7 @@ fun RecognitionHistoryScreen(navController: NavController) {
                         onClick = {
                             // Search for the track on YouTube Music
                             val searchQuery = "${item.title} ${item.artist}"
-                            navController.navigate("search/${java.net.URLEncoder.encode(searchQuery, "UTF-8")}")
+                            navController.navigate(SearchRoutes.resultRoute(searchQuery))
                         },
                         onDelete = {
                             itemToDelete = item

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/recognition/RecognitionScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/recognition/RecognitionScreen.kt
@@ -85,6 +85,7 @@ import com.metrolist.music.R
 import com.metrolist.music.db.entities.RecognitionHistory
 import com.metrolist.music.ui.component.IconButton
 import com.metrolist.music.ui.utils.backToMain
+import com.metrolist.music.utils.SearchRoutes
 import com.metrolist.shazamkit.models.RecognitionResult
 import com.metrolist.shazamkit.models.RecognitionStatus
 import kotlinx.coroutines.Dispatchers
@@ -263,7 +264,7 @@ fun RecognitionScreen(
                             onPlayOnApp = { result ->
                                 // Search for the track on YouTube Music
                                 val searchQuery = "${result.title} ${result.artist}"
-                                navController.navigate("search/${java.net.URLEncoder.encode(searchQuery, "UTF-8")}")
+                                navController.navigate(SearchRoutes.resultRoute(searchQuery))
                             },
                             onTryAgain = {
                                 startRecognition()

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/search/OnlineSearchResult.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/search/OnlineSearchResult.kt
@@ -108,12 +108,11 @@ import com.metrolist.music.ui.menu.YouTubeAlbumMenu
 import com.metrolist.music.ui.menu.YouTubeArtistMenu
 import com.metrolist.music.ui.menu.YouTubePlaylistMenu
 import com.metrolist.music.ui.menu.YouTubeSongMenu
+import com.metrolist.music.utils.SearchRoutes
 import com.metrolist.music.utils.rememberPreference
 import com.metrolist.music.viewmodels.OnlineSearchViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import java.net.URLDecoder
-import java.net.URLEncoder
 
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
@@ -168,14 +167,7 @@ fun OnlineSearchResult(
 
     // Extract query from navigation arguments
     val encodedQuery = navController.currentBackStackEntry?.arguments?.getString("query") ?: ""
-    val decodedQuery =
-        remember(encodedQuery) {
-            try {
-                URLDecoder.decode(encodedQuery, "UTF-8")
-            } catch (e: Exception) {
-                encodedQuery
-            }
-        }
+    val decodedQuery = remember(encodedQuery) { SearchRoutes.decodeQuery(encodedQuery) }
 
     var query by rememberSaveable(stateSaver = TextFieldValue.Saver) {
         mutableStateOf(TextFieldValue(decodedQuery, TextRange(decodedQuery.length)))
@@ -188,8 +180,8 @@ fun OnlineSearchResult(
                     isSearchFocused = false
                     focusManager.clearFocus()
 
-                    navController.navigate("search/${URLEncoder.encode(searchQuery, "UTF-8")}") {
-                        popUpTo("search/${URLEncoder.encode(decodedQuery, "UTF-8")}") {
+                    navController.navigate(SearchRoutes.resultRoute(searchQuery)) {
+                        popUpTo(SearchRoutes.ROUTE) {
                             inclusive = true
                         }
 

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/search/SearchScreen.kt
@@ -65,11 +65,11 @@ import com.metrolist.music.constants.SearchSourceKey
 import com.metrolist.music.db.entities.SearchHistory
 import com.metrolist.music.playback.queues.YouTubeQueue
 import com.metrolist.music.ui.component.HideOnScrollFAB
+import com.metrolist.music.utils.SearchRoutes
 import com.metrolist.music.utils.rememberEnumPreference
 import com.metrolist.music.utils.rememberPreference
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import java.net.URLEncoder
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -159,7 +159,7 @@ fun SearchScreen(
             }
 
             null -> {
-                navController.navigate("search/${URLEncoder.encode(searchQuery, "UTF-8")}")
+                navController.navigate(SearchRoutes.resultRoute(searchQuery))
             }
         }
 

--- a/app/src/main/kotlin/com/metrolist/music/utils/SearchRoutes.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/SearchRoutes.kt
@@ -10,11 +10,16 @@ import android.net.Uri
 object SearchRoutes {
     const val ROUTE = "search/{query}"
 
+    // Prefix query payloads so a literal "null" search is not confused with
+    // an absent or undefined Navigation argument.
     private const val QUERY_ROUTE_PREFIX = "__metrolist_search_query__"
 
+    // Encode the prefixed query as a route path segment before navigating.
     fun resultRoute(query: String): String =
         "search/${Uri.encode(QUERY_ROUTE_PREFIX + query)}"
 
+    // Navigation already decodes path segments once, so only strip the prefix.
+    // Decoding again would turn literal input like "%2F" into "/".
     fun decodeQuery(rawQuery: String): String =
         rawQuery.removePrefix(QUERY_ROUTE_PREFIX)
 }

--- a/app/src/main/kotlin/com/metrolist/music/utils/SearchRoutes.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/SearchRoutes.kt
@@ -16,5 +16,5 @@ object SearchRoutes {
         "search/${Uri.encode(QUERY_ROUTE_PREFIX + query)}"
 
     fun decodeQuery(rawQuery: String): String =
-        Uri.decode(rawQuery).removePrefix(QUERY_ROUTE_PREFIX)
+        rawQuery.removePrefix(QUERY_ROUTE_PREFIX)
 }

--- a/app/src/main/kotlin/com/metrolist/music/utils/SearchRoutes.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/SearchRoutes.kt
@@ -1,0 +1,20 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.utils
+
+import android.net.Uri
+
+object SearchRoutes {
+    const val ROUTE = "search/{query}"
+
+    private const val QUERY_ROUTE_PREFIX = "__metrolist_search_query__"
+
+    fun resultRoute(query: String): String =
+        "search/${Uri.encode(QUERY_ROUTE_PREFIX + query)}"
+
+    fun decodeQuery(rawQuery: String): String =
+        Uri.decode(rawQuery).removePrefix(QUERY_ROUTE_PREFIX)
+}

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/OnlineSearchViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/OnlineSearchViewModel.kt
@@ -22,6 +22,7 @@ import com.metrolist.music.constants.HideExplicitKey
 import com.metrolist.music.constants.HideVideoSongsKey
 import com.metrolist.music.constants.HideYoutubeShortsKey
 import com.metrolist.music.models.ItemsPage
+import com.metrolist.music.utils.SearchRoutes
 import com.metrolist.music.utils.dataStore
 import com.metrolist.music.utils.get
 import com.metrolist.music.utils.reportException
@@ -29,7 +30,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
-import java.net.URLDecoder
 import javax.inject.Inject
 
 @HiltViewModel
@@ -39,11 +39,7 @@ constructor(
     @ApplicationContext val context: Context,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
-    val query = try {
-        URLDecoder.decode(savedStateHandle.get<String>("query")!!, "UTF-8")
-    } catch (e: IllegalArgumentException) {
-        savedStateHandle.get<String>("query")!!
-    }
+    val query = SearchRoutes.decodeQuery(savedStateHandle.get<String>("query").orEmpty())
     val filter = MutableStateFlow<YouTube.SearchFilter?>(null)
     var summaryPage by mutableStateOf<SearchSummaryPage?>(null)
     val viewStateMap = mutableStateMapOf<String, ItemsPage?>()


### PR DESCRIPTION
## Summary

Fix search query handling so literal encoded input is preserved when navigating to search result routes.

This centralizes search route construction and decoding through `SearchRoutes`, uses URI path encoding for route arguments, and avoids double-decoding route arguments after Navigation has already decoded them.

This fixes cases where:

* `1+1%2B` was shown as `1 1+`
* `%2F` was shown as `/`
* `null` could crash search navigation because the route argument was treated as the wrong type

Fixes #3847

## Changes

* Add `SearchRoutes` helper for search result routes.
* Replace scattered `URLEncoder` / `URLDecoder` usage with `SearchRoutes`.
* Prefix search query route payloads so literal `null` is preserved safely.
* Avoid double-decoding route arguments.
* Use the shared search route constant instead of hardcoded `search/{query}`.
* Avoid unsafe `!!` when reading the search query argument.

## Validation

Tested search input preservation with:

* `null`
* `NULL`
* `1+1%2B`
* `%2F`
* `a/b`
* `a?b=c`
* `a+b`
* `a%2Bb`
* `100%`
* `100%25`
* `hello world`
* Thai text
* YouTube video / playlist URLs
* empty input
* whitespace-only input

Confirmed that empty and whitespace-only input keep the existing behavior and do not start a search.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified search routing for more consistent navigation across the app.
  * More reliable handling of search queries, improving search result navigation and history taps.
  * Improved deep-link and back-stack behavior for search, reducing edge-case navigation issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->