### PR TITLE
[fixed] feat(ui): replace pipe with dot for media metadata separation

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
@@ -7,6 +7,8 @@
 
 package com.metrolist.music.ui.component
 
+import com.metrolist.music.utils.BULLET_SEPARATOR
+
 import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animate
@@ -514,7 +516,7 @@ fun SongListItem(
                             modifier = Modifier.weight(1f)
                         )
                         Text(
-                            text = " | ${makeTimeString(song.song.duration * 1000L)}",
+                            text = "$BULLET_SEPARATOR${makeTimeString(song.song.duration * 1000L)}",
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.secondary,
                             maxLines = 1,
@@ -607,7 +609,7 @@ fun SongGridItem(
                 modifier = Modifier.weight(1f)
             )
             Text(
-                text = " | ${makeTimeString(song.song.duration * 1000L)}",
+                text = "$BULLET_SEPARATOR${makeTimeString(song.song.duration * 1000L)}",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.secondary,
                 maxLines = 1,
@@ -760,7 +762,7 @@ fun AlbumListItem(
                 modifier = Modifier.weight(1f)
             )
             Text(
-                text = " | ${pluralStringResource(R.plurals.n_song, album.album.songCount, album.album.songCount)}${album.album.year?.let { " | $it" } ?: ""}",
+                text = "$BULLET_SEPARATOR${pluralStringResource(R.plurals.n_song, album.album.songCount, album.album.songCount)}${album.album.year?.let { "$BULLET_SEPARATOR$it" } ?: ""}",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.secondary,
                 maxLines = 1,
@@ -1082,7 +1084,7 @@ fun MediaMetadataListItem(
                     modifier = Modifier.weight(1f)
                 )
                 Text(
-                    text = " | ${makeTimeString(mediaMetadata.duration * 1000L)}",
+                    text = "$BULLET_SEPARATOR${makeTimeString(mediaMetadata.duration * 1000L)}",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.secondary,
                     maxLines = 1,
@@ -1090,7 +1092,7 @@ fun MediaMetadataListItem(
                 )
                 if (mediaMetadata.suggestedBy != null) {
                     Text(
-                        text = " | ",
+                        text = BULLET_SEPARATOR,
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.secondary,
                         maxLines = 1,

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
@@ -516,7 +516,7 @@ fun SongListItem(
                             modifier = Modifier.weight(1f)
                         )
                         Text(
-                            text = "$BULLET_SEPARATOR${makeTimeString(song.song.duration * 1000L)}",
+                            text = " $BULLET_SEPARATOR ${makeTimeString(song.song.duration * 1000L)}",
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.secondary,
                             maxLines = 1,
@@ -609,7 +609,7 @@ fun SongGridItem(
                 modifier = Modifier.weight(1f)
             )
             Text(
-                text = "$BULLET_SEPARATOR${makeTimeString(song.song.duration * 1000L)}",
+                text = " $BULLET_SEPARATOR ${makeTimeString(song.song.duration * 1000L)}",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.secondary,
                 maxLines = 1,
@@ -762,7 +762,7 @@ fun AlbumListItem(
                 modifier = Modifier.weight(1f)
             )
             Text(
-                text = "$BULLET_SEPARATOR${pluralStringResource(R.plurals.n_song, album.album.songCount, album.album.songCount)}${album.album.year?.let { "$BULLET_SEPARATOR$it" } ?: ""}",
+                text = " $BULLET_SEPARATOR ${pluralStringResource(R.plurals.n_song, album.album.songCount, album.album.songCount)}${album.album.year?.let { " $BULLET_SEPARATOR $it" } ?: ""}",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.secondary,
                 maxLines = 1,
@@ -1084,7 +1084,7 @@ fun MediaMetadataListItem(
                     modifier = Modifier.weight(1f)
                 )
                 Text(
-                    text = "$BULLET_SEPARATOR${makeTimeString(mediaMetadata.duration * 1000L)}",
+                    text = " $BULLET_SEPARATOR ${makeTimeString(mediaMetadata.duration * 1000L)}",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.secondary,
                     maxLines = 1,
@@ -1092,7 +1092,7 @@ fun MediaMetadataListItem(
                 )
                 if (mediaMetadata.suggestedBy != null) {
                     Text(
-                        text = BULLET_SEPARATOR,
+                        text = " $BULLET_SEPARATOR ",
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.secondary,
                         maxLines = 1,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/AlbumScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/AlbumScreen.kt
@@ -275,7 +275,7 @@ fun AlbumScreen(
                                         ),
                                     )
                                     if (totalDuration > 0) {
-                                        append(BULLET_SEPARATOR)
+                                        append(" $BULLET_SEPARATOR ")
                                         append(makeTimeString(totalDuration * 1000L))
                                     }
                                 },

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/AlbumScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/AlbumScreen.kt
@@ -5,6 +5,8 @@
 
 package com.metrolist.music.ui.screens
 
+import com.metrolist.music.utils.BULLET_SEPARATOR
+
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
@@ -273,7 +275,7 @@ fun AlbumScreen(
                                         ),
                                     )
                                     if (totalDuration > 0) {
-                                        append(" | ")
+                                        append(BULLET_SEPARATOR)
                                         append(makeTimeString(totalDuration * 1000L))
                                     }
                                 },

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
@@ -588,7 +588,7 @@ fun DailyDiscoverCard(
                                 buildString {
                                     append((dailyDiscover.recommendation as? SongItem)?.artists?.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name } ?: "")
                                     if (playCount > 0) {
-                                        append("$BULLET_SEPARATOR$playCount $playsString")
+                                        append(" $BULLET_SEPARATOR $playCount $playsString")
                                     }
                                 },
                             style = MaterialTheme.typography.bodyMedium,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
@@ -5,6 +5,8 @@
 
 package com.metrolist.music.ui.screens
 
+import com.metrolist.music.utils.BULLET_SEPARATOR
+
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -586,7 +588,7 @@ fun DailyDiscoverCard(
                                 buildString {
                                     append((dailyDiscover.recommendation as? SongItem)?.artists?.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name } ?: "")
                                     if (playCount > 0) {
-                                        append(" | $playCount $playsString")
+                                        append("$BULLET_SEPARATOR$playCount $playsString")
                                     }
                                 },
                             style = MaterialTheme.typography.bodyMedium,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryPodcastsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryPodcastsScreen.kt
@@ -5,6 +5,8 @@
 
 package com.metrolist.music.ui.screens.library
 
+import com.metrolist.music.utils.BULLET_SEPARATOR
+
 import android.content.Intent
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
@@ -549,7 +551,7 @@ private fun AutoPlaylistCard(
                     buildString {
                         append(stringResource(R.string.auto_playlist))
                         if (!episodeCount.isNullOrBlank()) {
-                            append(" | ")
+                            append(BULLET_SEPARATOR)
                             append(episodeCount)
                         }
                     },

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryPodcastsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryPodcastsScreen.kt
@@ -551,7 +551,7 @@ private fun AutoPlaylistCard(
                     buildString {
                         append(stringResource(R.string.auto_playlist))
                         if (!episodeCount.isNullOrBlank()) {
-                            append(BULLET_SEPARATOR)
+                            append(" $BULLET_SEPARATOR ")
                             append(episodeCount)
                         }
                     },

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -5,6 +5,8 @@
 
 package com.metrolist.music.ui.screens.playlist
 
+import com.metrolist.music.utils.BULLET_SEPARATOR
+
 import android.net.Uri
 import android.provider.OpenableColumns
 import android.widget.Toast
@@ -927,7 +929,7 @@ private fun AutoPlaylistHeader(
                 buildString {
                     append(pluralStringResource(R.plurals.n_song, songs.size, songs.size))
                     if (likeLength > 0) {
-                        append(" | ")
+                        append(BULLET_SEPARATOR)
                         append(makeTimeString(likeLength * 1000L))
                     }
                 },

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -929,7 +929,7 @@ private fun AutoPlaylistHeader(
                 buildString {
                     append(pluralStringResource(R.plurals.n_song, songs.size, songs.size))
                     if (likeLength > 0) {
-                        append(BULLET_SEPARATOR)
+                        append(" $BULLET_SEPARATOR ")
                         append(makeTimeString(likeLength * 1000L))
                     }
                 },

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -1268,7 +1268,7 @@ fun LocalPlaylistHeader(
         val metadataString = buildString {
             append(nSongs)
             if (durationText != null) {
-                append(BULLET_SEPARATOR)
+                append(" $BULLET_SEPARATOR ")
                 append(durationText)
             }
         }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -5,6 +5,8 @@
 
 package com.metrolist.music.ui.screens.playlist
 
+import com.metrolist.music.utils.BULLET_SEPARATOR
+
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
@@ -1266,7 +1268,7 @@ fun LocalPlaylistHeader(
         val metadataString = buildString {
             append(nSongs)
             if (durationText != null) {
-                append(" | ")
+                append(BULLET_SEPARATOR)
                 append(durationText)
             }
         }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/OnlinePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/OnlinePlaylistScreen.kt
@@ -588,7 +588,7 @@ private fun OnlinePlaylistHeader(
         val metadataText = buildString {
             append(nSongs)
             if (durationText != null) {
-                append(BULLET_SEPARATOR)
+                append(" $BULLET_SEPARATOR ")
                 append(durationText)
             }
         }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/OnlinePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/OnlinePlaylistScreen.kt
@@ -5,6 +5,8 @@
 
 package com.metrolist.music.ui.screens.playlist
 
+import com.metrolist.music.utils.BULLET_SEPARATOR
+
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
@@ -586,7 +588,7 @@ private fun OnlinePlaylistHeader(
         val metadataText = buildString {
             append(nSongs)
             if (durationText != null) {
-                append(" | ")
+                append(BULLET_SEPARATOR)
                 append(durationText)
             }
         }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/TopPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/TopPlaylistScreen.kt
@@ -584,7 +584,7 @@ private fun TopPlaylistHeader(
             text = buildString {
                 append(pluralStringResource(R.plurals.n_song, songs.size, songs.size))
                 if (likeLength > 0) {
-                    append(BULLET_SEPARATOR)
+                    append(" $BULLET_SEPARATOR ")
                     append(makeTimeString(likeLength * 1000L))
                 }
             },

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/TopPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/TopPlaylistScreen.kt
@@ -5,6 +5,8 @@
 
 package com.metrolist.music.ui.screens.playlist
 
+import com.metrolist.music.utils.BULLET_SEPARATOR
+
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
@@ -582,7 +584,7 @@ private fun TopPlaylistHeader(
             text = buildString {
                 append(pluralStringResource(R.plurals.n_song, songs.size, songs.size))
                 if (likeLength > 0) {
-                    append(" | ")
+                    append(BULLET_SEPARATOR)
                     append(makeTimeString(likeLength * 1000L))
                 }
             },

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AlarmSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AlarmSettings.kt
@@ -215,7 +215,7 @@ fun AlarmSettingsSection(showTitle: Boolean = true) {
                             }
                         val description = buildString {
                             append(playlistTitle)
-                            append(BULLET_SEPARATOR)
+                            append(" $BULLET_SEPARATOR ")
                             append(if (alarm.randomSong) randomEnabledText else randomDisabledText)
                             append("\n")
                             append(stringResource(R.string.alarm_next_prefix, triggerText))

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AlarmSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AlarmSettings.kt
@@ -1,5 +1,7 @@
 package com.metrolist.music.ui.screens.settings
 
+import com.metrolist.music.utils.BULLET_SEPARATOR
+
 import android.app.AlarmManager
 import android.content.ActivityNotFoundException
 import android.content.Intent
@@ -213,7 +215,7 @@ fun AlarmSettingsSection(showTitle: Boolean = true) {
                             }
                         val description = buildString {
                             append(playlistTitle)
-                            append(" | ")
+                            append(BULLET_SEPARATOR)
                             append(if (alarm.randomSong) randomEnabledText else randomDisabledText)
                             append("\n")
                             append(stringResource(R.string.alarm_next_prefix, triggerText))

--- a/app/src/main/kotlin/com/metrolist/music/utils/StringUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/StringUtils.kt
@@ -5,7 +5,7 @@
 
 package com.metrolist.music.utils
 
-const val BULLET_SEPARATOR = " · "
+const val BULLET_SEPARATOR = "·"
 
 fun makeTimeString(duration: Long?): String {
     if (duration == null || duration < 0) return ""
@@ -27,4 +27,4 @@ fun joinByBullet(vararg str: String?) =
     str
         .filterNot {
             it.isNullOrEmpty()
-        }.joinToString(separator = BULLET_SEPARATOR)
+        }.joinToString(separator = " $BULLET_SEPARATOR ")

--- a/app/src/main/kotlin/com/metrolist/music/utils/StringUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/StringUtils.kt
@@ -5,6 +5,8 @@
 
 package com.metrolist.music.utils
 
+const val BULLET_SEPARATOR = " · "
+
 fun makeTimeString(duration: Long?): String {
     if (duration == null || duration < 0) return ""
     var sec = duration / 1000
@@ -25,4 +27,4 @@ fun joinByBullet(vararg str: String?) =
     str
         .filterNot {
             it.isNullOrEmpty()
-        }.joinToString(separator = " | ")
+        }.joinToString(separator = BULLET_SEPARATOR)


### PR DESCRIPTION
## Problem
The ` | ` character used as a separator in media metadata and other lists is visually intrusive and too large.

## Cause
The separator is currently hardcoded as ` | ` across multiple Kotlin files.

## Solution
- Replaced all instances of ` | ` with ` · ` across UI screens and string utilities.

## Testing
- Verified successful build via `./gradlew :app:assembleFossDebug`.

## Related Issues
- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Replaced pipe separators (|) with a bullet separator (·) across UI metadata displays — song/album/playlist headers, list/grid items, cards, and settings — for consistent, more readable counts, durations, and attribution text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->