### PR TITLE
fix(ui): correct FAB position in search screen

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/search/SearchScreen.kt
@@ -279,40 +279,31 @@ fun SearchScreen(
         },
         containerColor = if (pureBlack) Color.Black else MaterialTheme.colorScheme.background,
     ) { paddingValues ->
-        val bottomPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues().calculateBottomPadding()
-
         Box(
             modifier =
                 Modifier
-                    .padding(paddingValues)
+                    .padding(top = paddingValues.calculateTopPadding())
                     .fillMaxSize(),
         ) {
-            Box(
-                modifier =
-                    Modifier
-                        .padding(bottom = bottomPadding)
-                        .fillMaxSize(),
-            ) {
-                when (searchSource) {
-                    SearchSource.LOCAL -> {
-                        LocalSearchScreen(
-                            query = query.text,
-                            navController = navController,
-                            onDismiss = { navController.navigateUp() },
-                            pureBlack = pureBlack,
-                        )
-                    }
+            when (searchSource) {
+                SearchSource.LOCAL -> {
+                    LocalSearchScreen(
+                        query = query.text,
+                        navController = navController,
+                        onDismiss = { navController.navigateUp() },
+                        pureBlack = pureBlack,
+                    )
+                }
 
-                    SearchSource.ONLINE -> {
-                        OnlineSearchScreen(
-                            query = query.text,
-                            onQueryChange = { query = it },
-                            navController = navController,
-                            onSearch = onSearchFromSuggestion,
-                            onDismiss = { /* Don't dismiss when searching from suggestions */ },
-                            pureBlack = pureBlack,
-                        )
-                    }
+                SearchSource.ONLINE -> {
+                    OnlineSearchScreen(
+                        query = query.text,
+                        onQueryChange = { query = it },
+                        navController = navController,
+                        onSearch = onSearchFromSuggestion,
+                        onDismiss = { /* Don't dismiss when searching from suggestions */ },
+                        pureBlack = pureBlack,
+                    )
                 }
             }
 


### PR DESCRIPTION
## Problem
<!-- Describe the issue or limitation this PR addresses  DO NOT PR NEW FEATURES, WE'RE ON A FEATURE FREEZE!!! -->
On the search screen, the music-recognition FAB sits higher than on every other screen (Home, History, Library). The offset is more noticeable on some devices (e.g. Pixel 9a) than others.

<img width="178" height="400" alt="Media (1)" src="https://github.com/user-attachments/assets/3f97d080-7c94-47a9-b747-496c7dac9ff1" /> 
<img width="178" height="400" alt="Media" src="https://github.com/user-attachments/assets/0d9c948a-b82a-469c-8827-42cf6791e0f4" />


## Cause
<!-- Explain the root cause of the problem -->
The search screen is the only screen that hosts the FAB inside a `Scaffold`. Its content `Box` applied the full `paddingValues` from the Scaffold (which includes the bottom system-bar inset) and wrapped the content in an extra inner `Box` with `padding(bottom = bottomPadding)`. The `HideOnScrollFAB` already accounts for the bottom inset internally via `LocalPlayerAwareWindowInsets`, so the Scaffold's bottom padding was applied twice, pushing the FAB up. Other screens don't use a `Scaffold`, so they never hit this double-padding.

## Solution
<!-- List the changes made to fix the issue -->
- Apply only the top padding from the Scaffold's `paddingValues` (needed for the search bar app bar), letting `HideOnScrollFAB` handle the bottom inset itself, consistent with the other screens.
- Remove the redundant inner `Box` and its `bottomPadding`, so the search content and the FAB are direct siblings in a single `Box`.

## Testing
<!-- Describe how the changes were tested -->
- Built with `./gradlew :app:assembleFossDebug`.
- Verified on physical devices that the FAB now sits at the same height as on Home/History/Library, with 3-button navigation.

## Related Issues
<!-- List any related issues or PRs -->
MInor cosmetic bug, no issue reported.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified the search screen's layout and padding structure for cleaner rendering and maintainability; no changes to visible behavior.
  * Preserved existing dismiss behaviors: online search remains suppressed during suggestion searches, and local search still navigates back as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->