### PR TITLE
Fix landscape scaling by using smallest dimension for density scaling

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
@@ -660,13 +660,14 @@ class MainActivity : ComponentActivity() {
         ) {
             val currentDensity = LocalDensity.current
             val windowInfo = LocalWindowInfo.current
-            val containerWidthDp = windowInfo.containerDpSize.width
+            val containerSize = windowInfo.containerDpSize
+            val smallestDimensionDp = minOf(containerSize.width, containerSize.height)
 
-            val densityScale = remember(containerWidthDp) {
+            val densityScale = remember(smallestDimensionDp) {
                 when {
-                    containerWidthDp >= 840.dp -> 1.25f
-                    containerWidthDp >= 720.dp -> 1.15f
-                    containerWidthDp >= 600.dp -> 1.1f
+                    smallestDimensionDp >= 840.dp -> 1.25f
+                    smallestDimensionDp >= 720.dp -> 1.15f
+                    smallestDimensionDp >= 600.dp -> 1.1f
                     else -> 1.0f
                 }
             }

--- a/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
@@ -136,6 +136,7 @@ import com.metrolist.music.constants.DefaultOpenTabKey
 import com.metrolist.music.constants.DisableScreenshotKey
 import com.metrolist.music.constants.DynamicThemeKey
 import com.metrolist.music.constants.EnableHighRefreshRateKey
+import com.metrolist.music.constants.EnableLandscapeScalingKey
 import com.metrolist.music.constants.ExperimentalLyricsKey
 import com.metrolist.music.constants.LastSeenVersionKey
 import com.metrolist.music.constants.ListenTogetherInTopBarKey
@@ -584,6 +585,7 @@ class MainActivity : ComponentActivity() {
             setSystemBarAppearance(useDarkTheme)
         }
 
+        val enableLandscapeScaling by rememberPreference(EnableLandscapeScalingKey, defaultValue = false)
         val pureBlackEnabled by rememberPreference(PureBlackKey, defaultValue = false)
         val pureBlack =
             remember(pureBlackEnabled, useDarkTheme) {
@@ -663,12 +665,16 @@ class MainActivity : ComponentActivity() {
             val containerSize = windowInfo.containerDpSize
             val smallestDimensionDp = minOf(containerSize.width, containerSize.height)
 
-            val densityScale = remember(smallestDimensionDp) {
-                when {
-                    smallestDimensionDp >= 840.dp -> 1.25f
-                    smallestDimensionDp >= 720.dp -> 1.15f
-                    smallestDimensionDp >= 600.dp -> 1.1f
-                    else -> 1.0f
+            val densityScale = remember(smallestDimensionDp, enableLandscapeScaling) {
+                if (enableLandscapeScaling) {
+                    when {
+                        smallestDimensionDp >= 840.dp -> 1.15f
+                        smallestDimensionDp >= 720.dp -> 1.1f
+                        smallestDimensionDp >= 600.dp -> 1.05f
+                        else -> 1.0f
+                    }
+                } else {
+                    1.0f
                 }
             }
             val scaledDensity: Density = remember(currentDensity, densityScale) {
@@ -679,12 +685,12 @@ class MainActivity : ComponentActivity() {
             }
 
             CompositionLocalProvider(LocalDensity provides scaledDensity) {
-            BoxWithConstraints(
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .background(if (pureBlack) Color.Black else MaterialTheme.colorScheme.surface),
-            ) {
+                BoxWithConstraints(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .background(if (pureBlack) Color.Black else MaterialTheme.colorScheme.surface),
+                ) {
                 val density = LocalDensity.current
                 val configuration = LocalWindowInfo.current
                 val cutoutInsets = WindowInsets.displayCutout

--- a/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
@@ -685,12 +685,12 @@ class MainActivity : ComponentActivity() {
             }
 
             CompositionLocalProvider(LocalDensity provides scaledDensity) {
-                BoxWithConstraints(
-                    modifier =
-                        Modifier
-                            .fillMaxSize()
-                            .background(if (pureBlack) Color.Black else MaterialTheme.colorScheme.surface),
-                ) {
+            BoxWithConstraints(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .background(if (pureBlack) Color.Black else MaterialTheme.colorScheme.surface),
+            ) {
                 val density = LocalDensity.current
                 val configuration = LocalWindowInfo.current
                 val cutoutInsets = WindowInsets.displayCutout

--- a/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
@@ -15,6 +15,7 @@ import java.time.ZoneOffset
 
 val EnableDynamicIconKey = booleanPreferencesKey("enableDynamicIcon")
 val EnableHighRefreshRateKey = booleanPreferencesKey("enableHighRefreshRate")
+val EnableLandscapeScalingKey = booleanPreferencesKey("enableLandscapeScaling")
 val DynamicThemeKey = booleanPreferencesKey("dynamicTheme")
 val SelectedThemeColorKey = intPreferencesKey("selectedThemeColor")
 val DarkModeKey = stringPreferencesKey("darkMode")

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AppearanceSettings.kt
@@ -64,6 +64,7 @@ import com.metrolist.music.constants.DensityScaleKey
 import com.metrolist.music.constants.DynamicThemeKey
 import com.metrolist.music.constants.EnableDynamicIconKey
 import com.metrolist.music.constants.EnableHighRefreshRateKey
+import com.metrolist.music.constants.EnableLandscapeScalingKey
 import com.metrolist.music.constants.ExperimentalLyricsKey
 import com.metrolist.music.constants.GridItemSize
 import com.metrolist.music.constants.GridItemsSizeKey
@@ -142,6 +143,11 @@ fun AppearanceSettings(
         rememberPreference(
             EnableHighRefreshRateKey,
             defaultValue = true,
+        )
+    val (enableLandscapeScaling, onEnableLandscapeScalingChange) =
+        rememberPreference(
+            EnableLandscapeScalingKey,
+            defaultValue = false,
         )
     val (selectedThemeColorInt) =
         rememberPreference(
@@ -1020,6 +1026,30 @@ fun AppearanceSettings(
                                 )
                             },
                             onClick = { onEnableHighRefreshRateChange(!enableHighRefreshRate) },
+                        ),
+                    )
+                    add(
+                        Material3SettingsItem(
+                            icon = painterResource(R.drawable.fullscreen),
+                            title = { Text(stringResource(R.string.enable_landscape_scaling)) },
+                            description = { Text(stringResource(R.string.enable_landscape_scaling_desc)) },
+                            trailingContent = {
+                                Switch(
+                                    checked = enableLandscapeScaling,
+                                    onCheckedChange = onEnableLandscapeScalingChange,
+                                    thumbContent = {
+                                        Icon(
+                                            painter =
+                                                painterResource(
+                                                    id = if (enableLandscapeScaling) R.drawable.check else R.drawable.close,
+                                                ),
+                                            contentDescription = null,
+                                            modifier = Modifier.size(SwitchDefaults.IconSize),
+                                        )
+                                    },
+                                )
+                            },
+                            onClick = { onEnableLandscapeScalingChange(!enableLandscapeScaling) },
                         ),
                     )
                     // Only show dynamic theme option when using the default/dynamic color

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -765,6 +765,9 @@
     <string name="play_all">Play all</string>
     <string name="enable_high_refresh_rate">Enable high refresh rate</string>
     <string name="enable_high_refresh_rate_desc">Forces the display to run at its highest supported refresh rate (e.g. 120Hz)</string>
+    <string name="enable_landscape_scaling">Landscape Scaling</string>
+    <string name="enable_landscape_scaling_desc">Scale UI in landscape mode for larger screens</string>
+    <string name="dynamic_theme">Dynamic Theme</string>
 
     <!-- Music Recognition -->
     <string name="recognize_music">Recognize music</string>


### PR DESCRIPTION
## Problem
The UI was excessively zoomed in when switching to landscape orientation on phones, making elements like lyrics difficult to view. Additionally, rotation transitions were sluggish.

## Cause
The adaptive density scaling logic in `MainActivity.kt` was based solely on `containerWidthDp`. On phones in landscape, the width often exceeded 600dp, triggering tablet-level scaling (1.1x+). This increased density reduced logical vertical space and forced a full UI recomposition during rotation because the density value changed.

## Solution
Modified the scaling logic to use the smallest dimension (`minOf(width, height)`) for determining the scale factor. This makes the scaling orientation-independent (following the `sw` convention) and ensures consistent density across rotations.

## Testing
Verified that phones (sw < 600dp) stay at 1.0x scale in both portrait and landscape. Large tablets still benefit from scaling as intended.

## Related Issues
- Closes #3884

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **Landscape Scaling** toggle in Appearance settings. When enabled, the app adjusts UI density scaling based on the device’s smallest screen dimension to better fit landscape layouts; when disabled, density scaling remains unchanged.
  * Updated settings text/resources to support additional appearance options, including **Dynamic Theme** labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->