### PR TITLE
[wontfix] fix(sync): append offline liked songs to youtube instead of overwriting

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
@@ -734,10 +734,17 @@ class SyncUtils @Inject constructor(
                     val remoteIds = remoteSongs.map { it.id }.toSet()
                     val localSongs = database.likedSongEntitiesByNameAsc()
 
+                    val lastSync = context.dataStore.get(LastFullSyncKey, 0L)
+
                     // Remove likes from songs not in remote
-                    localSongs.filterNot { it.id in remoteIds }.forEach { song ->
+                    localSongs.filterNot { it.id in remoteIds || it.song.isLocal }.forEach { song ->
                         try {
-                            database.update(song.localToggleLike())
+                            val likedDate = song.song.likedDate
+                            if (likedDate != null && likedDate.toEpochSecond(ZoneOffset.UTC) > lastSync) {
+                                YouTube.likeVideo(song.id, true)
+                            } else {
+                                database.update(song.song.localToggleLike())
+                            }
                             delay(DB_OPERATION_DELAY_MS)
                         } catch (e: Exception) {
                             Timber.e(e, "Failed to update song: ${song.id}")

--- a/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
@@ -732,31 +732,21 @@ class SyncUtils @Inject constructor(
                 try {
                     val remoteSongs = page.songs
                     val remoteIds = remoteSongs.map { it.id }.toSet()
-                    val localSongs = database.likedSongEntitiesByNameAsc()
+                    val localLikedSongs = database.likedSongsByNameAsc().first()
 
-                    val lastSync = context.dataStore.get(LastFullSyncKey, 0L)
-
-                    // Remove likes from songs not in remote
-                    localSongs.filterNot { it.id in remoteIds || it.song.isLocal }.forEach { song ->
+                    localLikedSongs.filterNot { it.id in remoteIds || it.song.isLocal }.forEach { song ->
                         try {
-                            val likedDate = song.song.likedDate
-                            if (likedDate == null || likedDate.toEpochSecond(ZoneOffset.UTC) > lastSync) {
-                                // TODO: Schedule a migration/backfill job for songs with null likedDate
-                                withRetry {
-                                    YouTube.likeVideo(song.id, true)
-                                }.onFailure { e ->
-                                    Timber.e(e, "Failed to like song on YouTube: ${song.id}")
-                                }
-                            } else {
-                                database.update(song.song.localToggleLike())
+                            withRetry {
+                                YouTube.likeVideo(song.id, true)
+                            }.onFailure { e ->
+                                Timber.e(e, "Failed to like song on YouTube: ${song.id}")
                             }
                             delay(DB_OPERATION_DELAY_MS)
                         } catch (e: Exception) {
-                            Timber.e(e, "Failed to update song: ${song.id}")
+                            Timber.e(e, "Failed to push local liked song: ${song.id}")
                         }
                     }
 
-                    // Add/update songs from remote
                     val now = LocalDateTime.now()
                     remoteSongs.forEachIndexed { index, song ->
                         try {
@@ -769,8 +759,12 @@ class SyncUtils @Inject constructor(
                                     insert(song.toMediaMetadata()) {
                                         it.copy(liked = true, likedDate = timestamp, isVideo = isVideoSong)
                                     }
-                                } else if (!dbSong.liked || dbSong.likedDate != timestamp || dbSong.isVideo != isVideoSong) {
-                                    update(dbSong.copy(liked = true, likedDate = timestamp, isVideo = isVideoSong))
+                                } else if (!dbSong.song.liked) {
+                                    update(dbSong.song.copy(
+                                        liked = true,
+                                        likedDate = dbSong.song.likedDate ?: timestamp,
+                                        isVideo = isVideoSong
+                                    ))
                                 }
                             }
                             delay(DB_OPERATION_DELAY_MS)
@@ -780,7 +774,7 @@ class SyncUtils @Inject constructor(
                     }
 
                     updateState { copy(likedSongs = SyncStatus.Completed) }
-                    Timber.d("Synced ${remoteSongs.size} liked songs")
+                    Timber.d("Synced liked songs: ${remoteSongs.size} remote, ${localLikedSongs.size} local")
                 } catch (e: Exception) {
                     Timber.e(e, "Error processing liked songs")
                     updateState { copy(likedSongs = SyncStatus.Error(e.message ?: "Unknown error")) }

--- a/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
@@ -740,8 +740,13 @@ class SyncUtils @Inject constructor(
                     localSongs.filterNot { it.id in remoteIds || it.song.isLocal }.forEach { song ->
                         try {
                             val likedDate = song.song.likedDate
-                            if (likedDate != null && likedDate.toEpochSecond(ZoneOffset.UTC) > lastSync) {
-                                YouTube.likeVideo(song.id, true)
+                            if (likedDate == null || likedDate.toEpochSecond(ZoneOffset.UTC) > lastSync) {
+                                // TODO: Schedule a migration/backfill job for songs with null likedDate
+                                withRetry {
+                                    YouTube.likeVideo(song.id, true)
+                                }.onFailure { e ->
+                                    Timber.e(e, "Failed to like song on YouTube: ${song.id}")
+                                }
                             } else {
                                 database.update(song.song.localToggleLike())
                             }

--- a/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
@@ -350,12 +350,6 @@ class SyncUtils @Inject constructor(
             }
 
             enqueue(SyncOperation.FullSync)
-
-            val now = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)
-            cachedLastSyncEpoch = now
-            context.safeDataStoreEdit { settings ->
-                settings[LastFullSyncKey] = now
-            }
         }
     }
 
@@ -623,6 +617,12 @@ class SyncUtils @Inject constructor(
             executeSyncSavedPlaylists()
             delay(DB_OPERATION_DELAY_MS)
 
+            val now = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)
+            cachedLastSyncEpoch = now
+            context.safeDataStoreEdit { settings ->
+                settings[LastFullSyncKey] = now
+            }
+
             updateState { copy(overallStatus = SyncStatus.Completed, currentOperation = "") }
             Timber.d("Full sync completed successfully")
         } catch (e: CancellationException) {
@@ -734,16 +734,23 @@ class SyncUtils @Inject constructor(
                     val remoteIds = remoteSongs.map { it.id }.toSet()
                     val localLikedSongs = database.likedSongsByNameAsc().first()
 
+                    val lastSync = context.dataStore.get(LastFullSyncKey, 0L)
+
                     localLikedSongs.filterNot { it.id in remoteIds || it.song.isLocal }.forEach { song ->
                         try {
-                            withRetry {
-                                YouTube.likeVideo(song.id, true)
-                            }.onFailure { e ->
-                                Timber.e(e, "Failed to like song on YouTube: ${song.id}")
+                            val likedDate = song.song.likedDate
+                            if (likedDate == null || likedDate.toEpochSecond(ZoneOffset.UTC) > lastSync) {
+                                withRetry {
+                                    YouTube.likeVideo(song.id, true)
+                                }.onFailure { e ->
+                                    Timber.e(e, "Failed to like song on YouTube: ${song.id}")
+                                }
+                            } else {
+                                database.update(song.song.localToggleLike())
                             }
                             delay(DB_OPERATION_DELAY_MS)
                         } catch (e: Exception) {
-                            Timber.e(e, "Failed to push local liked song: ${song.id}")
+                            Timber.e(e, "Failed to update song: ${song.id}")
                         }
                     }
 
@@ -759,10 +766,10 @@ class SyncUtils @Inject constructor(
                                     insert(song.toMediaMetadata()) {
                                         it.copy(liked = true, likedDate = timestamp, isVideo = isVideoSong)
                                     }
-                                } else if (!dbSong.song.liked) {
-                                    update(dbSong.song.copy(
+                                } else if (!dbSong.liked) {
+                                    update(dbSong.copy(
                                         liked = true,
-                                        likedDate = dbSong.song.likedDate ?: timestamp,
+                                        likedDate = dbSong.likedDate ?: timestamp,
                                         isVideo = isVideoSong
                                     ))
                                 }


### PR DESCRIPTION
## Problem
Local liked songs are getting overwritten by the YouTube account liked songs when a user logs in, effectively wiping out their offline likes.

## Cause
The sync logic in `SyncUtils` was removing local likes for any songs not present in the remote YouTube list, without accounting for songs that were liked while the user was offline or prior to logging in.

## Solution
- Checked the `LastFullSyncKey` timestamp to determine if a local like was added after the last sync or while offline.
- Pushed offline likes to YouTube during sync, appending them to the account instead of overwriting them.
- Ignored local device files (`isLocal`) during the sync so they are never unliked by the YouTube remote state.

## Testing
Analyzed and tested the sync algorithm to ensure offline likes are preserved and pushed, while still respecting unlikes made remotely.

## Related Issues
- Closes #3685


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization of liked songs between local and remote libraries: local-only likes are no longer removed during cleanup. Instead, qualifying local likes are pushed to the remote list.
  * Tightened merge/update behavior to apply changes more selectively, helping preserve existing like timestamps when appropriate and keeping video status aligned with the remote source.
  * Enhanced completion reporting to include both remote and local liked song counts for clearer sync results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->