### PR TITLE
fix(innertube): new player.sj - correct PoToken binding and cipher deobfuscation - add new client visionOS - fix age-restricted/uploaded

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -314,6 +314,7 @@ class MusicService :
     lateinit var connectivityObserver: NetworkConnectivityObserver
     val waitingForNetworkConnection = MutableStateFlow(false)
     private val isNetworkConnected = MutableStateFlow(false)
+    val currentStreamClient = MutableStateFlow<String?>(null)
 
     private lateinit var audioQuality: com.metrolist.music.constants.AudioQuality
 
@@ -3563,6 +3564,7 @@ class MusicService :
                 }
 
                 val streamUrl = nonNullPlayback.streamUrl
+                currentStreamClient.value = nonNullPlayback.streamClient
 
                 songUrlCache[mediaId] =
                     streamUrl to System.currentTimeMillis() + (nonNullPlayback.streamExpiresInSeconds * 1000L)

--- a/app/src/main/kotlin/com/metrolist/music/playback/PlayerConnection.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/PlayerConnection.kt
@@ -173,6 +173,7 @@ class PlayerConnection(
 
     val error = MutableStateFlow<PlaybackException?>(null)
     val isMuted = service.isMuted
+    val currentStreamClient = service.currentStreamClient
 
     val waitingForNetworkConnection = service.waitingForNetworkConnection
 

--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/ShowMediaInfo.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/ShowMediaInfo.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -80,6 +81,7 @@ fun ShowMediaInfo(videoId: String) {
     var currentFormat by remember { mutableStateOf<FormatEntity?>(null) }
 
     val playerConnection = LocalPlayerConnection.current
+    val currentStreamClient by playerConnection?.currentStreamClient?.collectAsState() ?: remember { mutableStateOf(null) }
     val context = LocalContext.current
 
     val loudnessLevel by rememberEnumPreference(
@@ -135,6 +137,7 @@ fun ShowMediaInfo(videoId: String) {
                         R.drawable.media3_icon_thumb_up_unfilled,
                         R.drawable.media3_icon_thumb_down_unfilled,
                         R.drawable.key,
+                        R.drawable.play,
                         R.drawable.info,
                         R.drawable.radio,
                         R.drawable.gradient,
@@ -153,6 +156,7 @@ fun ShowMediaInfo(videoId: String) {
                             stringResource(R.string.likes) to info?.like?.let(::numberFormatter).orEmpty(),
                             stringResource(R.string.dislikes) to info?.dislike?.let(::numberFormatter).orEmpty(),
                             "Itag" to currentFormat?.itag?.toString(),
+                            stringResource(R.string.stream_client) to currentStreamClient,
                             stringResource(R.string.mime_type) to currentFormat?.mimeType,
                             stringResource(R.string.codecs) to currentFormat?.codecs,
                             stringResource(R.string.bitrate) to currentFormat?.bitrate?.let { "${it / 1000} Kbps" },

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -103,7 +103,7 @@ object YTPlayerUtils {
 
         // Generate PoToken
         var poToken: PoTokenResult? = null
-        val sessionId = if (isLoggedIn) YouTube.dataSyncId else YouTube.visitorData
+        val sessionId = YouTube.visitorData
         if (MAIN_CLIENT.useWebPoTokens && sessionId != null) {
             Timber.tag(logTag).d("Generating PoToken for WEB_REMIX with sessionId")
             try {
@@ -463,8 +463,7 @@ object YTPlayerUtils {
     ): Result<PlayerResponse> {
         Timber.tag(logTag).d("Fetching metadata player response for videoId: $videoId using MAIN_CLIENT: ${MAIN_CLIENT.clientName}")
         val signatureTimestamp = getSignatureTimestampOrNull(videoId)
-        val isLoggedIn = YouTube.cookie != null
-        val sessionId = if (isLoggedIn) YouTube.dataSyncId else YouTube.visitorData
+        val sessionId = YouTube.visitorData
         var poToken: PoTokenResult? = null
         if (MAIN_CLIENT.useWebPoTokens && sessionId != null) {
             try {

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -20,6 +20,7 @@ import com.metrolist.innertube.models.YouTubeClient.Companion.IPADOS
 import com.metrolist.innertube.models.YouTubeClient.Companion.MOBILE
 import com.metrolist.innertube.models.YouTubeClient.Companion.TVHTML5
 import com.metrolist.innertube.models.YouTubeClient.Companion.TVHTML5_SIMPLY_EMBEDDED_PLAYER
+import com.metrolist.innertube.models.YouTubeClient.Companion.VISIONOS
 import com.metrolist.innertube.models.YouTubeClient.Companion.WEB
 import com.metrolist.innertube.models.YouTubeClient.Companion.WEB_CREATOR
 import com.metrolist.innertube.models.YouTubeClient.Companion.WEB_REMIX
@@ -46,20 +47,21 @@ object YTPlayerUtils {
 
     private val poTokenGenerator = PoTokenGenerator()
 
-    private val MAIN_CLIENT: YouTubeClient = WEB_REMIX
+    private val MAIN_CLIENT: YouTubeClient = VISIONOS
 
     private val STREAM_FALLBACK_CLIENTS: Array<YouTubeClient> = arrayOf(
-        TVHTML5_SIMPLY_EMBEDDED_PLAYER,  // Try embedded player first for age-restricted content
+        WEB_REMIX,
+        WEB_CREATOR,
+        TVHTML5_SIMPLY_EMBEDDED_PLAYER,
         TVHTML5,
         ANDROID_VR_1_43_32,
         ANDROID_VR_1_61_48,
-        ANDROID_CREATOR,
+        IOS,
         IPADOS,
+        ANDROID_CREATOR,
         ANDROID_VR_NO_AUTH,
         MOBILE,
-        IOS,
         WEB,
-        WEB_CREATOR
     )
 
     data class PlaybackData(
@@ -69,6 +71,7 @@ object YTPlayerUtils {
         val format: PlayerResponse.StreamingData.Format,
         val streamUrl: String,
         val streamExpiresInSeconds: Int,
+        val streamClient: String = "unknown",
     )
     /**
      * Custom player response intended to use for playback.
@@ -178,6 +181,8 @@ object YTPlayerUtils {
         var bestFallbackUrl: String? = null
         var bestFallbackExpiry: Int? = null
         var bestFallbackResponse: PlayerResponse? = null
+        var bestFallbackClient: String? = null
+        var successClient: String? = null
 
         val hasHighQuality = mainPlayerResponse.streamingData?.adaptiveFormats?.any { it.audioQuality == "AUDIO_QUALITY_HIGH" } == true
 
@@ -355,6 +360,7 @@ object YTPlayerUtils {
                         bestFallbackUrl = streamUrl
                         bestFallbackExpiry = streamExpiresInSeconds
                         bestFallbackResponse = streamPlayerResponse
+                        bestFallbackClient = currentClient.clientName
                     }
                     continue
                 }
@@ -364,6 +370,7 @@ object YTPlayerUtils {
                     Timber.tag(logTag).d("Using last fallback client without validation: ${STREAM_FALLBACK_CLIENTS[clientIndex].clientName}")
                     Timber.tag(TAG)
                         .i("Playback: client=${currentClient.clientName}, videoId=$videoId")
+                    successClient = currentClient.clientName
                     break
                 }
 
@@ -372,6 +379,7 @@ object YTPlayerUtils {
                     Timber.tag(logTag).d("Stream validated successfully with client: ${currentClient.clientName}")
                     // Log for release builds
                     Timber.tag(TAG).i("Playback: client=${currentClient.clientName}, videoId=$videoId")
+                    successClient = currentClient.clientName
                     break
                 } else {
                     Timber.tag(logTag).d("Stream validation failed for client: ${currentClient.clientName}")
@@ -387,6 +395,7 @@ object YTPlayerUtils {
             streamUrl = bestFallbackUrl
             streamExpiresInSeconds = bestFallbackExpiry
             streamPlayerResponse = bestFallbackResponse
+            successClient = bestFallbackClient
         }
 
         if (streamPlayerResponse == null) {
@@ -438,6 +447,7 @@ object YTPlayerUtils {
             format,
             streamUrl,
             streamExpiresInSeconds,
+            streamClient = successClient ?: "unknown",
         )
     }.onFailure { e ->
         println("[PLAYBACK_DEBUG] EXCEPTION during playback for videoId=$videoId: ${e::class.simpleName}: ${e.message}")

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -47,10 +47,10 @@ object YTPlayerUtils {
 
     private val poTokenGenerator = PoTokenGenerator()
 
-    private val MAIN_CLIENT: YouTubeClient = VISIONOS
+    private val MAIN_CLIENT: YouTubeClient = WEB_REMIX
 
     private val STREAM_FALLBACK_CLIENTS: Array<YouTubeClient> = arrayOf(
-        WEB_REMIX,
+        VISIONOS,
         WEB_CREATOR,
         TVHTML5_SIMPLY_EMBEDDED_PLAYER,
         TVHTML5,

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherDeobfuscator.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherDeobfuscator.kt
@@ -3,6 +3,8 @@ package com.metrolist.music.utils.cipher
 import android.content.Context
 import android.net.Uri
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
@@ -26,6 +28,7 @@ object CipherDeobfuscator {
 
     private var cipherWebView: CipherWebView? = null
     private var currentPlayerHash: String? = null
+    private val deobfuscateMutex = Mutex()
 
     /**
      * Deobfuscate a signatureCipher stream URL.
@@ -37,17 +40,11 @@ object CipherDeobfuscator {
      *
      * Returns the full URL with deobfuscated signature, or null if failed.
      */
-    suspend fun deobfuscateStreamUrl(signatureCipher: String, videoId: String): String? {
-        Timber.tag(TAG).d("=== DEOBFUSCATE STREAM URL ===")
-        Timber.tag(TAG).d("videoId: $videoId")
-        Timber.tag(TAG).d("signatureCipher length: ${signatureCipher.length}")
-        Timber.tag(TAG).d("signatureCipher preview: ${signatureCipher.take(100)}...")
-
-        return try {
+    suspend fun deobfuscateStreamUrl(signatureCipher: String, videoId: String): String? = deobfuscateMutex.withLock {
+        try {
             deobfuscateInternal(signatureCipher, videoId, isRetry = false)
         } catch (e: Exception) {
             Timber.tag(TAG).e(e, "Cipher deobfuscation failed, retrying with fresh JS: ${e.message}")
-            Timber.tag(TAG).d("Invalidating cache and retrying...")
             try {
                 PlayerJsFetcher.invalidateCache()
                 closeWebView()

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherWebView.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherWebView.kt
@@ -103,36 +103,41 @@ class CipherWebView private constructor(
         usingHardcodedMode = isHardcoded
 
         val exports = buildList {
-            if (sigFuncName != null) {
-                val sigConstArgs = sigInfo.constantArgs
-                val preprocessFunc = sigInfo.preprocessFunc
-                val preprocessArgs = sigInfo.preprocessArgs
+            val sigJsExpr = sigInfo?.jsExpression
+            if (sigJsExpr != null) {
+                val expr = sigJsExpr.replace("INPUT", "sig")
+                Timber.tag(TAG).d("Sig: expression-based export: $expr")
+                add("window._cipherSigFunc = function(sig) { try { return $expr; } catch(e) { return null; } };")
+            } else if (sigFuncName != null) {
+                val sigConstArgs = sigInfo?.constantArgs
+                val preprocessFunc = sigInfo?.preprocessFunc
+                val preprocessArgs = sigInfo?.preprocessArgs
 
                 if (!sigConstArgs.isNullOrEmpty() && preprocessFunc != null && !preprocessArgs.isNullOrEmpty()) {
-                    // Full wrapper: JI(48, 1918, f1(1, 6528, sig))
                     val mainArgsStr = sigConstArgs.joinToString(", ")
                     val prepArgsStr = preprocessArgs.joinToString(", ")
                     Timber.tag(TAG).d("Sig function needs full wrapper:")
                     Timber.tag(TAG).d("  $sigFuncName($mainArgsStr, $preprocessFunc($prepArgsStr, sig))")
                     add("window._cipherSigFunc = function(sig) { return $sigFuncName($mainArgsStr, $preprocessFunc($prepArgsStr, sig)); };")
                 } else if (!sigConstArgs.isNullOrEmpty()) {
-                    // Wrapper with constant args only (no preprocessing)
                     val argsStr = sigConstArgs.joinToString(", ")
                     Timber.tag(TAG).d("Sig function needs wrapper with constant args: $argsStr")
                     add("window._cipherSigFunc = function(sig) { return $sigFuncName($argsStr, sig); };")
                 } else if (isHardcoded) {
-                    // For hardcoded mode without full args, we'll inject the function export after player.js loads
                     Timber.tag(TAG).d("Will export sig function $sigFuncName in hardcoded mode (legacy)")
                     add("window._cipherSigFunc = typeof $sigFuncName !== 'undefined' ? $sigFuncName : null;")
                 } else {
                     add("window._cipherSigFunc = typeof $sigFuncName !== 'undefined' ? $sigFuncName : null;")
                 }
             }
-            if (nFuncName != null) {
-                val nConstArgs = nFuncInfo.constantArgs
+            val nJsExpr = nFuncInfo?.jsExpression
+            if (nJsExpr != null) {
+                val expr = nJsExpr.replace("INPUT", "n")
+                Timber.tag(TAG).d("N: expression-based export: ${expr.take(80)}")
+                add("window._nTransformFunc = function(n) { try { return $expr; } catch(e) { return n; } };")
+            } else if (nFuncName != null) {
+                val nConstArgs = nFuncInfo?.constantArgs
                 if (!nConstArgs.isNullOrEmpty()) {
-                    // Generate wrapper function for n-functions that require constant args
-                    // e.g. GU(6, 6010, n) -> window._nTransformFunc = function(n) { return GU(6, 6010, n); };
                     val argsStr = nConstArgs.joinToString(", ")
                     Timber.tag(TAG).d("N-function needs wrapper with constant args: $argsStr")
                     add("window._nTransformFunc = function(n) { return $nFuncName($argsStr, n); };")

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/FunctionNameExtractor.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/FunctionNameExtractor.kt
@@ -115,6 +115,28 @@ object FunctionNameExtractor {
             nConstantArgs = null,
             nJsExpression = "(function(n){try{var u=new g.iE('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
             signatureTimestamp = 20611
+        ),
+        // player_ias 9d2ef9ef (2026-06-08): VM-dispatch via v0/n7/uY. STS 20607.
+        "9d2ef9ef" to HardcodedPlayerConfig(
+            sigFuncName = "_expr_sig",
+            sigConstantArg = null,
+            sigJsExpression = "v0(35,4499,INPUT)",
+            nFuncName = "_expr_n",
+            nArrayIndex = null,
+            nConstantArgs = null,
+            nJsExpression = "(function(n){try{var u=new g.uY('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
+            signatureTimestamp = 20607
+        ),
+        // MD5-fallback alias for 9d2ef9ef
+        "6fb43da5" to HardcodedPlayerConfig(
+            sigFuncName = "_expr_sig",
+            sigConstantArg = null,
+            sigJsExpression = "v0(35,4499,INPUT)",
+            nFuncName = "_expr_n",
+            nArrayIndex = null,
+            nConstantArgs = null,
+            nJsExpression = "(function(n){try{var u=new g.uY('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
+            signatureTimestamp = 20607
         )
     )
 

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/FunctionNameExtractor.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/FunctionNameExtractor.kt
@@ -250,32 +250,28 @@ object FunctionNameExtractor {
             }
         }
 
-        Timber.tag(TAG).w("No sig pattern matched, checking for Q-array obfuscation...")
+        Timber.tag(TAG).w("No sig pattern matched, trying hardcoded config...")
 
-        // Check for Q-array obfuscation and use hardcoded fallback
-        if (hasQArrayObfuscation(playerJs)) {
-            // Use knownHash if provided, otherwise try to extract
-            val hashToUse = knownHash ?: extractPlayerHash(playerJs)
-            Timber.tag(TAG).d("Using hash for hardcoded lookup: $hashToUse (knownHash=$knownHash)")
-            if (hashToUse != null) {
-                val config = getHardcodedConfig(hashToUse)
-                if (config != null) {
-                    if (config.sigJsExpression != null) {
-                        Timber.tag(TAG).d("USING EXPRESSION-BASED SIG: ${config.sigJsExpression}")
-                    } else {
-                        Timber.tag(TAG).d("USING HARDCODED SIG FUNCTION: ${config.sigFuncName}(${config.sigConstantArgs}, ...)")
-                        Timber.tag(TAG).d("Sig preprocess: ${config.sigPreprocessFunc}(${config.sigPreprocessArgs}, sig)")
-                    }
-                    return SigFunctionInfo(
-                        name = config.sigFuncName,
-                        constantArg = config.sigConstantArg,
-                        constantArgs = config.sigConstantArgs,
-                        preprocessFunc = config.sigPreprocessFunc,
-                        preprocessArgs = config.sigPreprocessArgs,
-                        jsExpression = config.sigJsExpression,
-                        isHardcoded = true
-                    )
+        val hashToUse = knownHash ?: extractPlayerHash(playerJs)
+        Timber.tag(TAG).d("Using hash for hardcoded lookup: $hashToUse (knownHash=$knownHash)")
+        if (hashToUse != null) {
+            val config = getHardcodedConfig(hashToUse)
+            if (config != null) {
+                if (config.sigJsExpression != null) {
+                    Timber.tag(TAG).d("USING EXPRESSION-BASED SIG: ${config.sigJsExpression}")
+                } else {
+                    Timber.tag(TAG).d("USING HARDCODED SIG FUNCTION: ${config.sigFuncName}(${config.sigConstantArgs}, ...)")
+                    Timber.tag(TAG).d("Sig preprocess: ${config.sigPreprocessFunc}(${config.sigPreprocessArgs}, sig)")
                 }
+                return SigFunctionInfo(
+                    name = config.sigFuncName,
+                    constantArg = config.sigConstantArg,
+                    constantArgs = config.sigConstantArgs,
+                    preprocessFunc = config.sigPreprocessFunc,
+                    preprocessArgs = config.sigPreprocessArgs,
+                    jsExpression = config.sigJsExpression,
+                    isHardcoded = true
+                )
             }
         }
 
@@ -332,24 +328,20 @@ object FunctionNameExtractor {
             }
         }
 
-        Timber.tag(TAG).w("No n-func pattern matched, checking for Q-array obfuscation...")
+        Timber.tag(TAG).w("No n-func pattern matched, trying hardcoded config...")
 
-        // Check for Q-array obfuscation and use hardcoded fallback
-        if (hasQArrayObfuscation(playerJs)) {
-            // Use knownHash if provided, otherwise try to extract
-            val hashToUse = knownHash ?: extractPlayerHash(playerJs)
-            Timber.tag(TAG).d("Using hash for hardcoded lookup: $hashToUse (knownHash=$knownHash)")
-            if (hashToUse != null) {
-                val config = getHardcodedConfig(hashToUse)
-                if (config != null) {
-                    if (config.nJsExpression != null) {
-                        Timber.tag(TAG).d("USING EXPRESSION-BASED N-FUNCTION: ${config.nJsExpression.take(60)}")
-                    } else {
-                        Timber.tag(TAG).d("USING HARDCODED N-FUNCTION: ${config.nFuncName}[${config.nArrayIndex}]")
-                        Timber.tag(TAG).d("N-function constant args: ${config.nConstantArgs}")
-                    }
-                    return NFunctionInfo(config.nFuncName, config.nArrayIndex, config.nConstantArgs, config.nJsExpression, isHardcoded = true)
+        val hashToUse = knownHash ?: extractPlayerHash(playerJs)
+        Timber.tag(TAG).d("Using hash for hardcoded lookup: $hashToUse (knownHash=$knownHash)")
+        if (hashToUse != null) {
+            val config = getHardcodedConfig(hashToUse)
+            if (config != null) {
+                if (config.nJsExpression != null) {
+                    Timber.tag(TAG).d("USING EXPRESSION-BASED N-FUNCTION: ${config.nJsExpression.take(60)}")
+                } else {
+                    Timber.tag(TAG).d("USING HARDCODED N-FUNCTION: ${config.nFuncName}[${config.nArrayIndex}]")
+                    Timber.tag(TAG).d("N-function constant args: ${config.nConstantArgs}")
                 }
+                return NFunctionInfo(config.nFuncName, config.nArrayIndex, config.nConstantArgs, config.nJsExpression, isHardcoded = true)
             }
         }
 

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/FunctionNameExtractor.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/FunctionNameExtractor.kt
@@ -20,6 +20,7 @@ object FunctionNameExtractor {
         val constantArgs: List<Int>? = null, // All constant args e.g., JI(48, 1918, ...) -> [48, 1918]
         val preprocessFunc: String? = null, // Preprocessing function e.g., f1
         val preprocessArgs: List<Int>? = null, // Preprocess args e.g., f1(1, 6528, sig) -> [1, 6528]
+        val jsExpression: String? = null,
         val isHardcoded: Boolean = false
     )
 
@@ -27,6 +28,7 @@ object FunctionNameExtractor {
         val name: String,
         val arrayIndex: Int?, // e.g. FUNC[0] -> index=0
         val constantArgs: List<Int>? = null, // e.g. GU(6, 6010, n) -> [6, 6010]
+        val jsExpression: String? = null,
         val isHardcoded: Boolean = false
     )
 
@@ -40,9 +42,11 @@ object FunctionNameExtractor {
         val sigConstantArgs: List<Int>? = null, // e.g. JI(48, 1918, ...) -> [48, 1918]
         val sigPreprocessFunc: String? = null, // e.g. f1
         val sigPreprocessArgs: List<Int>? = null, // e.g. f1(1, 6528, sig) -> [1, 6528]
+        val sigJsExpression: String? = null,
         val nFuncName: String,
         val nArrayIndex: Int?,
         val nConstantArgs: List<Int>?, // e.g. GU(6, 6010, n) -> [6, 6010]
+        val nJsExpression: String? = null,
         val signatureTimestamp: Int
     )
 
@@ -89,6 +93,28 @@ object FunctionNameExtractor {
             nArrayIndex = null,
             nConstantArgs = null,
             signatureTimestamp = 20591
+        ),
+        // player_ias 69e2a55d (2026-06-08): VM-dispatch via Jf/C6/iE. STS 20611.
+        "69e2a55d" to HardcodedPlayerConfig(
+            sigFuncName = "_expr_sig",
+            sigConstantArg = null,
+            sigJsExpression = "Jf(20,3699,INPUT)",
+            nFuncName = "_expr_n",
+            nArrayIndex = null,
+            nConstantArgs = null,
+            nJsExpression = "(function(n){try{var u=new g.iE('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
+            signatureTimestamp = 20611
+        ),
+        // MD5-fallback alias for 69e2a55d
+        "70d8066f" to HardcodedPlayerConfig(
+            sigFuncName = "_expr_sig",
+            sigConstantArg = null,
+            sigJsExpression = "Jf(20,3699,INPUT)",
+            nFuncName = "_expr_n",
+            nArrayIndex = null,
+            nConstantArgs = null,
+            nJsExpression = "(function(n){try{var u=new g.iE('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
+            signatureTimestamp = 20611
         )
     )
 
@@ -234,14 +260,19 @@ object FunctionNameExtractor {
             if (hashToUse != null) {
                 val config = getHardcodedConfig(hashToUse)
                 if (config != null) {
-                    Timber.tag(TAG).d("USING HARDCODED SIG FUNCTION: ${config.sigFuncName}(${config.sigConstantArgs}, ...)")
-                    Timber.tag(TAG).d("Sig preprocess: ${config.sigPreprocessFunc}(${config.sigPreprocessArgs}, sig)")
+                    if (config.sigJsExpression != null) {
+                        Timber.tag(TAG).d("USING EXPRESSION-BASED SIG: ${config.sigJsExpression}")
+                    } else {
+                        Timber.tag(TAG).d("USING HARDCODED SIG FUNCTION: ${config.sigFuncName}(${config.sigConstantArgs}, ...)")
+                        Timber.tag(TAG).d("Sig preprocess: ${config.sigPreprocessFunc}(${config.sigPreprocessArgs}, sig)")
+                    }
                     return SigFunctionInfo(
                         name = config.sigFuncName,
                         constantArg = config.sigConstantArg,
                         constantArgs = config.sigConstantArgs,
                         preprocessFunc = config.sigPreprocessFunc,
                         preprocessArgs = config.sigPreprocessArgs,
+                        jsExpression = config.sigJsExpression,
                         isHardcoded = true
                     )
                 }
@@ -311,9 +342,13 @@ object FunctionNameExtractor {
             if (hashToUse != null) {
                 val config = getHardcodedConfig(hashToUse)
                 if (config != null) {
-                    Timber.tag(TAG).d("USING HARDCODED N-FUNCTION: ${config.nFuncName}[${config.nArrayIndex}]")
-                    Timber.tag(TAG).d("N-function constant args: ${config.nConstantArgs}")
-                    return NFunctionInfo(config.nFuncName, config.nArrayIndex, config.nConstantArgs, isHardcoded = true)
+                    if (config.nJsExpression != null) {
+                        Timber.tag(TAG).d("USING EXPRESSION-BASED N-FUNCTION: ${config.nJsExpression.take(60)}")
+                    } else {
+                        Timber.tag(TAG).d("USING HARDCODED N-FUNCTION: ${config.nFuncName}[${config.nArrayIndex}]")
+                        Timber.tag(TAG).d("N-function constant args: ${config.nConstantArgs}")
+                    }
+                    return NFunctionInfo(config.nFuncName, config.nArrayIndex, config.nConstantArgs, config.nJsExpression, isHardcoded = true)
                 }
             }
         }

--- a/app/src/main/kotlin/com/metrolist/music/utils/potoken/PoTokenGenerator.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/potoken/PoTokenGenerator.kt
@@ -127,8 +127,11 @@ class PoTokenGenerator {
             }
         }
 
-        Timber.tag(TAG).d("poToken generated successfully: player=${playerPot.take(20)}..., streaming=${streamingPot.take(20)}...")
+        Timber.tag(TAG).d("poToken generated successfully: session=${streamingPot.take(20)}..., video=${playerPot.take(20)}...")
 
-        return PoTokenResult(playerPot, streamingPot)
+        return PoTokenResult(
+            playerRequestPoToken = streamingPot,
+            streamingDataPoToken = playerPot,
+        )
     }
 }

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -975,4 +975,5 @@
     <string name="widget_playlists">Playlists</string>
     <string name="widget_playlists_description">Playlist shortcuts with mini-player controls</string>
     <string name="choose_something_below">Choose something below</string>
+    <string name="stream_client">Stream client</string>
 </resources>

--- a/innertube/src/main/kotlin/com/metrolist/innertube/models/YouTubeClient.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/models/YouTubeClient.kt
@@ -73,6 +73,7 @@ data class YouTubeClient(
             loginSupported = true,
             loginRequired = true,
             useSignatureTimestamp = true,
+            useWebPoTokens = true,
         )
 
         val TVHTML5 = YouTubeClient(


### PR DESCRIPTION
## Problem
Playback fails for age-restricted content and some normal content.

## Cause
1. PoToken binding reversed - playerRequestPoToken received video-bound token instead of session-bound
2. Session ID used dataSyncId for logged-in users instead of visitorData
3. Cipher deobfuscation failed for VM-dispatch players (69e2a55d, 9d2ef9ef) - hardcoded config required Q-array detection
4. WEB_CREATOR missing useWebPoTokens flag

## Solution
- Swap PoToken binding in PoTokenGenerator.kt
- Always use visitorData for session
- Add expression-based cipher configs for 69e2a55d, 9d2ef9ef players
- Remove Q-array check for hardcoded fallback
- Add mutex to CipherDeobfuscator
- Add VISIONOS to fallback clients
- Add stream client display in media info

## Testing
Verified playback for age-restricted songs and normal content with current player hashes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Display stream client information in media details.
  * Added support for additional platforms.

* **Improvements**
  * Enhanced playback session handling for consistency.
  * Improved thread-safety for stream deobfuscation.
  * Extended JavaScript-based cipher transform support with prebuilt configurations for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->