### PR TITLE
feat(recognition): simplify recognition result screen

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/recognition/RecognitionForegroundService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/recognition/RecognitionForegroundService.kt
@@ -264,7 +264,7 @@ class RecognitionForegroundService : Service() {
             contentIntent = pendingIntent,
             largeIcon = null,
             actionIntent = pendingIntent,
-            actionTitle = getString(R.string.listen_on_metrolist),
+            actionTitle = getString(R.string.recognition_open),
         )
 
         serviceScope.launch {
@@ -286,7 +286,7 @@ class RecognitionForegroundService : Service() {
                     contentIntent = pendingIntent,
                     largeIcon = coverBitmap,
                     actionIntent = pendingIntent,
-                    actionTitle = getString(R.string.listen_on_metrolist),
+                    actionTitle = getString(R.string.recognition_open),
                 )
             }
             finishWithPersistentResult()

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/recognition/RecognitionScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/recognition/RecognitionScreen.kt
@@ -44,7 +44,6 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -54,13 +53,13 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -101,72 +100,39 @@ fun RecognitionScreen(
     val database = LocalDatabase.current
     val coroutineScope = rememberCoroutineScope()
 
-    // Only reset in Ready state: Listening/Processing belong to a running widget-service
-    // recognition that must not be cancelled; Success/NoMatch/Error are results pending
-    // display and history saving.
-    LaunchedEffect(Unit) {
-        if (com.metrolist.music.recognition.MusicRecognitionService.recognitionStatus.value
-                is RecognitionStatus.Ready
-        ) {
-            com.metrolist.music.recognition.MusicRecognitionService
-                .reset()
-        }
+    fun resetToReady() {
+        com.metrolist.music.recognition.MusicRecognitionService.reset()
     }
 
-    DisposableEffect(Unit) {
-        onDispose {
-            com.metrolist.music.recognition.MusicRecognitionService
-                .reset()
+    // Track whether we navigated to a child screen (search results or history)
+    var navigatedToChild by rememberSaveable { mutableStateOf(false) }
+
+    // Reset on fresh entry (not when returning from child screens)
+    LaunchedEffect(Unit) {
+        if (!navigatedToChild) {
+            resetToReady()
         }
+        navigatedToChild = false
     }
 
     // Observe recognition status from service for real-time updates (Listening -> Processing -> Result)
     val recognitionStatus by com.metrolist.music.recognition.MusicRecognitionService.recognitionStatus
         .collectAsStateWithLifecycle()
 
+    // System back button: reset to Ready if showing a result, otherwise normal back
+    androidx.activity.compose.BackHandler(
+        enabled = recognitionStatus is RecognitionStatus.Success ||
+                recognitionStatus is RecognitionStatus.NoMatch ||
+                recognitionStatus is RecognitionStatus.Error
+    ) {
+        resetToReady()
+    }
+
     var hasPermission by remember {
         mutableStateOf(
             ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO)
                 == PackageManager.PERMISSION_GRANTED,
         )
-    }
-
-    val permissionLauncher =
-        rememberLauncherForActivityResult(
-            contract = ActivityResultContracts.RequestPermission(),
-        ) { isGranted ->
-            hasPermission = isGranted
-            if (isGranted) {
-                coroutineScope.launch {
-                    com.metrolist.music.recognition.MusicRecognitionService
-                        .recognize(context)
-                }
-            }
-        }
-
-    fun startRecognition() {
-        if (hasPermission) {
-            coroutineScope.launch {
-                com.metrolist.music.recognition.MusicRecognitionService
-                    .recognize(context)
-            }
-        } else {
-            permissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
-        }
-    }
-
-    LaunchedEffect(Unit) {
-        if (autoStart &&
-            com.metrolist.music.recognition.MusicRecognitionService.recognitionStatus.value
-                is RecognitionStatus.Ready
-        ) {
-            startRecognition()
-        }
-    }
-
-    fun resetToReady() {
-        com.metrolist.music.recognition.MusicRecognitionService
-            .reset()
     }
 
     fun saveToHistory(result: RecognitionResult) {
@@ -197,13 +163,61 @@ fun RecognitionScreen(
         }
     }
 
+    val permissionLauncher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.RequestPermission(),
+        ) { isGranted ->
+            hasPermission = isGranted
+            if (isGranted) {
+                coroutineScope.launch {
+                    val status = com.metrolist.music.recognition.MusicRecognitionService
+                        .recognize(context)
+                    if (status is RecognitionStatus.Success) {
+                        saveToHistory(status.result)
+                    }
+                }
+            }
+        }
+
+    fun startRecognition() {
+        if (hasPermission) {
+            coroutineScope.launch {
+                val status = com.metrolist.music.recognition.MusicRecognitionService
+                    .recognize(context)
+                if (status is RecognitionStatus.Success) {
+                    saveToHistory(status.result)
+                }
+            }
+        } else {
+            permissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        if (autoStart &&
+            com.metrolist.music.recognition.MusicRecognitionService.recognitionStatus.value
+                is RecognitionStatus.Ready
+        ) {
+            startRecognition()
+        }
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.recognize_music)) },
                 navigationIcon = {
                     IconButton(
-                        onClick = { navController.navigateUp() },
+                        onClick = {
+                            if (recognitionStatus is RecognitionStatus.Success ||
+                                recognitionStatus is RecognitionStatus.NoMatch ||
+                                recognitionStatus is RecognitionStatus.Error
+                            ) {
+                                resetToReady()
+                            } else {
+                                navController.navigateUp()
+                            }
+                        },
                         onLongClick = { navController.backToMain() },
                     ) {
                         Icon(
@@ -213,7 +227,10 @@ fun RecognitionScreen(
                     }
                 },
                 actions = {
-                    IconButton(onClick = { navController.navigate("recognition_history") }) {
+                    IconButton(onClick = {
+                        navigatedToChild = true
+                        navController.navigate("recognition_history")
+                    }) {
                         Icon(
                             painter = painterResource(R.drawable.history),
                             contentDescription = stringResource(R.string.recognition_history),
@@ -246,10 +263,7 @@ fun RecognitionScreen(
 
                     is RecognitionStatus.Listening -> {
                         ListeningState(
-                            onCancel = {
-                                com.metrolist.music.recognition.MusicRecognitionService
-                                    .reset()
-                            },
+                            onCancel = { resetToReady() },
                         )
                     }
 
@@ -260,16 +274,11 @@ fun RecognitionScreen(
                     is RecognitionStatus.Success -> {
                         SuccessState(
                             result = status.result,
-                            onPlayOnApp = { result ->
-                                // Search for the track on YouTube Music
+                            onSearch = { result ->
+                                navigatedToChild = true
                                 val searchQuery = "${result.title} ${result.artist}"
                                 navController.navigate("search/${java.net.URLEncoder.encode(searchQuery, "UTF-8")}")
                             },
-                            onTryAgain = {
-                                startRecognition()
-                            },
-                            onClose = ::resetToReady,
-                            onSaveToHistory = ::saveToHistory,
                         )
                     }
 
@@ -480,16 +489,8 @@ private fun ProcessingState() {
 @Composable
 private fun SuccessState(
     result: RecognitionResult,
-    onPlayOnApp: (RecognitionResult) -> Unit,
-    onTryAgain: () -> Unit,
-    onClose: () -> Unit,
-    onSaveToHistory: (RecognitionResult) -> Unit,
+    onSearch: (RecognitionResult) -> Unit,
 ) {
-    // Save to history when success is shown
-    LaunchedEffect(result) {
-        onSaveToHistory(result)
-    }
-
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(16.dp),
@@ -546,50 +547,17 @@ private fun SuccessState(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        // Action buttons - stacked vertically
-        Column(
-            verticalArrangement = Arrangement.spacedBy(12.dp),
+        Button(
+            onClick = { onSearch(result) },
             modifier = Modifier.fillMaxWidth(),
         ) {
-            Button(
-                onClick = { onPlayOnApp(result) },
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.play),
-                    contentDescription = null,
-                    modifier = Modifier.size(18.dp),
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(stringResource(R.string.play_on_app))
-            }
-
-            FilledTonalButton(
-                onClick = onTryAgain,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.mic),
-                    contentDescription = null,
-                    modifier = Modifier.size(18.dp),
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(stringResource(R.string.re_listen))
-            }
-
-            // Close button - Material 3 Expressive outlined style
-            OutlinedButton(
-                onClick = onClose,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.close),
-                    contentDescription = null,
-                    modifier = Modifier.size(18.dp),
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(stringResource(R.string.close))
-            }
+            Icon(
+                painter = painterResource(R.drawable.search),
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(stringResource(R.string.search))
         }
     }
 }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/recognition/RecognitionScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/recognition/RecognitionScreen.kt
@@ -639,7 +639,7 @@ private fun ErrorState(
         }
 
         Text(
-            text = stringResource(R.string.recognition_error),
+            text = stringResource(R.string.recognition_failed),
             style = MaterialTheme.typography.titleLarge,
             fontWeight = FontWeight.Bold,
         )

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -769,25 +769,23 @@
     <!-- Music Recognition -->
     <string name="recognize_music">Recognize music</string>
     <string name="tap_to_recognize">Tap to recognize</string>
-    <string name="listening">Listening…</string>
-    <string name="processing">Processing…</string>
+    <string name="listening">Listening for music…</string>
+    <string name="processing">Identifying song…</string>
     <string name="no_match_found">No match found</string>
-    <string name="recognition_error">Recognition error</string>
+    <string name="recognition_failed">Recognition failed</string>
     <string name="try_again">Try again</string>
     <string name="recognition_history">Recognition history</string>
     <string name="clear_recognition_history">Clear recognition history</string>
     <string name="clear_recognition_history_confirm">Are you sure you want to clear all recognition history?</string>
     <string name="delete_from_history">Delete from history</string>
-    <string name="re_listen">Re-listen</string>
-    <string name="play_on_app">Play on Metrolist</string>
     <string name="qs_tile_music_recognizer">Recognize music</string>
     <string name="recognition_notification_channel_name">Music recognition</string>
     <string name="recognition_notification_channel_desc">Shows a notification while identifying a song from quick settings</string>
     <string name="recognition_notification_listening">Listening for music…</string>
-    <string name="recognition_notification_processing">Identifying…</string>
+    <string name="recognition_notification_processing">Identifying song…</string>
     <string name="recognition_notification_no_match">No match found</string>
     <string name="recognition_notification_failed">Recognition failed</string>
-    <string name="listen_on_metrolist">Listen on Metrolist</string>
+    <string name="recognition_open">Open</string>
 
     <!-- CSV Import Strings -->
     <string name="map_csv_columns">Map CSV columns</string>


### PR DESCRIPTION
## Problem
<!-- Describe the issue or limitation this PR addresses  DO NOT PR NEW FEATURES, WE'RE ON A FEATURE FREEZE!!! -->
The recognition result screen presented three buttons — "Play on App", "Re-listen", and "Close" — but they didn't work as intended or were redundant:

- **"Play on App"** couldn't reliably play the recognized song. It depended on a YouTube video ID from the Shazam response, but that field is almost never present, so the button fell back to a plain search instead of playing. Its label was therefore misleading.
- **"Re-listen"** was redundant: the result screen already returns to the listening state on back, so a dedicated button added nothing.
- **"Close"** duplicated the existing top-left back button / system back, offering no extra value.

There was also a navigation issue: going to a child screen (search results or recognition history) and pressing back lost the result, dropping the user on the "tap to recognise" state instead of the result they were viewing.

This is a usability improvement, not a new feature — it removes broken/redundant controls and fixes incorrect back behavior.

## Cause
<!-- Explain the root cause of the problem -->
- The Shazam recognition response only optionally includes a YouTube link in `hub.options`, and in practice it's almost always absent. "Play on App" relied on that ID, so it could rarely (if ever) actually start playback and silently degraded to a search.
- The button set included two controls ("Re-listen", "Close") that overlapped with existing back navigation.
- The recognition screen is a single destination driven by a shared status flow; returning from a child screen wasn't distinguished from a fresh entry, so the screen reset its state at the wrong time.

## Solution
<!-- List the changes made to fix the issue -->
- Replace the three buttons with a single **Search** button with a clear, accurate label.
- The Search button navigates to YouTube Music search using the recognized `title + artist`, which is the reliable way to find the track (no dependency on a Shazam-provided YouTube ID).
- Preserve the result state when navigating to child screens (search, recognition history) so back returns to the result.
- Reset to the "tap to recognise" state only on a fresh entry from Home/Search, not when returning from a child screen.

## Testing
<!-- Describe how the changes were tested -->
- Verified on a physical device:
  - Recognize a song → result shows with a single Search button.
  - Tap Search → YouTube Music search opens with the correct query; back returns to the result (not the listening screen).
  - Open recognition history from the result and press back → result is still shown.
  - Opening recognition fresh from Home/Search shows the "tap to recognise" state.

## Related Issues
<!-- List any related issues or PRs -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Back button now resets recognition status when results are displayed
  * Success screen features a dedicated "search" action to explore results further
  * History saving enhanced to prevent duplicate entries
  * Refined recognition and permission flow handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->