### PR TITLE
fix(ui): add linkColor to remember keys in ClickableArtistText

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
@@ -149,7 +149,7 @@ fun ClickableArtistText(
     val navController = LocalNavController.current
     val andString = stringResource(R.string.and)
     val linkColor = LocalContentColor.current
-    val annotatedString = remember(artists, andString) {
+    val annotatedString = remember(artists, andString, linkColor) {
         buildAnnotatedString {
             artists.forEachIndexed { index, artist ->
                 withLink(
@@ -242,7 +242,7 @@ fun ClickableArtistText(
     val navController = LocalNavController.current
     val andString = stringResource(R.string.and)
     val linkColor = LocalContentColor.current
-    val annotatedString = remember(artists, andString) {
+    val annotatedString = remember(artists, andString, linkColor) {
         buildAnnotatedString {
             artists.forEachIndexed { index, artist ->
                 val artistId = artist.id


### PR DESCRIPTION
## Problem
The `annotatedString` in `ClickableArtistText` components did not recompute when theme/content color changed because it was missing `linkColor` as a `remember` key.

## Cause
`remember(artists, andString)` was missing `linkColor` which was captured in the block.

## Solution
- Added `linkColor` to `remember` keys for `ClickableArtistTextEntities` and `ClickableArtistTextMedia` in `Items.kt`.

## Testing
- Verified through code analysis that the missing dependencies are now correctly passed to `remember`.
- App builds successfully.

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a visual issue where artist link colors would not refresh when the app's color theme or display settings changed. Artist text links now properly update their appearance to match the active color scheme, ensuring consistent and accurate styling across the music application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->