### PR TITLE
fix: resolve cache size formatting truncation issue

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/StorageSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/StorageSettings.kt
@@ -58,8 +58,8 @@ import com.metrolist.music.ui.component.ActionPromptDialog
 import com.metrolist.music.ui.component.IconButton
 import com.metrolist.music.ui.component.Material3SettingsGroup
 import com.metrolist.music.ui.component.Material3SettingsItem
+import android.text.format.Formatter
 import com.metrolist.music.ui.utils.backToMain
-import com.metrolist.music.ui.utils.formatFileSize
 import com.metrolist.music.utils.rememberPreference
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -254,7 +254,7 @@ fun StorageSettings(
                 Text(
                     stringResource(
                         R.string.cache_size_warning_message,
-                        formatFileSize(cacheUsage),
+                        Formatter.formatShortFileSize(context, cacheUsage),
                         cacheType,
                     ),
                 )
@@ -304,7 +304,7 @@ fun StorageSettings(
                         icon = painterResource(R.drawable.storage),
                         title = { Text(stringResource(R.string.downloaded_songs)) },
                         description = {
-                            Text(text = formatFileSize(downloadCacheSize))
+                            Text(text = Formatter.formatShortFileSize(context, downloadCacheSize))
                         },
                     ),
                     Material3SettingsItem(
@@ -353,7 +353,7 @@ fun StorageSettings(
                                 text = when (maxSongCacheSize) {
                                     0 -> stringResource(R.string.disable)
                                     -1 -> stringResource(R.string.unlimited)
-                                    else -> formatFileSize(maxSongCacheSize * 1024 * 1024L)
+                                    else -> Formatter.formatShortFileSize(context, maxSongCacheSize * 1024 * 1024L)
                                 }
                             )
                             Slider(
@@ -388,10 +388,10 @@ fun StorageSettings(
                                 Text(
                                     text =
                                         if (maxSongCacheSize == -1) {
-                                            formatFileSize(playerCacheSize)
+                                            Formatter.formatShortFileSize(context, playerCacheSize)
                                         } else {
-                                            "${formatFileSize(playerCacheSize)} / ${
-                                                formatFileSize(
+                                            "${Formatter.formatShortFileSize(context, playerCacheSize)} / ${
+                                                Formatter.formatShortFileSize(context, 
                                                     maxSongCacheSize * 1024 * 1024L,
                                                 )
                                             }"
@@ -426,7 +426,7 @@ fun StorageSettings(
                                     text =
                                         when (maxImageCacheSize) {
                                             0 -> stringResource(R.string.disable)
-                                            else -> formatFileSize(maxImageCacheSize * 1024 * 1024L)
+                                            else -> Formatter.formatShortFileSize(context, maxImageCacheSize * 1024 * 1024L)
                                         },
                                 )
                                 Slider(
@@ -454,8 +454,8 @@ fun StorageSettings(
                                 )
                                 Spacer(modifier = Modifier.padding(2.dp))
                                 Text(
-                                    text = "${formatFileSize(imageCacheSize)} / ${
-                                        formatFileSize(
+                                    text = "${Formatter.formatShortFileSize(context, imageCacheSize)} / ${
+                                        Formatter.formatShortFileSize(context, 
                                             maxImageCacheSize * 1024 * 1024L,
                                         )
                                     }",

--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/StringUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/StringUtils.kt
@@ -6,34 +6,6 @@
 package com.metrolist.music.ui.utils
 
 import java.text.DecimalFormat
-import kotlin.math.absoluteValue
-
-fun formatFileSize(sizeBytes: Long): String {
-    val prefix = if (sizeBytes < 0) "-" else ""
-    var result: Long = sizeBytes.absoluteValue
-    var suffix = "B"
-    if (result > 900) {
-        suffix = "KB"
-        result /= 1024
-    }
-    if (result > 900) {
-        suffix = "MB"
-        result /= 1024
-    }
-    if (result > 900) {
-        suffix = "GB"
-        result /= 1024
-    }
-    if (result > 900) {
-        suffix = "TB"
-        result /= 1024
-    }
-    if (result > 900) {
-        suffix = "PB"
-        result /= 1024
-    }
-    return "$prefix$result $suffix"
-}
 
 fun numberFormatter(n: Int) =
     DecimalFormat("#,###")


### PR DESCRIPTION
## Problem
<!-- Describe the issue or limitation this PR addresses  
DO NOT PR NEW FEATURES, WE'RE ON A FEATURE FREEZE!!! -->
Cache sizes in the storage settings display incorrectly as "0 GB / 1 GB" instead of a proper decimal value when they are almost full, because the size string formatter uses integer division.

## Cause
<!-- Explain the root cause of the problem -->
`formatFileSize` in `StringUtils.kt` performs integer division (`result /= 1024`) and uses custom arrays for suffixes, which causes the decimal portion to be discarded (leading to "0 GB") and ignores system-level localizations.

## Solution
<!-- List the changes made to fix the issue -->
- Removed the custom `formatFileSize` implementation from `StringUtils.kt` entirely.
- Replaced all usages of the custom formatter in `StorageSettings.kt` with Android's native `android.text.format.Formatter.formatShortFileSize(context, sizeBytes)`.
- This ensures correct locale-aware formatting, proper rounding for edge cases, and natively resolves the "0 GB" issue without relying on temporary workarounds or placeholders.

## Testing
<!-- Describe how the changes were tested -->
Compiled the app using `./gradlew :app:assembleFossDebug` and verified that cache sizes are properly rendered using native units.

## Related Issues
<!-- List any related issues or PRs -->
- Closes #3527


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved file size display formatting throughout the application. Enhanced how storage and cache information sizes are displayed by implementing more consistent formatting standards. The changes optimize the underlying implementation while maintaining a seamless user experience, ensuring all storage details appear uniform and reliable across the entire app interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->