### PR TITLE
[fixed] fix(playback): resolve age-restricted content and playback issues for uploaded songs

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/models/MediaMetadata.kt
+++ b/app/src/main/kotlin/com/metrolist/music/models/MediaMetadata.kt
@@ -9,6 +9,8 @@ import androidx.compose.runtime.Immutable
 import com.metrolist.innertube.models.EpisodeItem
 import com.metrolist.innertube.models.SongItem
 import com.metrolist.innertube.models.WatchEndpoint.WatchEndpointMusicSupportedConfigs.WatchEndpointMusicConfig.Companion.MUSIC_VIDEO_TYPE_ATV
+import com.metrolist.innertube.models.WatchEndpoint.WatchEndpointMusicSupportedConfigs.WatchEndpointMusicConfig.Companion.MUSIC_VIDEO_TYPE_OMV
+import com.metrolist.innertube.models.WatchEndpoint.WatchEndpointMusicSupportedConfigs.WatchEndpointMusicConfig.Companion.MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK
 import com.metrolist.music.db.entities.Song
 import com.metrolist.music.db.entities.SongEntity
 import com.metrolist.music.ui.utils.resize
@@ -36,7 +38,9 @@ data class MediaMetadata(
     val uploadEntityId: String? = null,
 ) : Serializable {
     val isVideoSong: Boolean
-        get() = musicVideoType != null && musicVideoType != MUSIC_VIDEO_TYPE_ATV
+        get() = musicVideoType != null &&
+            musicVideoType != MUSIC_VIDEO_TYPE_ATV &&
+            musicVideoType != MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK
 
     data class Artist(
         val id: String?,
@@ -64,6 +68,7 @@ data class MediaMetadata(
             libraryRemoveToken = libraryRemoveToken,
             isVideo = isVideoSong,
             isEpisode = isEpisode,
+            isUploaded = musicVideoType == MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK,
             uploadEntityId = uploadEntityId
         )
 
@@ -108,10 +113,14 @@ fun Song.toMediaMetadata() =
             )
         },
         explicit = song.explicit,
-        // Use a non-ATV type if isVideo is true to indicate it's a video song
-        musicVideoType = if (song.isVideo) "MUSIC_VIDEO_TYPE_OMV" else null,
+        musicVideoType = when {
+            song.isUploaded -> MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK
+            song.isVideo -> MUSIC_VIDEO_TYPE_OMV
+            else -> null
+        },
         suggestedBy = null,
         isEpisode = song.isEpisode,
+        uploadEntityId = song.uploadEntityId,
     )
 
 /**

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -3248,7 +3248,26 @@ class MusicService :
                                                 .header("Proxy-Authorization", auth)
                                                 .build()
                                         } ?: response.request
-                                    }.build(),
+                                    }
+                                    .addInterceptor { chain ->
+                                        var request = chain.request()
+                                        if (request.url.queryParameter(PRIVATE_STREAM_MARKER) != null) {
+                                            val cleanUrl = request.url.newBuilder()
+                                                .removeAllQueryParameters(PRIVATE_STREAM_MARKER)
+                                                .build()
+                                            val host = cleanUrl.host
+                                            val builder = request.newBuilder().url(cleanUrl)
+                                            if (host == "youtube.com" ||
+                                                host.endsWith(".youtube.com") ||
+                                                host.endsWith(".googlevideo.com")
+                                            ) {
+                                                YouTube.cookie?.let { builder.header("Cookie", it) }
+                                            }
+                                            request = builder.build()
+                                        }
+                                        chain.proceed(request)
+                                    }
+                                    .build(),
                             ),
                         ),
                     ),
@@ -3484,10 +3503,12 @@ class MusicService :
             }
 
             Timber.tag(TAG).i("FETCHING STREAM: $mediaId | quality=$audioQuality")
+            val isUploaded = database.getSongByIdBlocking(mediaId)?.song?.isUploaded == true
             val playbackData =
                 runBlocking(Dispatchers.IO) {
                     YTPlayerUtils.playerResponseForPlayback(
                         mediaId,
+                        isUploadedHint = isUploaded,
                         audioQuality = audioQuality,
                         connectivityManager = connectivityManager,
                     )
@@ -3563,15 +3584,21 @@ class MusicService :
                 }
 
                 val streamUrl = nonNullPlayback.streamUrl
+                val finalUrl = if (nonNullPlayback.isPrivatelyOwned) {
+                    val separator = if ("?" in streamUrl) "&" else "?"
+                    "${streamUrl}${separator}${PRIVATE_STREAM_MARKER}=1"
+                } else {
+                    streamUrl
+                }
 
                 songUrlCache[mediaId] =
-                    streamUrl to System.currentTimeMillis() + (nonNullPlayback.streamExpiresInSeconds * 1000L)
+                    finalUrl to System.currentTimeMillis() + (nonNullPlayback.streamExpiresInSeconds * 1000L)
 
                 nonNullPlayback.playbackTracking?.videostatsPlaybackUrl?.baseUrl?.let {
                     playbackUrlCache[cacheKey(mediaId)] = it
                 }
 
-                return@Factory dataSpec.withUri(streamUrl.toUri()).subrange(dataSpec.uriPositionOffset, CHUNK_LENGTH)
+                return@Factory dataSpec.withUri(finalUrl.toUri()).subrange(dataSpec.uriPositionOffset, CHUNK_LENGTH)
             }
         }
     }
@@ -4561,6 +4588,7 @@ class MusicService :
         private const val MIN_GAIN_MB = -1500 // Minimum gain in millibels (-15 dB)
 
         private const val TAG = "MusicService"
+        private const val PRIVATE_STREAM_MARKER = "_metrolist_private"
 
         @Volatile
         var isRunning = false

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/PlaybackError.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/PlaybackError.kt
@@ -43,15 +43,15 @@ fun PlaybackError(
         ?: error.message 
         ?: stringResource(R.string.error_unknown)
     
-    // Check if this is an age-restricted content error
-    // Age-restricted content typically returns 403 Forbidden or contains age-related messages
-    val isAgeRestricted = rawErrorMessage.contains("age", ignoreCase = true) ||
-            rawErrorMessage.contains("Sign in to confirm your age", ignoreCase = true) ||
-            rawErrorMessage.contains("LOGIN_REQUIRED", ignoreCase = true) ||
+    // Only treat explicit age/login gate messages as age-restricted.
+    // HTTP 403 on stream URLs is usually a bad/expired URL or failed n-transform, not age gating.
+    val isAgeRestricted = rawErrorMessage.contains("Sign in to confirm your age", ignoreCase = true) ||
             rawErrorMessage.contains("confirm your age", ignoreCase = true) ||
-            rawErrorMessage.contains("403", ignoreCase = true) ||
-            rawErrorMessage.contains("Response code: 403", ignoreCase = true) ||
-            error.errorCode == PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS
+            rawErrorMessage.contains("AGE_CHECK_REQUIRED", ignoreCase = true) ||
+            rawErrorMessage.contains("AGE_VERIFICATION_REQUIRED", ignoreCase = true) ||
+            rawErrorMessage.contains("CONTENT_CHECK_REQUIRED", ignoreCase = true) ||
+            (rawErrorMessage.contains("age", ignoreCase = true) &&
+                rawErrorMessage.contains("restrict", ignoreCase = true))
     
     val errorMessage = if (isAgeRestricted) {
         "This app does not support playing age-restricted songs. We are working on fixing this issue."

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -23,6 +23,7 @@ import com.metrolist.innertube.models.YouTubeClient.Companion.TVHTML5_SIMPLY_EMB
 import com.metrolist.innertube.models.YouTubeClient.Companion.WEB
 import com.metrolist.innertube.models.YouTubeClient.Companion.WEB_CREATOR
 import com.metrolist.innertube.models.YouTubeClient.Companion.WEB_REMIX
+import com.metrolist.innertube.models.WatchEndpoint.WatchEndpointMusicSupportedConfigs.WatchEndpointMusicConfig.Companion.MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK
 import com.metrolist.innertube.models.response.PlayerResponse
 import com.metrolist.music.constants.AudioQuality
 import com.metrolist.music.utils.YTPlayerUtils.MAIN_CLIENT
@@ -39,6 +40,9 @@ import timber.log.Timber
 object YTPlayerUtils {
     private const val logTag = "YTPlayerUtils"
     private const val TAG = "YTPlayerUtils"
+    private const val UPLOADED_TRACKS_PLAYLIST_PREFIX = "MLPT"
+
+    private val WEB_CLIENTS = listOf("WEB", "WEB_REMIX", "WEB_CREATOR", "TVHTML5")
 
     private val httpClient = OkHttpClient.Builder()
         .proxy(YouTube.proxy)
@@ -69,6 +73,7 @@ object YTPlayerUtils {
         val format: PlayerResponse.StreamingData.Format,
         val streamUrl: String,
         val streamExpiresInSeconds: Int,
+        val isPrivatelyOwned: Boolean = false,
     )
     /**
      * Custom player response intended to use for playback.
@@ -78,6 +83,7 @@ object YTPlayerUtils {
     suspend fun playerResponseForPlayback(
         videoId: String,
         playlistId: String? = null,
+        isUploadedHint: Boolean = false,
         audioQuality: AudioQuality,
         connectivityManager: ConnectivityManager,
     ): Result<PlaybackData> = runCatching {
@@ -87,9 +93,9 @@ object YTPlayerUtils {
         Timber.tag(TAG).d("audioQuality: $audioQuality")
 
         // Check if this is an uploaded/privately owned track
-        val isUploadedTrack = playlistId == "MLPT" || playlistId?.contains("MLPT") == true
+        val isUploadedTrack = isUploadedHint || playlistId?.startsWith(UPLOADED_TRACKS_PLAYLIST_PREFIX) == true
         Timber.tag(TAG).d("Content type detection (preliminary):")
-        Timber.tag(TAG).d("  isUploadedTrack (from playlistId): $isUploadedTrack")
+        Timber.tag(TAG).d("  isUploadedTrack: $isUploadedTrack")
 
         val isLoggedIn = YouTube.cookie != null
         Timber.tag(TAG).d("Authentication status: ${if (isLoggedIn) "LOGGED_IN" else "ANONYMOUS"}")
@@ -129,12 +135,13 @@ object YTPlayerUtils {
         var usedAgeRestrictedClient: YouTubeClient? = null
         val wasOriginallyAgeRestricted: Boolean
 
-        // Check if WEB_REMIX response indicates age-restricted
+        // Check if WEB_REMIX response indicates age-restricted or login-required.
         val mainStatus = mainPlayerResponse.playabilityStatus.status
-        val isAgeRestrictedFromResponse = mainStatus in listOf("AGE_CHECK_REQUIRED", "AGE_VERIFICATION_REQUIRED", "LOGIN_REQUIRED", "CONTENT_CHECK_REQUIRED")
-        wasOriginallyAgeRestricted = isAgeRestrictedFromResponse
+        val isAgeRestrictedFromResponse = mainStatus in listOf("AGE_CHECK_REQUIRED", "AGE_VERIFICATION_REQUIRED", "CONTENT_CHECK_REQUIRED")
+        val isLoginRequired = mainStatus == "LOGIN_REQUIRED"
+        wasOriginallyAgeRestricted = isAgeRestrictedFromResponse || (isLoginRequired && !isUploadedTrack)
 
-        if (isAgeRestrictedFromResponse && isLoggedIn) {
+        if ((isAgeRestrictedFromResponse || isLoginRequired) && isLoggedIn) {
             // Age-restricted: use WEB_CREATOR directly (no NewPipe needed from here)
             Timber.tag(logTag).d("Age-restricted detected, using WEB_CREATOR")
             Timber.tag(TAG).i("Age-restricted: using WEB_CREATOR for videoId=$videoId")
@@ -155,11 +162,16 @@ object YTPlayerUtils {
         var streamUrl: String? = null
         var streamExpiresInSeconds: Int? = null
         var streamPlayerResponse: PlayerResponse? = null
+        var privateCandidateStreamUrl: String? = null
+        var privateCandidateFormat: PlayerResponse.StreamingData.Format? = null
+        var privateCandidateExpiry: Int? = null
+        var privateCandidateResponse: PlayerResponse? = null
         val retryMainPlayerResponse: PlayerResponse? = if (usedAgeRestrictedClient != null) mainPlayerResponse else null
 
         // Check current status
         val currentStatus = mainPlayerResponse.playabilityStatus.status
-        val isAgeRestricted = currentStatus in listOf("AGE_CHECK_REQUIRED", "AGE_VERIFICATION_REQUIRED", "LOGIN_REQUIRED", "CONTENT_CHECK_REQUIRED")
+        val isAgeRestricted = currentStatus in listOf("AGE_CHECK_REQUIRED", "AGE_VERIFICATION_REQUIRED", "CONTENT_CHECK_REQUIRED") ||
+            (!isUploadedTrack && currentStatus == "LOGIN_REQUIRED")
 
         if (isAgeRestricted) {
             Timber.tag(logTag).d("Content is still age-restricted (status: $currentStatus), will try fallback clients")
@@ -167,9 +179,15 @@ object YTPlayerUtils {
                 .i("Age-restricted content detected: videoId=$videoId, status=$currentStatus")
         }
 
+        val isPrivateTrack = isUploadedTrack ||
+            mainPlayerResponse.videoDetails?.musicVideoType == MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK
+
         // For age-restricted: skip main client, start with fallbacks
         // For normal content: standard order
         val startIndex = when {
+            isPrivateTrack && usedAgeRestrictedClient != null -> -1
+            isPrivateTrack && mainPlayerResponse.playabilityStatus.status == "OK" -> -1
+            isPrivateTrack -> 1
             isAgeRestricted -> 0
             else -> -1
         }
@@ -218,9 +236,11 @@ object YTPlayerUtils {
             if (streamPlayerResponse?.playabilityStatus?.status == "OK") {
                 Timber.tag(logTag).d("Player response status OK for client: ${if (clientIndex == -1) MAIN_CLIENT.clientName else STREAM_FALLBACK_CLIENTS[clientIndex].clientName}")
 
-                // Skip NewPipe for age-restricted content (NewPipe doesn't use our auth)
-                val responseToUse = if (wasOriginallyAgeRestricted) {
-                    Timber.tag(logTag).d("Skipping NewPipe for age-restricted content")
+                val isPrivateContent = isPrivateTrack ||
+                    streamPlayerResponse.videoDetails?.musicVideoType == MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK
+                val skipNewPipe = wasOriginallyAgeRestricted || isPrivateContent
+                val responseToUse = if (skipNewPipe) {
+                    Timber.tag(logTag).d("Skipping NewPipe: ageRestricted=$wasOriginallyAgeRestricted, private=$isPrivateContent")
                     streamPlayerResponse
                 } else {
                     // Try to get streams using newPipePlayer method
@@ -252,7 +272,7 @@ object YTPlayerUtils {
 
                 Timber.tag(logTag).d("Format found: ${format.mimeType}, bitrate: ${format.bitrate}")
 
-                streamUrl = findUrlOrNull(format, videoId, responseToUse, skipNewPipe = wasOriginallyAgeRestricted)
+                streamUrl = findUrlOrNull(format, videoId, responseToUse, skipNewPipe = skipNewPipe)
                 if (streamUrl == null) {
                     Timber.tag(logTag).d("Stream URL not found for format")
                     continue
@@ -265,11 +285,14 @@ object YTPlayerUtils {
                     STREAM_FALLBACK_CLIENTS[clientIndex]
                 }
 
+                val isPrivatelyOwnedTrack = isPrivateTrack ||
+                    streamPlayerResponse.videoDetails?.musicVideoType == MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK
                 val musicVideoType = streamPlayerResponse.videoDetails?.musicVideoType
 
                 Timber.tag(TAG).d("=== N-TRANSFORM DECISION ===")
                 Timber.tag(TAG).d("Content type analysis:")
                 Timber.tag(TAG).d("  musicVideoType: $musicVideoType")
+                Timber.tag(TAG).d("  isPrivatelyOwnedTrack: $isPrivatelyOwnedTrack")
                 Timber.tag(TAG).d("  isUploadedTrack (from playlistId): $isUploadedTrack")
                 Timber.tag(TAG).d("  wasOriginallyAgeRestricted: $wasOriginallyAgeRestricted")
                 Timber.tag(TAG).d("Client analysis:")
@@ -278,12 +301,14 @@ object YTPlayerUtils {
 
                 // Apply n-transform and PoToken for web clients (WEB, WEB_REMIX, WEB_CREATOR, TVHTML5)
                 val needsNTransform = currentClient.useWebPoTokens ||
-                    currentClient.clientName in listOf("WEB", "WEB_REMIX", "WEB_CREATOR", "TVHTML5")
+                    currentClient.clientName in WEB_CLIENTS ||
+                    isPrivatelyOwnedTrack
 
                 Timber.tag(TAG).d("N-transform decision:")
                 Timber.tag(TAG).d("  needsNTransform: $needsNTransform")
                 Timber.tag(TAG).d("  Reason: useWebPoTokens=${currentClient.useWebPoTokens}, " +
-                    "clientInList=${currentClient.clientName in listOf("WEB", "WEB_REMIX", "WEB_CREATOR", "TVHTML5")}")
+                    "clientInList=${currentClient.clientName in WEB_CLIENTS}, " +
+                    "isPrivatelyOwnedTrack=$isPrivatelyOwnedTrack")
 
                 if (needsNTransform) {
                     try {
@@ -299,7 +324,8 @@ object YTPlayerUtils {
                         Timber.tag(TAG).d("  URL changed: ${originalUrl != streamUrl}")
 
                         // Append pot= parameter with streaming data poToken
-                        val needsPoToken = currentClient.useWebPoTokens && poToken?.streamingDataPoToken != null
+                        val needsPoToken = (currentClient.useWebPoTokens || isPrivatelyOwnedTrack) &&
+                            poToken?.streamingDataPoToken != null
                         Timber.tag(TAG).d("PoToken decision:")
                         Timber.tag(TAG).d("  needsPoToken: $needsPoToken")
                         Timber.tag(TAG).d("  hasStreamingDataPoToken: ${poToken?.streamingDataPoToken != null}")
@@ -367,6 +393,17 @@ object YTPlayerUtils {
                     break
                 }
 
+                if (isPrivatelyOwnedTrack) {
+                    if (privateCandidateStreamUrl == null) {
+                        Timber.tag(logTag).d("Skipping validation for privately owned track, recording first candidate: ${currentClient.clientName}")
+                        privateCandidateStreamUrl = streamUrl
+                        privateCandidateFormat = format
+                        privateCandidateExpiry = streamExpiresInSeconds
+                        privateCandidateResponse = streamPlayerResponse
+                    }
+                    continue
+                }
+
                 if (validateStatus(streamUrl)) {
                     // working stream found
                     Timber.tag(logTag).d("Stream validated successfully with client: ${currentClient.clientName}")
@@ -379,6 +416,13 @@ object YTPlayerUtils {
             } else {
                 Timber.tag(logTag).d("Player response status not OK: ${streamPlayerResponse?.playabilityStatus?.status}, reason: ${streamPlayerResponse?.playabilityStatus?.reason}")
             }
+        }
+
+        if (streamUrl == null && privateCandidateStreamUrl != null) {
+            streamUrl = privateCandidateStreamUrl
+            format = privateCandidateFormat
+            streamExpiresInSeconds = privateCandidateExpiry
+            streamPlayerResponse = privateCandidateResponse
         }
 
         if (audioQuality == AudioQuality.HIGH && format?.audioQuality != "AUDIO_QUALITY_HIGH" && bestFallbackFormat != null) {
@@ -438,6 +482,8 @@ object YTPlayerUtils {
             format,
             streamUrl,
             streamExpiresInSeconds,
+            isPrivatelyOwned = isPrivateTrack ||
+                streamPlayerResponse.videoDetails?.musicVideoType == MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK,
         )
     }.onFailure { e ->
         println("[PLAYBACK_DEBUG] EXCEPTION during playback for videoId=$videoId: ${e::class.simpleName}: ${e.message}")

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherDeobfuscator.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherDeobfuscator.kt
@@ -196,9 +196,12 @@ object CipherDeobfuscator {
         Timber.tag(TAG).d("Analyzing player JS for cipher functions (knownHash=$hash)...")
         val analysis = FunctionNameExtractor.analyzePlayerJs(playerJs, knownHash = hash)
 
-        if (analysis.sigInfo == null) {
-            Timber.tag(TAG).e("Could not extract signature function info from player JS")
+        if (analysis.sigInfo == null && analysis.nFuncInfo == null) {
+            Timber.tag(TAG).e("Could not extract signature or n-function info from player JS")
             return null
+        }
+        if (analysis.sigInfo == null) {
+            Timber.tag(TAG).w("Sig function not found (direct URLs?) ΓÇö WebView created for n-transform only")
         }
 
         if (analysis.nFuncInfo == null) {
@@ -206,7 +209,9 @@ object CipherDeobfuscator {
         }
 
         Timber.tag(TAG).d("Creating CipherWebView...")
-        Timber.tag(TAG).d("  sig: ${analysis.sigInfo.name} (constantArg=${analysis.sigInfo.constantArg}, hardcoded=${analysis.sigInfo.isHardcoded})")
+        analysis.sigInfo?.let { sig ->
+            Timber.tag(TAG).d("  sig: ${sig.name} (constantArg=${sig.constantArg}, hardcoded=${sig.isHardcoded})")
+        }
         Timber.tag(TAG).d("  nFunc: ${analysis.nFuncInfo?.name}[${analysis.nFuncInfo?.arrayIndex}] (hardcoded=${analysis.nFuncInfo?.isHardcoded})")
 
         // Create WebView

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherWebView.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherWebView.kt
@@ -103,7 +103,7 @@ class CipherWebView private constructor(
         usingHardcodedMode = isHardcoded
 
         val exports = buildList {
-            if (sigFuncName != null) {
+            if (!sigFuncName.isNullOrEmpty()) {
                 val sigConstArgs = sigInfo.constantArgs
                 val preprocessFunc = sigInfo.preprocessFunc
                 val preprocessArgs = sigInfo.preprocessArgs
@@ -130,7 +130,21 @@ class CipherWebView private constructor(
             }
             if (nFuncName != null) {
                 val nConstArgs = nFuncInfo.constantArgs
-                if (!nConstArgs.isNullOrEmpty()) {
+                if (nFuncName == "__URL_PARSER__") {
+                    // June 2026+: n-transform via URL parser (W_ on 4f38b487, uY on 9d2ef9ef+)
+                    Timber.tag(TAG).d("N-function uses URL parser mode (_yt_player.uY / W_)")
+                    add("""window._nTransformFunc = function(n) {
+                        try {
+                            var url = 'https://rr1.c.youtube.com/videoplayback?n=' + encodeURIComponent(n);
+                            var Parser = (typeof _yt_player.uY === 'function') ? _yt_player.uY
+                                : (typeof _yt_player.W_ === 'function' ? _yt_player.W_ : null);
+                            if (!Parser) return n;
+                            var parsed = new Parser(url, true);
+                            var result = parsed.get('n');
+                            return (result && typeof result === 'string' && result !== n) ? result : n;
+                        } catch(e) { return n; }
+                    };""".trimIndent().replace("\n", " "))
+                } else if (!nConstArgs.isNullOrEmpty()) {
                     // Generate wrapper function for n-functions that require constant args
                     // e.g. GU(6, 6010, n) -> window._nTransformFunc = function(n) { return GU(6, 6010, n); };
                     val argsStr = nConstArgs.joinToString(", ")

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/FunctionNameExtractor.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/FunctionNameExtractor.kt
@@ -89,7 +89,36 @@ object FunctionNameExtractor {
             nArrayIndex = null,
             nConstantArgs = null,
             signatureTimestamp = 20591
+        ),
+        // June 2026: direct URLs, n-transform via _yt_player.W_ URL parser (AVj wrapper)
+        "4f38b487" to HardcodedPlayerConfig(
+            sigFuncName = "",
+            sigConstantArg = null,
+            sigConstantArgs = null,
+            sigPreprocessFunc = null,
+            sigPreprocessArgs = null,
+            nFuncName = "__URL_PARSER__",
+            nArrayIndex = null,
+            nConstantArgs = null,
+            signatureTimestamp = 20602
+        ),
+        // June 2026 RC: same URL-parser n-transform, class renamed to g.uY (bIR wrapper)
+        "9d2ef9ef" to HardcodedPlayerConfig(
+            sigFuncName = "",
+            sigConstantArg = null,
+            sigConstantArgs = null,
+            sigPreprocessFunc = null,
+            sigPreprocessArgs = null,
+            nFuncName = "__URL_PARSER__",
+            nArrayIndex = null,
+            nConstantArgs = null,
+            signatureTimestamp = 20607
         )
+    )
+
+    // Players that rewrite n= via (new g.uY(url,true)).get("n") or (new g.W_(url,true)).get("n")
+    private val URL_PARSER_N_TRANSFORM_PATTERN = Regex(
+        """\(new\s+g\.(?:uY|W_)\([^,]+,!0\)\)\.get\("n"\)"""
     )
 
     // ==================== DETECTION PATTERNS ====================
@@ -130,6 +159,8 @@ object FunctionNameExtractor {
         Regex("""\(\s*([a-zA-Z0-9$]+)\s*=\s*String\.fromCharCode\(110\)"""),
         // Pattern 5: enhanced_except_ function pattern
         Regex("""([a-zA-Z0-9$]+)\s*=\s*function\([a-zA-Z0-9]\)\s*\{[^}]*?enhanced_except_"""),
+        // Pattern 6: AVj-style URL parser (June 2026+): FUNC=function(x){try{var y=(new g.W_(x,!0)).get("n")
+        Regex("""([a-zA-Z0-9$]+)=function\([a-zA-Z0-9$]+\)\{try\{var\s+[a-zA-Z0-9$]+=\(new\s+[a-zA-Z0-9$.]+\.W_\([a-zA-Z0-9$]+,!0\)\)\.get\("n"\)"""),
     )
 
     // ==================== EXTRACTION FUNCTIONS ====================
@@ -224,27 +255,22 @@ object FunctionNameExtractor {
             }
         }
 
-        Timber.tag(TAG).w("No sig pattern matched, checking for Q-array obfuscation...")
+        Timber.tag(TAG).w("No sig pattern matched, trying hardcoded config...")
 
-        // Check for Q-array obfuscation and use hardcoded fallback
-        if (hasQArrayObfuscation(playerJs)) {
-            // Use knownHash if provided, otherwise try to extract
-            val hashToUse = knownHash ?: extractPlayerHash(playerJs)
-            Timber.tag(TAG).d("Using hash for hardcoded lookup: $hashToUse (knownHash=$knownHash)")
-            if (hashToUse != null) {
-                val config = getHardcodedConfig(hashToUse)
-                if (config != null) {
-                    Timber.tag(TAG).d("USING HARDCODED SIG FUNCTION: ${config.sigFuncName}(${config.sigConstantArgs}, ...)")
-                    Timber.tag(TAG).d("Sig preprocess: ${config.sigPreprocessFunc}(${config.sigPreprocessArgs}, sig)")
-                    return SigFunctionInfo(
-                        name = config.sigFuncName,
-                        constantArg = config.sigConstantArg,
-                        constantArgs = config.sigConstantArgs,
-                        preprocessFunc = config.sigPreprocessFunc,
-                        preprocessArgs = config.sigPreprocessArgs,
-                        isHardcoded = true
-                    )
-                }
+        val hashToUse = knownHash ?: if (hasQArrayObfuscation(playerJs)) extractPlayerHash(playerJs) else null
+        if (hashToUse != null) {
+            val config = getHardcodedConfig(hashToUse)
+            if (config != null && config.sigFuncName.isNotEmpty()) {
+                Timber.tag(TAG).d("USING HARDCODED SIG FUNCTION: ${config.sigFuncName}(${config.sigConstantArgs}, ...)")
+                Timber.tag(TAG).d("Sig preprocess: ${config.sigPreprocessFunc}(${config.sigPreprocessArgs}, sig)")
+                return SigFunctionInfo(
+                    name = config.sigFuncName,
+                    constantArg = config.sigConstantArg,
+                    constantArgs = config.sigConstantArgs,
+                    preprocessFunc = config.sigPreprocessFunc,
+                    preprocessArgs = config.sigPreprocessArgs,
+                    isHardcoded = true
+                )
             }
         }
 
@@ -301,21 +327,21 @@ object FunctionNameExtractor {
             }
         }
 
-        Timber.tag(TAG).w("No n-func pattern matched, checking for Q-array obfuscation...")
+        Timber.tag(TAG).w("No n-func pattern matched, trying hardcoded config...")
 
-        // Check for Q-array obfuscation and use hardcoded fallback
-        if (hasQArrayObfuscation(playerJs)) {
-            // Use knownHash if provided, otherwise try to extract
-            val hashToUse = knownHash ?: extractPlayerHash(playerJs)
-            Timber.tag(TAG).d("Using hash for hardcoded lookup: $hashToUse (knownHash=$knownHash)")
-            if (hashToUse != null) {
-                val config = getHardcodedConfig(hashToUse)
-                if (config != null) {
-                    Timber.tag(TAG).d("USING HARDCODED N-FUNCTION: ${config.nFuncName}[${config.nArrayIndex}]")
-                    Timber.tag(TAG).d("N-function constant args: ${config.nConstantArgs}")
-                    return NFunctionInfo(config.nFuncName, config.nArrayIndex, config.nConstantArgs, isHardcoded = true)
-                }
+        val hashToUse = knownHash ?: if (hasQArrayObfuscation(playerJs)) extractPlayerHash(playerJs) else null
+        if (hashToUse != null) {
+            val config = getHardcodedConfig(hashToUse)
+            if (config != null && config.nFuncName.isNotEmpty()) {
+                Timber.tag(TAG).d("USING HARDCODED N-FUNCTION: ${config.nFuncName}[${config.nArrayIndex}]")
+                Timber.tag(TAG).d("N-function constant args: ${config.nConstantArgs}")
+                return NFunctionInfo(config.nFuncName, config.nArrayIndex, config.nConstantArgs, isHardcoded = true)
             }
+        }
+
+        if (URL_PARSER_N_TRANSFORM_PATTERN.containsMatchIn(playerJs)) {
+            Timber.tag(TAG).d("USING URL-PARSER N-TRANSFORM (detected g.uY/g.W_ in player.js)")
+            return NFunctionInfo("__URL_PARSER__", null, null, isHardcoded = true)
         }
 
         Timber.tag(TAG).e("========== N-FUNCTION EXTRACTION FAILED ==========")

--- a/innertube/src/main/kotlin/com/metrolist/innertube/models/Endpoint.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/models/Endpoint.kt
@@ -32,6 +32,7 @@ data class WatchEndpoint(
                 const val MUSIC_VIDEO_TYPE_OMV = "MUSIC_VIDEO_TYPE_OMV"
                 const val MUSIC_VIDEO_TYPE_UGC = "MUSIC_VIDEO_TYPE_UGC"
                 const val MUSIC_VIDEO_TYPE_ATV = "MUSIC_VIDEO_TYPE_ATV"
+                const val MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK = "MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK"
             }
         }
     }


### PR DESCRIPTION
## Problem
- Uploaded (privately owned) songs fail to play, resulting in 403 or 2000 error, or incorrectly showing "age-restricted" messages.

## Cause
- YouTube players `4f38b487` / `9d2ef9ef` rewrite the throttle `n` parameter via URL-parser classes (`g.W_` / `g.uY`). Since these were not implemented in the app's hardcoded configurations, the app failed to apply the `n-transform`, causing YouTube to return 403 HTTP status. This then misleads ExoPlayer to report 2004 (`IO_BAD_HTTP_STATUS`) surfaced as age-restricted or 2000 (`REMOTE_ERROR`).
- Constant missing for `MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK` leading to missing type support.

## Solution
- Added support for URL-parser based `n-transform` for the players `4f38b487` and `9d2ef9ef` within `FunctionNameExtractor` and `CipherWebView`.
- Handled private video streaming markers and fallback correctly inside `MusicService` and `YTPlayerUtils` by implementing logic for `MUSIC_VIDEO_TYPE_PRIVATELY_OWNED_TRACK`.

## Testing
- Verified through successful compilation (`./gradlew :app:assembleFossDebug`).
- Confirmed correct logic integration across ExoPlayer and WebView.

## Related Issues
- Related to #3910


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for playback of privately owned music tracks.

* **Improvements**
  * Enhanced detection of age-restricted content with more accurate matching.
  * Improved stream URL handling and caching for private content.
  * Better extraction of streaming parameters for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->