### PR TITLE
[wontfix] docs(agents): update rule to use upstream/main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Metrolist is a 3rd party YouTube Music client written in Kotlin. It follows mate
 
 ## Rules for working on the project
 
-1. Always pull the latest changes from `main` before starting your work to minimize merge conflicts.
+1. Always pull the latest changes from `upstream/main` before starting your work to minimize discrepancies and merge conflicts. If the `upstream` remote does not exist, set it up first (`git remote add upstream https://github.com/metrolistgroup/metrolist.git`) as individual forks are often not updated.
 2. Commit names should be clear and follow the format: `type(scope): short description`. For example: `feat(ui): add dark mode support`. Including the scope is optional.
 3. All string edits should be made to the `Metrolist/app/src/main/res/values/metrolist_strings.xml` file, NOT `Metrolist/app/src/main/res/values/strings.xml`. Do not touch other `strings.xml` or `metrolist_strings.xml` files in the project. ONLY edit the default (English) `metrolist_strings.xml` file, DO NOT EDIT OTHER LANGUAGES.
 4. You are to follow best practices for Kotlin and Android development.


### PR DESCRIPTION
## Problem
Forks are often not updated, causing discrepancies and merge conflicts for AI agents.

## Cause
AI agents were instructed to pull from `main`, which on a fork can be outdated compared to the main upstream repository.

## Solution
- Updated `AGENTS.md` to instruct AI agents to always pull from `upstream/main` and set up the `upstream` remote if it doesn't exist.

## Testing
N/A - Documentation only update.

## Related Issues
- N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor workflow guidance for code synchronization procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->