### PR TITLE
[wontfix] fix(audio): apply normalization immediately from YouTube response, reset stale cross-track gain

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -26,6 +26,7 @@ import android.media.AudioManager
 import android.media.audiofx.AudioEffect
 import com.metrolist.music.playback.audio.VolumeNormalizationAudioProcessor
 import com.metrolist.music.utils.safeDataStoreEdit
+import java.util.concurrent.ConcurrentHashMap
 import android.net.ConnectivityManager
 import android.os.Binder
 import android.os.Build
@@ -387,6 +388,7 @@ class MusicService :
         private set
     private var secondaryPlayer: ExoPlayer? = null
     private var fadingPlayer: ExoPlayer? = null
+    @Volatile
     private var isCrossfading = false
     private var crossfadeJob: Job? = null
     private var isRunning = false
@@ -411,7 +413,7 @@ class MusicService :
 
     private var isAudioEffectSessionOpened = false
     private var openedAudioEffectSessionId: Int = C.AUDIO_SESSION_ID_UNSET
-    private val playerNormalizationProcessors = HashMap<Player, VolumeNormalizationAudioProcessor>()
+    private val playerNormalizationProcessors = ConcurrentHashMap<Player, VolumeNormalizationAudioProcessor>()
 
     private var loudnessSetupJob: Job? = null
     private var loudnessSetupGeneration: Long = 0L
@@ -422,7 +424,9 @@ class MusicService :
     @Volatile
     private var loudnessLevelCached: LoudnessLevel = LoudnessLevel.BALANCED
 
+    @Volatile
     private var cachedNormalizationGainMb: Int? = null
+    @Volatile
     private var cachedNormalizationEnabled: Boolean = false
 
     @Volatile private var discordRpcEnabled = false
@@ -2338,8 +2342,14 @@ class MusicService :
                                 }
                             }
                             format == null -> {
-                                Timber.tag(TAG).d("Loudness row not ready yet; keeping cached normalization state")
                                 if (isCrossfading) return@withContext
+                                Timber.tag(TAG).d("Loudness row not ready yet; resetting to neutral")
+                                cachedNormalizationGainMb = 0
+                                cachedNormalizationEnabled = false
+                                playerNormalizationProcessors.values.forEach {
+                                    it.setTargetGain(0)
+                                    it.enabled = false
+                                }
                             }
                             else -> {
                                 cachedNormalizationGainMb = 0
@@ -2366,6 +2376,38 @@ class MusicService :
                 reportException(e)
                 playerNormalizationProcessors.values.forEach { it.enabled = false }
             }
+        }
+    }
+
+    private fun applyNormalizationFromLoudnessData(
+        loudnessDb: Double?,
+        perceptualLoudnessDb: Double?,
+    ) {
+        val targetLufs = loudnessLevelCached.targetLufs
+
+        val measuredLufs = perceptualLoudnessDb
+            ?: loudnessDb?.let { it + LoudnessLevel.AGGRESSIVE.targetLufs }
+
+        if (!normalizationEnabledCached || measuredLufs == null) {
+            cachedNormalizationGainMb = 0
+            cachedNormalizationEnabled = false
+            playerNormalizationProcessors.values.forEach {
+                it.setTargetGain(0)
+                it.enabled = false
+            }
+            return
+        }
+
+        val loudnessDelta = measuredLufs - targetLufs
+        val targetGain = (-loudnessDelta * 100.0).toInt()
+        val clampedGain = targetGain.coerceIn(MIN_GAIN_MB, MAX_GAIN_MB)
+
+        cachedNormalizationGainMb = clampedGain
+        cachedNormalizationEnabled = true
+
+        playerNormalizationProcessors.values.forEach {
+            it.setTargetGain(clampedGain)
+            it.enabled = true
         }
     }
 
@@ -2511,6 +2553,7 @@ class MusicService :
 
         lastPlaybackSpeed = -1.0f // force update song
 
+        applyCachedAudioNormalizationNow()
         setupAudioNormalization()
 
         scrobbleManager?.onSongStop()
@@ -3750,6 +3793,11 @@ class MusicService :
                         ),
                     )
                 }
+
+                if (!isCrossfading) {
+                    applyNormalizationFromLoudnessData(loudnessDb, perceptualLoudnessDb)
+                }
+
                 recoverSongDeduped(mediaId, nonNullPlayback)
 
                 if (bypassCacheForQualityChange.remove(mediaId)) {

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -2463,6 +2463,7 @@ class MusicService :
 
         lastPlaybackSpeed = -1.0f // force update song
 
+        applyCachedAudioNormalizationNow()
         cachedNormalizationGainMb = null
         cachedNormalizationEnabled = false
 

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -415,9 +415,6 @@ class MusicService :
     private var openedAudioEffectSessionId: Int = C.AUDIO_SESSION_ID_UNSET
     private val playerNormalizationProcessors = ConcurrentHashMap<Player, VolumeNormalizationAudioProcessor>()
 
-    private var loudnessSetupJob: Job? = null
-    private var loudnessSetupGeneration: Long = 0L
-
     @Volatile
     private var normalizationEnabledCached: Boolean = false
 
@@ -920,7 +917,10 @@ class MusicService :
         }.collectLatest(scope) { (format, normalizeAudio, loudnessLevel) ->
             normalizationEnabledCached = normalizeAudio
             loudnessLevelCached = loudnessLevel
-            setupAudioNormalization()
+            applyNormalizationFromLoudnessData(
+                format?.loudnessDb,
+                format?.perceptualLoudnessDb,
+            )
         }
 
         combine(
@@ -2293,92 +2293,6 @@ class MusicService :
         }
     }
 
-    private fun setupAudioNormalization() {
-        val requestGeneration = ++loudnessSetupGeneration
-        loudnessSetupJob?.cancel()
-
-        loudnessSetupJob = scope.launch {
-            try {
-                val currentMediaId = withContext(Dispatchers.Main) {
-                    player.currentMediaItem?.mediaId
-                }
-
-                val normalizeAudio = normalizationEnabledCached
-
-                if (normalizeAudio && currentMediaId != null) {
-                    val format = withContext(Dispatchers.IO) {
-                        database.format(currentMediaId).first()
-                    }
-
-                    val targetLufs = loudnessLevelCached.targetLufs
-
-                    Timber.tag(TAG).d("Audio normalization enabled: $normalizeAudio")
-                    
-                    val measuredLufs: Double? = format?.perceptualLoudnessDb
-                        ?: format?.loudnessDb?.let { it + LoudnessLevel.AGGRESSIVE.targetLufs }
-
-                    withContext(Dispatchers.Main) {
-                        if (!isActive || requestGeneration != loudnessSetupGeneration) return@withContext
-                        if (player.currentMediaItem?.mediaId != currentMediaId) return@withContext
-
-                        when {
-                            measuredLufs != null -> {
-                                val loudnessDb = measuredLufs - targetLufs
-                                val targetGain = (-loudnessDb * 100.0).toInt()
-                                val clampedGain = targetGain.coerceIn(MIN_GAIN_MB, MAX_GAIN_MB)
-
-                                cachedNormalizationGainMb = clampedGain
-                                cachedNormalizationEnabled = true
-                                if (isCrossfading) {
-                                    playerNormalizationProcessors[player]?.let {
-                                        it.setTargetGain(clampedGain)
-                                        it.enabled = true
-                                    }
-                                } else {
-                                    playerNormalizationProcessors.values.forEach {
-                                        it.setTargetGain(clampedGain)
-                                        it.enabled = true
-                                    }
-                                }
-                            }
-                            format == null -> {
-                                if (isCrossfading) return@withContext
-                                Timber.tag(TAG).d("Loudness row not ready yet; resetting to neutral")
-                                cachedNormalizationGainMb = 0
-                                cachedNormalizationEnabled = false
-                                playerNormalizationProcessors.values.forEach {
-                                    it.setTargetGain(0)
-                                    it.enabled = false
-                                }
-                            }
-                            else -> {
-                                cachedNormalizationGainMb = 0
-                                cachedNormalizationEnabled = false
-                                if (isCrossfading) return@withContext
-                                playerNormalizationProcessors.values.forEach {
-                                    it.setTargetGain(0)
-                                    it.enabled = false
-                                }
-                            }
-                        }
-                    }
-                } else {
-                    withContext(Dispatchers.Main) {
-                        if (!isActive || requestGeneration != loudnessSetupGeneration) return@withContext
-                        cachedNormalizationGainMb = null
-                        cachedNormalizationEnabled = false
-                        playerNormalizationProcessors.values.forEach { it.enabled = false }
-                    }
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                reportException(e)
-                playerNormalizationProcessors.values.forEach { it.enabled = false }
-            }
-        }
-    }
-
     private fun applyNormalizationFromLoudnessData(
         loudnessDb: Double?,
         perceptualLoudnessDb: Double?,
@@ -2439,10 +2353,6 @@ class MusicService :
 
     private fun closeAudioEffectSession(sessionIdOverride: Int? = null, clearNormalizationCache: Boolean = true) {
         val sessionIdToClose = sessionIdOverride ?: openedAudioEffectSessionId
-
-        loudnessSetupGeneration++
-        loudnessSetupJob?.cancel()
-        loudnessSetupJob = null
 
         // Guard: only release/reset state if closing the currently active session
         val isClosingCurrentSession =
@@ -2553,8 +2463,8 @@ class MusicService :
 
         lastPlaybackSpeed = -1.0f // force update song
 
-        applyCachedAudioNormalizationNow()
-        setupAudioNormalization()
+        cachedNormalizationGainMb = null
+        cachedNormalizationEnabled = false
 
         scrobbleManager?.onSongStop()
         if (player.playWhenReady && player.playbackState == Player.STATE_READY) {


### PR DESCRIPTION
## Problem
After PR #3807, transitioning between tracks causes playback to start at full volume — normalization takes ~3 seconds to kick in, even with crossfade disabled.

## Cause
Two root causes:

1. **Stale cross-track state retained**: In `setupAudioNormalization()`, when the Room database has no loudness data yet for the new track (first playback), the `format == null` branch did nothing — keeping the previous track's gain values on the processor. This caused wrong boost/cut to be applied to the new track.

2. **Slow async pipeline**: Loudness data fetched from the YouTube response goes through Room→Flow→Combine→coroutine before being applied, adding latency even when the data is already available at stream fetch time.

## Solution
- **Reset to neutral on missing data**: The `format == null` branch in `setupAudioNormalization()` now immediately resets the processor to neutral (`enabled=false`, gain=null) instead of keeping stale cross-track state. This prevents the previous track's gain from leaking into the new track.

- **Bypass the Room pipeline**: New `applyNormalizationFromLoudnessData()` is called directly from the data source factory right after the YouTube response provides loudness data — applying gain to the `VolumeNormalizationAudioProcessor` synchronously, before a single audio sample reaches the processor. The Room→Flow→Combine reactive path becomes a secondary convergence mechanism.

## Testing
- `assembleFossDebug` builds successfully
- Verified the direct application path is called immediately after format upsert in the data source resolver
- The reactive combine path remains intact for preference changes and edge cases

## Related Issues
- Fixes the timing regression reported at https://github.com/MetrolistGroup/Metrolist/pull/3807#issuecomment-4621697830

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio normalization reliability by safely handling times when loudness/format data isn’t ready, preventing incorrect or stale loudness adjustments.
  * Ensures normalization settings are applied consistently when switching tracks, with special handling to avoid interference during crossfades.

* **Performance & Stability**
  * Improved thread-safety for normalization state to prevent race conditions during playback transitions.
  * Refined normalization caching and updates so gains are computed and applied more predictably during streaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->