### PR TITLE
fix(recognition): use non-deprecated flush() to solve "failed to resample audio" issue

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/recognition/AudioResampler.kt
+++ b/app/src/main/kotlin/com/metrolist/music/recognition/AudioResampler.kt
@@ -66,7 +66,7 @@ object AudioResampler {
                 decodedAudio.pcmEncoding
             )
             val outputFormat = sonic.configure(inputFormat)
-            sonic.flush()
+            sonic.flush(AudioProcessor.StreamMetadata.DEFAULT)
 
             val inputBuf = ByteBuffer.wrap(decodedAudio.data).order(ByteOrder.nativeOrder())
             sonic.queueInput(inputBuf)


### PR DESCRIPTION
## Problem
<!-- Describe the issue or limitation this PR addresses  DO NOT PR NEW FEATURES, WE'RE ON A FEATURE FREEZE!!! -->
Music recognition fails with the error "Failed to resample audio: AudioProcessor must implement at least one #flush() overload."

## Cause
<!-- Explain the root cause of the problem -->
`AudioResampler` calls the deprecated no-argument `AudioProcessor.flush()` on a `SonicAudioProcessor`. In Media3 1.10.x the `AudioProcessor` interface changed: the no-arg `flush()` is now a deprecated default method that throws `IllegalStateException`, and implementations are expected to use the new `flush(StreamMetadata)` overload instead.

The recognition feature was originally written against Media3 1.7.1 (where the old `flush()` worked). When the project bumped Media3 to 1.10.x, `AudioResampler` was not updated to the new API, so the call now hits the throwing default.

## Solution
<!-- List the changes made to fix the issue -->
- Replace the deprecated `sonic.flush()` call with `sonic.flush(AudioProcessor.StreamMetadata.DEFAULT)`, the non-deprecated overload that correctly invokes `SonicAudioProcessor`'s implementation.

## Testing
<!-- Describe how the changes were tested -->
- Built with `./gradlew :app:assembleFossDebug` (clean build).
- Verified on a physical device: music recognition now records, resamples, and returns a match successfully where it previously failed with the resample error.

## Related Issues
<!-- List any related issues or PRs -->
- Closes https://github.com/MetrolistGroup/Metrolist/issues/3834 , https://github.com/MetrolistGroup/Metrolist/issues/3766


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio stream handling during music recognition to ensure proper metadata processing at stream completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->