### PR TITLE
Feat/3604 streaming uploads

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -384,6 +384,7 @@ dependencies {
     implementation(libs.viewmodel)
     implementation(libs.viewmodel.compose)
     implementation(libs.lifecycle.process)
+    implementation(libs.lifecycle.service)
 
     implementation(libs.material3)
     implementation(libs.palette)

--- a/app/schemas/com.metrolist.music.db.InternalDatabase/39.json
+++ b/app/schemas/com.metrolist.music.db.InternalDatabase/39.json
@@ -1,0 +1,1438 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 39,
+    "identityHash": "48901da27585d656863ce22a47e20daa",
+    "entities": [
+      {
+        "tableName": "song",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `duration` INTEGER NOT NULL, `thumbnailUrl` TEXT, `albumId` TEXT, `albumName` TEXT, `explicit` INTEGER NOT NULL DEFAULT 0, `year` INTEGER, `date` INTEGER, `dateModified` INTEGER, `liked` INTEGER NOT NULL, `likedDate` INTEGER, `totalPlayTime` INTEGER NOT NULL, `inLibrary` INTEGER, `dateDownload` INTEGER, `isLocal` INTEGER NOT NULL DEFAULT false, `libraryAddToken` TEXT, `libraryRemoveToken` TEXT, `lyricsOffset` INTEGER NOT NULL DEFAULT 0, `romanizeLyrics` INTEGER NOT NULL DEFAULT true, `isDownloaded` INTEGER NOT NULL DEFAULT 0, `isUploaded` INTEGER NOT NULL DEFAULT false, `isVideo` INTEGER NOT NULL DEFAULT false, `isEpisode` INTEGER NOT NULL DEFAULT false, `playbackPosition` INTEGER DEFAULT NULL, `uploadEntityId` TEXT DEFAULT NULL, `isCached` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumName",
+            "columnName": "albumName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "explicit",
+            "columnName": "explicit",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "dateModified",
+            "columnName": "dateModified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "liked",
+            "columnName": "liked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "likedDate",
+            "columnName": "likedDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalPlayTime",
+            "columnName": "totalPlayTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inLibrary",
+            "columnName": "inLibrary",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "dateDownload",
+            "columnName": "dateDownload",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isLocal",
+            "columnName": "isLocal",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "libraryAddToken",
+            "columnName": "libraryAddToken",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "libraryRemoveToken",
+            "columnName": "libraryRemoveToken",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lyricsOffset",
+            "columnName": "lyricsOffset",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "romanizeLyrics",
+            "columnName": "romanizeLyrics",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "isDownloaded",
+            "columnName": "isDownloaded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isUploaded",
+            "columnName": "isUploaded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "isVideo",
+            "columnName": "isVideo",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "isEpisode",
+            "columnName": "isEpisode",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "playbackPosition",
+            "columnName": "playbackPosition",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "uploadEntityId",
+            "columnName": "uploadEntityId",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "isCached",
+            "columnName": "isCached",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_song_albumId",
+            "unique": false,
+            "columnNames": [
+              "albumId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_albumId` ON `${TABLE_NAME}` (`albumId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "artist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `thumbnailUrl` TEXT, `channelId` TEXT, `lastUpdateTime` INTEGER NOT NULL, `bookmarkedAt` INTEGER, `isLocal` INTEGER NOT NULL DEFAULT false, `isPodcastChannel` INTEGER NOT NULL DEFAULT false, `cachedPageJson` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "lastUpdateTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkedAt",
+            "columnName": "bookmarkedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isLocal",
+            "columnName": "isLocal",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "isPodcastChannel",
+            "columnName": "isPodcastChannel",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "cachedPageJson",
+            "columnName": "cachedPageJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "album",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `playlistId` TEXT, `title` TEXT NOT NULL, `year` INTEGER, `thumbnailUrl` TEXT, `themeColor` INTEGER, `songCount` INTEGER NOT NULL, `duration` INTEGER NOT NULL, `explicit` INTEGER NOT NULL DEFAULT 0, `lastUpdateTime` INTEGER NOT NULL, `bookmarkedAt` INTEGER, `likedDate` INTEGER, `inLibrary` INTEGER, `isLocal` INTEGER NOT NULL DEFAULT false, `isUploaded` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "themeColor",
+            "columnName": "themeColor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "songCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "explicit",
+            "columnName": "explicit",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "lastUpdateTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkedAt",
+            "columnName": "bookmarkedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "likedDate",
+            "columnName": "likedDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "inLibrary",
+            "columnName": "inLibrary",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isLocal",
+            "columnName": "isLocal",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "isUploaded",
+            "columnName": "isUploaded",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `browseId` TEXT, `createdAt` INTEGER, `lastUpdateTime` INTEGER, `isEditable` INTEGER NOT NULL DEFAULT true, `bookmarkedAt` INTEGER, `remoteSongCount` INTEGER, `playEndpointParams` TEXT, `thumbnailUrl` TEXT, `shuffleEndpointParams` TEXT, `radioEndpointParams` TEXT, `isLocal` INTEGER NOT NULL DEFAULT false, `isAutoSync` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browseId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "lastUpdateTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isEditable",
+            "columnName": "isEditable",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "bookmarkedAt",
+            "columnName": "bookmarkedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "remoteSongCount",
+            "columnName": "remoteSongCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playEndpointParams",
+            "columnName": "playEndpointParams",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shuffleEndpointParams",
+            "columnName": "shuffleEndpointParams",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "radioEndpointParams",
+            "columnName": "radioEndpointParams",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isLocal",
+            "columnName": "isLocal",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "isAutoSync",
+            "columnName": "isAutoSync",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "song_artist_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`songId` TEXT NOT NULL, `artistId` TEXT NOT NULL, `position` INTEGER NOT NULL, PRIMARY KEY(`songId`, `artistId`), FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`artistId`) REFERENCES `artist`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "songId",
+            "artistId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_song_artist_map_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_artist_map_songId` ON `${TABLE_NAME}` (`songId`)"
+          },
+          {
+            "name": "index_song_artist_map_artistId",
+            "unique": false,
+            "columnNames": [
+              "artistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_artist_map_artistId` ON `${TABLE_NAME}` (`artistId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "artist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "artistId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "song_album_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`songId` TEXT NOT NULL, `albumId` TEXT NOT NULL, `index` INTEGER NOT NULL, PRIMARY KEY(`songId`, `albumId`), FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`albumId`) REFERENCES `album`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "songId",
+            "albumId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_song_album_map_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_album_map_songId` ON `${TABLE_NAME}` (`songId`)"
+          },
+          {
+            "name": "index_song_album_map_albumId",
+            "unique": false,
+            "columnNames": [
+              "albumId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_album_map_albumId` ON `${TABLE_NAME}` (`albumId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "album",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "albumId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "album_artist_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`albumId` TEXT NOT NULL, `artistId` TEXT NOT NULL, `order` INTEGER NOT NULL, PRIMARY KEY(`albumId`, `artistId`), FOREIGN KEY(`albumId`) REFERENCES `album`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`artistId`) REFERENCES `artist`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "albumId",
+            "artistId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_album_artist_map_albumId",
+            "unique": false,
+            "columnNames": [
+              "albumId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_album_artist_map_albumId` ON `${TABLE_NAME}` (`albumId`)"
+          },
+          {
+            "name": "index_album_artist_map_artistId",
+            "unique": false,
+            "columnNames": [
+              "artistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_album_artist_map_artistId` ON `${TABLE_NAME}` (`artistId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "album",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "albumId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "artist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "artistId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_song_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `playlistId` TEXT NOT NULL, `songId` TEXT NOT NULL, `position` INTEGER NOT NULL, `setVideoId` TEXT, FOREIGN KEY(`playlistId`) REFERENCES `playlist`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "setVideoId",
+            "columnName": "setVideoId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_song_map_playlistId",
+            "unique": false,
+            "columnNames": [
+              "playlistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_song_map_playlistId` ON `${TABLE_NAME}` (`playlistId`)"
+          },
+          {
+            "name": "index_playlist_song_map_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_song_map_songId` ON `${TABLE_NAME}` (`songId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlistId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `query` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_search_history_query",
+            "unique": true,
+            "columnNames": [
+              "query"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_query` ON `${TABLE_NAME}` (`query`)"
+          }
+        ]
+      },
+      {
+        "tableName": "format",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `itag` INTEGER NOT NULL, `mimeType` TEXT NOT NULL, `codecs` TEXT NOT NULL, `bitrate` INTEGER NOT NULL, `sampleRate` INTEGER, `contentLength` INTEGER NOT NULL, `loudnessDb` REAL, `perceptualLoudnessDb` REAL, `playbackUrl` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itag",
+            "columnName": "itag",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mimeType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "codecs",
+            "columnName": "codecs",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bitrate",
+            "columnName": "bitrate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sampleRate",
+            "columnName": "sampleRate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "contentLength",
+            "columnName": "contentLength",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "loudnessDb",
+            "columnName": "loudnessDb",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "perceptualLoudnessDb",
+            "columnName": "perceptualLoudnessDb",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "playbackUrl",
+            "columnName": "playbackUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lyrics",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `lyrics` TEXT NOT NULL, `provider` TEXT NOT NULL DEFAULT 'Unknown', `translatedLyrics` TEXT NOT NULL DEFAULT '', `translationLanguage` TEXT NOT NULL DEFAULT '', `translationMode` TEXT NOT NULL DEFAULT '', PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lyrics",
+            "columnName": "lyrics",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Unknown'"
+          },
+          {
+            "fieldPath": "translatedLyrics",
+            "columnName": "translatedLyrics",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "translationLanguage",
+            "columnName": "translationLanguage",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "translationMode",
+            "columnName": "translationMode",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "event",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `songId` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `playTime` INTEGER NOT NULL, FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playTime",
+            "columnName": "playTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_event_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_event_songId` ON `${TABLE_NAME}` (`songId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "related_song_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `songId` TEXT NOT NULL, `relatedSongId` TEXT NOT NULL, FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`relatedSongId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "relatedSongId",
+            "columnName": "relatedSongId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_related_song_map_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_related_song_map_songId` ON `${TABLE_NAME}` (`songId`)"
+          },
+          {
+            "name": "index_related_song_map_relatedSongId",
+            "unique": false,
+            "columnNames": [
+              "relatedSongId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_related_song_map_relatedSongId` ON `${TABLE_NAME}` (`relatedSongId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "relatedSongId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "set_video_id",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`videoId` TEXT NOT NULL, `setVideoId` TEXT, PRIMARY KEY(`videoId`))",
+        "fields": [
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "setVideoId",
+            "columnName": "setVideoId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "videoId"
+          ]
+        }
+      },
+      {
+        "tableName": "playCount",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`song` TEXT NOT NULL, `year` INTEGER NOT NULL, `month` INTEGER NOT NULL, `count` INTEGER NOT NULL, PRIMARY KEY(`song`, `year`, `month`))",
+        "fields": [
+          {
+            "fieldPath": "song",
+            "columnName": "song",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "song",
+            "year",
+            "month"
+          ]
+        }
+      },
+      {
+        "tableName": "recognition_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `trackId` TEXT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT, `coverArtUrl` TEXT, `coverArtHqUrl` TEXT, `genre` TEXT, `releaseDate` TEXT, `label` TEXT, `shazamUrl` TEXT, `appleMusicUrl` TEXT, `spotifyUrl` TEXT, `isrc` TEXT, `youtubeVideoId` TEXT, `recognizedAt` INTEGER NOT NULL, `liked` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "trackId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtUrl",
+            "columnName": "coverArtUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtHqUrl",
+            "columnName": "coverArtHqUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "releaseDate",
+            "columnName": "releaseDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shazamUrl",
+            "columnName": "shazamUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "appleMusicUrl",
+            "columnName": "appleMusicUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "spotifyUrl",
+            "columnName": "spotifyUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isrc",
+            "columnName": "isrc",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "youtubeVideoId",
+            "columnName": "youtubeVideoId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "recognizedAt",
+            "columnName": "recognizedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "liked",
+            "columnName": "liked",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_recognition_history_trackId",
+            "unique": false,
+            "columnNames": [
+              "trackId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recognition_history_trackId` ON `${TABLE_NAME}` (`trackId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "speed_dial_item",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `secondaryId` TEXT, `title` TEXT NOT NULL, `subtitle` TEXT, `subtitleIds` TEXT, `thumbnailUrl` TEXT, `type` TEXT NOT NULL, `explicit` INTEGER NOT NULL, `createDate` INTEGER NOT NULL, `albumId` TEXT, `albumName` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "secondaryId",
+            "columnName": "secondaryId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "subtitleIds",
+            "columnName": "subtitleIds",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "explicit",
+            "columnName": "explicit",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createDate",
+            "columnName": "createDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumName",
+            "columnName": "albumName",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "podcast",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT, `thumbnailUrl` TEXT, `channelId` TEXT, `bookmarkedAt` INTEGER, `lastUpdateTime` INTEGER NOT NULL, `libraryAddToken` TEXT, `libraryRemoveToken` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookmarkedAt",
+            "columnName": "bookmarkedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "lastUpdateTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryAddToken",
+            "columnName": "libraryAddToken",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "libraryRemoveToken",
+            "columnName": "libraryRemoveToken",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "upload_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `uri` TEXT NOT NULL, `displayName` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `state` TEXT NOT NULL, `progress` REAL NOT NULL, `attempts` INTEGER NOT NULL, `errorMessage` TEXT, `enqueuedAt` INTEGER NOT NULL, `completedAt` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uri",
+            "columnName": "uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progress",
+            "columnName": "progress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attempts",
+            "columnName": "attempts",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "enqueuedAt",
+            "columnName": "enqueuedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "views": [
+      {
+        "viewName": "sorted_song_artist_map",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT * FROM song_artist_map ORDER BY position"
+      },
+      {
+        "viewName": "sorted_song_album_map",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT * FROM song_album_map ORDER BY `index`"
+      },
+      {
+        "viewName": "playlist_song_map_preview",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT * FROM playlist_song_map WHERE position <= 3 ORDER BY position"
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '48901da27585d656863ce22a47e20daa')"
+    ]
+  }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -365,6 +365,11 @@
             android:exported="false"
             android:foregroundServiceType="microphone" />
 
+        <service
+            android:name=".upload.UploadService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
+
         <!-- Music Recognizer Quick Settings Tile -->
         <service
             android:name=".quicksettings.MusicRecognizerTileService"

--- a/app/src/main/kotlin/com/metrolist/music/App.kt
+++ b/app/src/main/kotlin/com/metrolist/music/App.kt
@@ -168,8 +168,17 @@ class App :
             ).apply {
                 description = getString(R.string.update_channel_desc)
             }
+        val uploadsChannel =
+            NotificationChannel(
+                "uploads",
+                getString(R.string.upload_channel_name),
+                NotificationManager.IMPORTANCE_LOW,
+            ).apply {
+                description = getString(R.string.upload_channel_desc)
+            }
         val nm = getSystemService(NotificationManager::class.java)
         nm.createNotificationChannel(channel)
+        nm.createNotificationChannel(uploadsChannel)
     }
 
     private fun observeSettingsChanges() {

--- a/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
@@ -1954,10 +1954,28 @@ interface DatabaseDao {
     @Query("UPDATE upload_queue SET state = :state, errorMessage = :error, completedAt = :completedAt WHERE id = :id")
     suspend fun updateUploadState(id: String, state: UploadState, error: String? = null, completedAt: Long? = null): Int
 
+    /**
+     * Atomically flip a row PENDING -> RUNNING. Returns 0 if the row is no longer
+     * PENDING (e.g. it was CANCELLED between the collector reading it and runOne
+     * acquiring its permit), letting the caller bail without clobbering the new
+     * state. Replaces an unguarded `updateUploadState(RUNNING)`.
+     */
+    @Query("UPDATE upload_queue SET state = 'RUNNING' WHERE id = :id AND state = 'PENDING'")
+    suspend fun markUploadRunning(id: String): Int
+
     @Query("UPDATE upload_queue SET progress = :progress WHERE id = :id")
     suspend fun updateUploadProgress(id: String, progress: Float): Int
 
-    @Query("DELETE FROM upload_queue WHERE state IN ('SUCCESS', 'CANCELLED')")
+    /** Flip a FAILED row back to PENDING (fresh start) so the collector retries it. */
+    @Query("UPDATE upload_queue SET state = 'PENDING', progress = 0, attempts = 0, errorMessage = NULL, completedAt = NULL WHERE id = :id")
+    suspend fun retryUpload(id: String): Int
+
+    /** Mark every still-active (PENDING/RUNNING) row CANCELLED — used by "Cancel all". */
+    @Query("UPDATE upload_queue SET state = 'CANCELLED', completedAt = :completedAt WHERE state IN ('PENDING', 'RUNNING')")
+    suspend fun cancelActiveUploads(completedAt: Long): Int
+
+    /** Delete all terminal rows (SUCCESS, CANCELLED, FAILED) — the "Clear completed" action. */
+    @Query("DELETE FROM upload_queue WHERE state IN ('SUCCESS', 'CANCELLED', 'FAILED')")
     suspend fun deleteCompletedUploads(): Int
 
     /**

--- a/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
@@ -1959,4 +1959,15 @@ interface DatabaseDao {
 
     @Query("DELETE FROM upload_queue WHERE state IN ('SUCCESS', 'CANCELLED')")
     suspend fun deleteCompletedUploads(): Int
+
+    /**
+     * Re-mark rows orphaned in RUNNING by a previous process back to PENDING so
+     * the collector picks them up again. Must run on UploadService start before
+     * the collector, else stale RUNNING rows are skipped and never retry.
+     */
+    @Query("UPDATE upload_queue SET state = 'PENDING' WHERE state = 'RUNNING'")
+    suspend fun resetRunningUploads(): Int
+
+    @Query("SELECT COUNT(*) FROM upload_queue WHERE state IN ('PENDING', 'RUNNING')")
+    suspend fun countActiveUploads(): Int
 }

--- a/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
@@ -51,6 +51,8 @@ import com.metrolist.music.db.entities.SongAlbumMap
 import com.metrolist.music.db.entities.SongArtistMap
 import com.metrolist.music.db.entities.SongEntity
 import com.metrolist.music.db.entities.SongWithStats
+import com.metrolist.music.db.entities.UploadQueueEntity
+import com.metrolist.music.db.entities.UploadState
 import com.metrolist.music.extensions.reversed
 import com.metrolist.music.extensions.toSQLiteQuery
 import com.metrolist.music.models.MediaMetadata
@@ -1931,4 +1933,30 @@ interface DatabaseDao {
 
     @Delete
     fun delete(podcast: PodcastEntity)
+
+    /**
+     * upload_queue — the background upload pipeline's durable job queue (#3604).
+     * Enum columns are stored by Room as their TEXT name, so SQL compares against
+     * the literal state name (e.g. 'PENDING').
+     */
+    @Query("SELECT * FROM upload_queue WHERE state = 'PENDING' ORDER BY enqueuedAt")
+    fun observePendingUploads(): Flow<List<UploadQueueEntity>>
+
+    @Query("SELECT * FROM upload_queue ORDER BY enqueuedAt")
+    fun observeAllUploads(): Flow<List<UploadQueueEntity>>
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insert(upload: UploadQueueEntity)
+
+    @Update
+    suspend fun update(upload: UploadQueueEntity)
+
+    @Query("UPDATE upload_queue SET state = :state, errorMessage = :error, completedAt = :completedAt WHERE id = :id")
+    suspend fun updateUploadState(id: String, state: UploadState, error: String? = null, completedAt: Long? = null): Int
+
+    @Query("UPDATE upload_queue SET progress = :progress WHERE id = :id")
+    suspend fun updateUploadProgress(id: String, progress: Float): Int
+
+    @Query("DELETE FROM upload_queue WHERE state IN ('SUCCESS', 'CANCELLED')")
+    suspend fun deleteCompletedUploads(): Int
 }

--- a/app/src/main/kotlin/com/metrolist/music/db/MusicDatabase.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/MusicDatabase.kt
@@ -43,6 +43,7 @@ import com.metrolist.music.db.entities.SongEntity
 import com.metrolist.music.db.entities.SortedSongAlbumMap
 import com.metrolist.music.db.entities.SortedSongArtistMap
 import com.metrolist.music.db.entities.SpeedDialItem
+import com.metrolist.music.db.entities.UploadQueueEntity
 import com.metrolist.music.extensions.toSQLiteQuery
 import timber.log.Timber
 import java.io.File
@@ -112,13 +113,14 @@ class MusicDatabase(
         RecognitionHistory::class,
         SpeedDialItem::class,
         PodcastEntity::class,
+        UploadQueueEntity::class,
     ],
     views = [
         SortedSongArtistMap::class,
         SortedSongAlbumMap::class,
         PlaylistSongMapPreview::class,
     ],
-    version = 38,
+    version = 39,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 2, to = 3),
@@ -157,6 +159,7 @@ class MusicDatabase(
         AutoMigration(from = 35, to = 36, spec = Migration35To36::class),
         AutoMigration(from = 36, to = 37),
         AutoMigration(from = 37, to = 38),
+        AutoMigration(from = 38, to = 39),
     ],
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/UploadQueueEntity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/UploadQueueEntity.kt
@@ -1,0 +1,28 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.db.entities
+
+import androidx.compose.runtime.Immutable
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import java.util.UUID
+
+@Immutable
+@Entity(tableName = "upload_queue")
+data class UploadQueueEntity(
+    @PrimaryKey val id: String = UUID.randomUUID().toString(),
+    val uri: String,
+    val displayName: String,
+    val sizeBytes: Long,
+    val state: UploadState = UploadState.PENDING,
+    val progress: Float = 0f,
+    val attempts: Int = 0,
+    val errorMessage: String? = null,
+    val enqueuedAt: Long = System.currentTimeMillis(),
+    val completedAt: Long? = null,
+)
+
+enum class UploadState { PENDING, RUNNING, SUCCESS, FAILED, CANCELLED }

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/UploadStatusBar.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/UploadStatusBar.kt
@@ -23,10 +23,12 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -53,16 +55,24 @@ import kotlin.math.roundToInt
  *
  * Collapsed: a one-line summary ("Uploading N of M · P%") with an aggregate
  * progress indicator. Tapping expands a per-job list (name, state, progress,
- * and a reserved action slot — Cancel/Retry land in #3604 iter 7).
+ * and a per-row action: Cancel for active rows, Retry for failed ones) plus a
+ * footer with "Cancel all" / "Clear completed".
  *
  * Visibility: shown while any job is active (`PENDING`/`RUNNING`); once every
  * job is terminal and none failed, it lingers [AUTO_HIDE_DELAY_MS] (mirroring
  * the old dialog's 1 s success delay) then hides. If any job `FAILED`, the bar
- * stays up so the failure is visible (per-row dismissal arrives in iter 7).
+ * stays up so the failure is visible until the user retries or clears it.
+ *
+ * Stateless / VM-agnostic: callers pass the action lambdas (the screens wire
+ * them to `UploadViewModel`).
  */
 @Composable
 fun UploadStatusBar(
     jobs: List<UploadQueueEntity>,
+    onCancel: (String) -> Unit,
+    onRetry: (String) -> Unit,
+    onCancelAll: () -> Unit,
+    onClearCompleted: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val hasActive = jobs.any { it.state == UploadState.PENDING || it.state == UploadState.RUNNING }
@@ -141,7 +151,29 @@ fun UploadStatusBar(
                     Column {
                         jobs.forEach { job ->
                             Spacer(Modifier.height(12.dp))
-                            UploadJobRow(job)
+                            UploadJobRow(job, onCancel = onCancel, onRetry = onRetry)
+                        }
+                        Spacer(Modifier.height(8.dp))
+                        Row(
+                            horizontalArrangement = Arrangement.End,
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            if (hasActive) {
+                                TextButton(onClick = onCancelAll) {
+                                    Text(stringResource(R.string.upload_cancel_all))
+                                }
+                            }
+                            val hasTerminal =
+                                jobs.any {
+                                    it.state == UploadState.SUCCESS ||
+                                        it.state == UploadState.FAILED ||
+                                        it.state == UploadState.CANCELLED
+                                }
+                            if (hasTerminal) {
+                                TextButton(onClick = onClearCompleted) {
+                                    Text(stringResource(R.string.upload_clear_completed))
+                                }
+                            }
                         }
                     }
                 }
@@ -151,7 +183,11 @@ fun UploadStatusBar(
 }
 
 @Composable
-private fun UploadJobRow(job: UploadQueueEntity) {
+private fun UploadJobRow(
+    job: UploadQueueEntity,
+    onCancel: (String) -> Unit,
+    onRetry: (String) -> Unit,
+) {
     Column(modifier = Modifier.fillMaxWidth()) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Text(
@@ -163,8 +199,25 @@ private fun UploadJobRow(job: UploadQueueEntity) {
             )
             Spacer(Modifier.width(8.dp))
             UploadStateChip(job.state)
-            // Action slot placeholder — Cancel/Retry buttons land in #3604 iter 7.
-            Box(modifier = Modifier.size(40.dp))
+            // Action slot: Cancel while active, Retry once failed, empty otherwise.
+            when (job.state) {
+                UploadState.PENDING, UploadState.RUNNING ->
+                    IconButton(onClick = { onCancel(job.id) }, modifier = Modifier.size(40.dp)) {
+                        Icon(
+                            painter = painterResource(R.drawable.close),
+                            contentDescription = stringResource(R.string.upload_cancel),
+                        )
+                    }
+                UploadState.FAILED ->
+                    IconButton(onClick = { onRetry(job.id) }, modifier = Modifier.size(40.dp)) {
+                        Icon(
+                            painter = painterResource(R.drawable.replay),
+                            contentDescription = stringResource(R.string.upload_retry),
+                        )
+                    }
+                UploadState.SUCCESS, UploadState.CANCELLED ->
+                    Box(modifier = Modifier.size(40.dp))
+            }
         }
         if (job.state == UploadState.RUNNING) {
             Spacer(Modifier.height(4.dp))

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/UploadStatusBar.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/UploadStatusBar.kt
@@ -1,0 +1,209 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.ui.component
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.metrolist.music.R
+import com.metrolist.music.db.entities.UploadQueueEntity
+import com.metrolist.music.db.entities.UploadState
+import kotlinx.coroutines.delay
+import kotlin.math.roundToInt
+
+/**
+ * Persistent bottom bar that surfaces the DB-backed upload queue
+ * ([com.metrolist.music.viewmodels.UploadViewModel.jobs]). Replaces the per-screen
+ * upload `AlertDialog` and the temporary inline jobs list.
+ *
+ * Collapsed: a one-line summary ("Uploading N of M · P%") with an aggregate
+ * progress indicator. Tapping expands a per-job list (name, state, progress,
+ * and a reserved action slot — Cancel/Retry land in #3604 iter 7).
+ *
+ * Visibility: shown while any job is active (`PENDING`/`RUNNING`); once every
+ * job is terminal and none failed, it lingers [AUTO_HIDE_DELAY_MS] (mirroring
+ * the old dialog's 1 s success delay) then hides. If any job `FAILED`, the bar
+ * stays up so the failure is visible (per-row dismissal arrives in iter 7).
+ */
+@Composable
+fun UploadStatusBar(
+    jobs: List<UploadQueueEntity>,
+    modifier: Modifier = Modifier,
+) {
+    val hasActive = jobs.any { it.state == UploadState.PENDING || it.state == UploadState.RUNNING }
+    val hasFailed = jobs.any { it.state == UploadState.FAILED }
+
+    var visible by remember { mutableStateOf(false) }
+    var expanded by rememberSaveable { mutableStateOf(false) }
+
+    LaunchedEffect(jobs) {
+        when {
+            jobs.isEmpty() -> visible = false
+            hasActive || hasFailed -> visible = true
+            else -> {
+                // All terminal and nothing failed → linger briefly, then auto-hide.
+                visible = true
+                delay(AUTO_HIDE_DELAY_MS)
+                visible = false
+            }
+        }
+    }
+
+    AnimatedVisibility(
+        visible = visible && jobs.isNotEmpty(),
+        enter = fadeIn() + expandVertically(),
+        exit = fadeOut() + shrinkVertically(),
+        modifier = modifier,
+    ) {
+        val total = jobs.size
+        val done =
+            jobs.count {
+                it.state == UploadState.SUCCESS ||
+                    it.state == UploadState.FAILED ||
+                    it.state == UploadState.CANCELLED
+            }
+        val overall = if (total == 0) 0f else jobs.sumOf { effectiveProgress(it).toDouble() }.toFloat() / total
+        val percent = (overall * 100).roundToInt()
+
+        Surface(
+            shape = RoundedCornerShape(16.dp),
+            color = MaterialTheme.colorScheme.surfaceVariant,
+            tonalElevation = 3.dp,
+            shadowElevation = 6.dp,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .clickable { expanded = !expanded },
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = stringResource(R.string.upload_status_summary, done, total, percent),
+                            style = MaterialTheme.typography.titleSmall,
+                        )
+                        Spacer(Modifier.height(6.dp))
+                        LinearProgressIndicator(
+                            progress = { overall },
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+                    Spacer(Modifier.width(12.dp))
+                    Icon(
+                        painter = painterResource(if (expanded) R.drawable.expand_less else R.drawable.expand_more),
+                        contentDescription = null,
+                    )
+                }
+
+                AnimatedVisibility(
+                    visible = expanded,
+                    enter = expandVertically(),
+                    exit = shrinkVertically(),
+                ) {
+                    Column {
+                        jobs.forEach { job ->
+                            Spacer(Modifier.height(12.dp))
+                            UploadJobRow(job)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun UploadJobRow(job: UploadQueueEntity) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = job.displayName,
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+            Spacer(Modifier.width(8.dp))
+            UploadStateChip(job.state)
+            // Action slot placeholder — Cancel/Retry buttons land in #3604 iter 7.
+            Box(modifier = Modifier.size(40.dp))
+        }
+        if (job.state == UploadState.RUNNING) {
+            Spacer(Modifier.height(4.dp))
+            LinearProgressIndicator(
+                progress = { job.progress },
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun UploadStateChip(state: UploadState) {
+    val color =
+        when (state) {
+            UploadState.RUNNING -> MaterialTheme.colorScheme.primary
+            UploadState.SUCCESS -> MaterialTheme.colorScheme.tertiary
+            UploadState.FAILED -> MaterialTheme.colorScheme.error
+            UploadState.PENDING, UploadState.CANCELLED -> MaterialTheme.colorScheme.onSurfaceVariant
+        }
+    Surface(
+        shape = RoundedCornerShape(8.dp),
+        color = color.copy(alpha = 0.15f),
+        contentColor = color,
+    ) {
+        Text(
+            text = state.name,
+            style = MaterialTheme.typography.labelSmall,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+        )
+    }
+}
+
+/** Terminal rows count as fully done; running rows report live progress. */
+private fun effectiveProgress(job: UploadQueueEntity): Float =
+    when (job.state) {
+        UploadState.SUCCESS, UploadState.FAILED, UploadState.CANCELLED -> 1f
+        UploadState.RUNNING -> job.progress
+        UploadState.PENDING -> 0f
+    }
+
+private const val AUTO_HIDE_DELAY_MS = 1000L

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibrarySongsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibrarySongsScreen.kt
@@ -6,8 +6,6 @@
 package com.metrolist.music.ui.screens.library
 
 import android.net.Uri
-import android.provider.OpenableColumns
-import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -39,20 +37,15 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
@@ -61,7 +54,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.currentBackStackEntryAsState
-import com.metrolist.innertube.YouTube
 import com.metrolist.music.LocalPlayerAwareWindowInsets
 import com.metrolist.music.LocalPlayerConnection
 import com.metrolist.music.R
@@ -74,12 +66,12 @@ import com.metrolist.music.constants.SongSortDescendingKey
 import com.metrolist.music.constants.SongSortType
 import com.metrolist.music.constants.SongSortTypeKey
 import com.metrolist.music.constants.YtmSyncKey
+import com.metrolist.music.db.entities.UploadState
 import com.metrolist.music.extensions.matchesNormalizedQuery
 import com.metrolist.music.extensions.normalizeForSearch
 import com.metrolist.music.extensions.toMediaItem
 import com.metrolist.music.playback.queues.ListQueue
 import com.metrolist.music.ui.component.ChipsRow
-import com.metrolist.music.ui.component.DefaultDialog
 import com.metrolist.music.ui.component.HideOnScrollFAB
 import com.metrolist.music.ui.component.LibrarySearchEmptyPlaceholder
 import com.metrolist.music.ui.component.LibrarySearchHeader
@@ -90,12 +82,8 @@ import com.metrolist.music.ui.menu.SongMenu
 import com.metrolist.music.ui.utils.isScrollingUp
 import com.metrolist.music.utils.rememberEnumPreference
 import com.metrolist.music.utils.rememberPreference
-import com.metrolist.music.utils.withJobRetry
 import com.metrolist.music.viewmodels.LibrarySongsViewModel
-import timber.log.Timber
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import com.metrolist.music.viewmodels.UploadViewModel
 
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
@@ -103,19 +91,14 @@ fun LibrarySongsScreen(
     navController: NavController,
     onDeselect: () -> Unit,
     viewModel: LibrarySongsViewModel = hiltViewModel(),
+    uploadViewModel: UploadViewModel = hiltViewModel(),
 ) {
-    val context = LocalContext.current
     val keyboardController = LocalSoftwareKeyboardController.current
     val menuState = LocalMenuState.current
-    val uploadUnsupportedFormatStr = stringResource(R.string.upload_unsupported_format)
-    val uploadFileTooLargeStr = stringResource(R.string.upload_file_too_large)
-    val uploadFailedStr = stringResource(R.string.upload_failed)
-    val uploadCompleteStr = stringResource(R.string.upload_complete)
     val queueAllSongsStr = stringResource(R.string.queue_all_songs)
     val playerConnection = LocalPlayerConnection.current ?: return
     val isPlaying by playerConnection.isEffectivelyPlaying.collectAsStateWithLifecycle()
     val mediaMetadata by playerConnection.mediaMetadata.collectAsStateWithLifecycle()
-    val scope = rememberCoroutineScope()
 
     val (sortType, onSortTypeChange) =
         rememberEnumPreference(
@@ -135,143 +118,14 @@ fun LibrarySongsScreen(
 
     var filter by rememberEnumPreference(SongFilterKey, SongFilter.LIKED)
 
-    // Upload state
-    var showUploadDialog by remember { mutableStateOf(false) }
-    var uploadProgress by remember { mutableFloatStateOf(0f) }
-    var currentUploadIndex by remember { mutableIntStateOf(0) }
-    var totalUploads by remember { mutableIntStateOf(0) }
-    var currentFileName by remember { mutableStateOf("") }
-    var isUploading by remember { mutableStateOf(false) }
-    var uploadJob by remember { mutableStateOf<kotlinx.coroutines.Job?>(null) }
+    val uploadJobs by uploadViewModel.jobs.collectAsStateWithLifecycle()
 
     val filePickerLauncher =
         rememberLauncherForActivityResult(
             contract = ActivityResultContracts.OpenMultipleDocuments(),
         ) { uris: List<Uri> ->
             if (uris.isNotEmpty()) {
-                uris.forEach { uri ->
-                    try {
-                        val takeFlags = android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION
-                        context.contentResolver.takePersistableUriPermission(uri, takeFlags)
-                    } catch (e: SecurityException) {
-                        Timber.w(e, "Could not take persistable permission")
-                    }
-                }
-                uploadJob =
-                    scope.launch {
-                        isUploading = true
-                        showUploadDialog = true
-                        totalUploads = uris.size
-                        var successCount = 0
-
-                        uris.forEachIndexed { index, uri ->
-                            currentUploadIndex = index + 1
-                            uploadProgress = 0f
-
-                            try {
-                                // Get actual display name from content resolver
-                                var fileName = uri.lastPathSegment?.substringAfterLast('/') ?: "unknown"
-                                context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
-                                    if (cursor.moveToFirst()) {
-                                        val displayNameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
-                                        if (displayNameIndex >= 0) {
-                                            val name = cursor.getString(displayNameIndex)
-                                            if (!name.isNullOrBlank()) {
-                                                fileName = name
-                                            }
-                                        }
-                                    }
-                                }
-                                currentFileName = fileName
-                                val extension = fileName.substringAfterLast('.', "").lowercase()
-
-                                if (extension !in YouTube.SUPPORTED_UPLOAD_TYPES) {
-                                    withContext(Dispatchers.Main) {
-                                        Toast
-                                            .makeText(
-                                                context,
-                                                uploadUnsupportedFormatStr,
-                                                Toast.LENGTH_SHORT,
-                                            ).show()
-                                    }
-                                    return@forEachIndexed
-                                }
-
-                                val size = context.contentResolver
-                                    .openFileDescriptor(uri, "r")
-                                    ?.use { it.statSize }
-                                    ?: -1L
-
-                                if (size <= 0L) return@forEachIndexed
-
-                                if (size > YouTube.MAX_UPLOAD_SIZE) {
-                                    withContext(Dispatchers.Main) {
-                                        Toast
-                                            .makeText(
-                                                context,
-                                                uploadFileTooLargeStr,
-                                                Toast.LENGTH_SHORT,
-                                            ).show()
-                                    }
-                                    return@forEachIndexed
-                                }
-
-                                val result =
-                                    withJobRetry {
-                                        YouTube.uploadSong(
-                                            filename = fileName,
-                                            contentLength = size,
-                                            contentSource = {
-                                                context.contentResolver.openInputStream(uri)
-                                                    ?: throw java.io.IOException("Cannot open $uri")
-                                            },
-                                            onProgress = { progress ->
-                                                uploadProgress = progress
-                                            },
-                                        )
-                                    }
-
-                                if (result.isSuccess && result.getOrDefault(false)) {
-                                    successCount++
-                                }
-                            } catch (e: Exception) {
-                                withContext(Dispatchers.Main) {
-                                    Toast
-                                        .makeText(
-                                            context,
-                                            uploadFailedStr + ": ${e.message}",
-                                            Toast.LENGTH_SHORT,
-                                        ).show()
-                                }
-                            }
-                        }
-
-                        isUploading = false
-
-                        if (successCount > 0) {
-                            // Show completion briefly
-                            uploadProgress = 1f
-                            currentFileName = uploadCompleteStr
-                            kotlinx.coroutines.delay(1000)
-
-                            // Show toast on main thread
-                            withContext(Dispatchers.Main) {
-                                Toast
-                                    .makeText(
-                                        context,
-                                        uploadCompleteStr,
-                                        Toast.LENGTH_SHORT,
-                                    ).show()
-                            }
-
-                            showUploadDialog = false
-
-                            // Refresh uploaded songs
-                            viewModel.syncUploadedSongs()
-                        } else {
-                            showUploadDialog = false
-                        }
-                    }
+                uploadViewModel.enqueue(uris)
             }
         }
 
@@ -308,55 +162,6 @@ fun LibrarySongsScreen(
             val artistNames = song.artists.map { it.name }.toTypedArray()
             matchesNormalizedQuery(normalizedQuery, song.song.title, song.album?.title, *artistNames)
         }
-
-    // Upload progress dialog
-    if (showUploadDialog) {
-        DefaultDialog(
-            onDismiss = {
-                if (isUploading) {
-                    uploadJob?.cancel()
-                    isUploading = false
-                }
-                showUploadDialog = false
-            },
-            icon = {
-                Icon(
-                    painter = painterResource(R.drawable.upload),
-                    contentDescription = null,
-                )
-            },
-            title = { Text(stringResource(R.string.uploading)) },
-            buttons = {
-                TextButton(
-                    onClick = {
-                        if (isUploading) {
-                            uploadJob?.cancel()
-                            isUploading = false
-                        }
-                        showUploadDialog = false
-                    },
-                ) {
-                    Text(stringResource(R.string.cancel))
-                }
-            },
-        ) {
-            Text(
-                text = stringResource(R.string.upload_progress, currentUploadIndex, totalUploads),
-                style = MaterialTheme.typography.bodyMedium,
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = currentFileName,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Spacer(modifier = Modifier.height(16.dp))
-            LinearProgressIndicator(
-                progress = { uploadProgress },
-                modifier = Modifier.fillMaxWidth(),
-            )
-        }
-    }
 
     Box(
         modifier = Modifier.fillMaxSize(),
@@ -398,6 +203,41 @@ fun LibrarySongsScreen(
                         },
                         modifier = Modifier.weight(1f),
                     )
+                }
+            }
+
+            // Minimal inline upload jobs list (polished UploadStatusBar lands in iter 5).
+            if (uploadJobs.isNotEmpty()) {
+                item(
+                    key = "upload_jobs",
+                    contentType = CONTENT_TYPE_HEADER,
+                ) {
+                    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+                        uploadJobs.forEach { job ->
+                            Column(modifier = Modifier.padding(vertical = 4.dp)) {
+                                Row {
+                                    Text(
+                                        text = job.displayName,
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        modifier = Modifier.weight(1f),
+                                    )
+                                    Spacer(Modifier.width(8.dp))
+                                    Text(
+                                        text = job.state.name,
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    )
+                                }
+                                if (job.state == UploadState.RUNNING) {
+                                    Spacer(Modifier.height(4.dp))
+                                    LinearProgressIndicator(
+                                        progress = { job.progress },
+                                        modifier = Modifier.fillMaxWidth(),
+                                    )
+                                }
+                            }
+                        }
+                    }
                 }
             }
 

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibrarySongsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibrarySongsScreen.kt
@@ -347,6 +347,10 @@ fun LibrarySongsScreen(
 
         UploadStatusBar(
             jobs = uploadJobs,
+            onCancel = uploadViewModel::cancel,
+            onRetry = uploadViewModel::retry,
+            onCancelAll = uploadViewModel::cancelAll,
+            onClearCompleted = uploadViewModel::clearCompleted,
             modifier =
                 Modifier
                     .align(Alignment.BottomCenter)

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibrarySongsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibrarySongsScreen.kt
@@ -90,6 +90,7 @@ import com.metrolist.music.ui.menu.SongMenu
 import com.metrolist.music.ui.utils.isScrollingUp
 import com.metrolist.music.utils.rememberEnumPreference
 import com.metrolist.music.utils.rememberPreference
+import com.metrolist.music.utils.withJobRetry
 import com.metrolist.music.viewmodels.LibrarySongsViewModel
 import timber.log.Timber
 import kotlinx.coroutines.Dispatchers
@@ -216,17 +217,19 @@ fun LibrarySongsScreen(
                                 }
 
                                 val result =
-                                    YouTube.uploadSong(
-                                        filename = fileName,
-                                        contentLength = size,
-                                        contentSource = {
-                                            context.contentResolver.openInputStream(uri)
-                                                ?: throw java.io.IOException("Cannot open $uri")
-                                        },
-                                        onProgress = { progress ->
-                                            uploadProgress = progress
-                                        },
-                                    )
+                                    withJobRetry {
+                                        YouTube.uploadSong(
+                                            filename = fileName,
+                                            contentLength = size,
+                                            contentSource = {
+                                                context.contentResolver.openInputStream(uri)
+                                                    ?: throw java.io.IOException("Cannot open $uri")
+                                            },
+                                            onProgress = { progress ->
+                                                uploadProgress = progress
+                                            },
+                                        )
+                                    }
 
                                 if (result.isSuccess && result.getOrDefault(false)) {
                                     successCount++

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibrarySongsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibrarySongsScreen.kt
@@ -11,14 +11,12 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -34,7 +32,6 @@ import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -45,6 +42,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
@@ -66,7 +64,6 @@ import com.metrolist.music.constants.SongSortDescendingKey
 import com.metrolist.music.constants.SongSortType
 import com.metrolist.music.constants.SongSortTypeKey
 import com.metrolist.music.constants.YtmSyncKey
-import com.metrolist.music.db.entities.UploadState
 import com.metrolist.music.extensions.matchesNormalizedQuery
 import com.metrolist.music.extensions.normalizeForSearch
 import com.metrolist.music.extensions.toMediaItem
@@ -78,6 +75,7 @@ import com.metrolist.music.ui.component.LibrarySearchHeader
 import com.metrolist.music.ui.component.LocalMenuState
 import com.metrolist.music.ui.component.SongListItem
 import com.metrolist.music.ui.component.SortHeader
+import com.metrolist.music.ui.component.UploadStatusBar
 import com.metrolist.music.ui.menu.SongMenu
 import com.metrolist.music.ui.utils.isScrollingUp
 import com.metrolist.music.utils.rememberEnumPreference
@@ -203,41 +201,6 @@ fun LibrarySongsScreen(
                         },
                         modifier = Modifier.weight(1f),
                     )
-                }
-            }
-
-            // Minimal inline upload jobs list (polished UploadStatusBar lands in iter 5).
-            if (uploadJobs.isNotEmpty()) {
-                item(
-                    key = "upload_jobs",
-                    contentType = CONTENT_TYPE_HEADER,
-                ) {
-                    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
-                        uploadJobs.forEach { job ->
-                            Column(modifier = Modifier.padding(vertical = 4.dp)) {
-                                Row {
-                                    Text(
-                                        text = job.displayName,
-                                        style = MaterialTheme.typography.bodyMedium,
-                                        modifier = Modifier.weight(1f),
-                                    )
-                                    Spacer(Modifier.width(8.dp))
-                                    Text(
-                                        text = job.state.name,
-                                        style = MaterialTheme.typography.labelSmall,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    )
-                                }
-                                if (job.state == UploadState.RUNNING) {
-                                    Spacer(Modifier.height(4.dp))
-                                    LinearProgressIndicator(
-                                        progress = { job.progress },
-                                        modifier = Modifier.fillMaxWidth(),
-                                    )
-                                }
-                            }
-                        }
-                    }
                 }
             }
 
@@ -380,6 +343,17 @@ fun LibrarySongsScreen(
                     )
                 }
             },
+        )
+
+        UploadStatusBar(
+            jobs = uploadJobs,
+            modifier =
+                Modifier
+                    .align(Alignment.BottomCenter)
+                    .windowInsetsPadding(
+                        LocalPlayerAwareWindowInsets.current
+                            .only(WindowInsetsSides.Bottom + WindowInsetsSides.Horizontal),
+                    ).padding(16.dp),
         )
     }
 }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibrarySongsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibrarySongsScreen.kt
@@ -196,13 +196,14 @@ fun LibrarySongsScreen(
                                     return@forEachIndexed
                                 }
 
-                                val inputStream = context.contentResolver.openInputStream(uri)
-                                val data = inputStream?.readBytes()
-                                inputStream?.close()
+                                val size = context.contentResolver
+                                    .openFileDescriptor(uri, "r")
+                                    ?.use { it.statSize }
+                                    ?: -1L
 
-                                if (data == null) return@forEachIndexed
+                                if (size <= 0L) return@forEachIndexed
 
-                                if (data.size > YouTube.MAX_UPLOAD_SIZE) {
+                                if (size > YouTube.MAX_UPLOAD_SIZE) {
                                     withContext(Dispatchers.Main) {
                                         Toast
                                             .makeText(
@@ -217,7 +218,11 @@ fun LibrarySongsScreen(
                                 val result =
                                     YouTube.uploadSong(
                                         filename = fileName,
-                                        data = data,
+                                        contentLength = size,
+                                        contentSource = {
+                                            context.contentResolver.openInputStream(uri)
+                                                ?: throw java.io.IOException("Cannot open $uri")
+                                        },
                                         onProgress = { progress ->
                                             uploadProgress = progress
                                         },

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -682,6 +682,10 @@ fun AutoPlaylistScreen(
 
         UploadStatusBar(
             jobs = uploadJobs,
+            onCancel = uploadViewModel::cancel,
+            onRetry = uploadViewModel::retry,
+            onCancelAll = uploadViewModel::cancelAll,
+            onClearCompleted = uploadViewModel::clearCompleted,
             modifier =
                 Modifier
                     .align(Alignment.BottomCenter)

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -226,20 +226,15 @@ fun AutoPlaylistScreen(
         }
 
     LaunchedEffect(Unit) {
-        println("[UPLOAD_DEBUG] AutoPlaylistScreen LaunchedEffect: playlistId=$playlistId, playlistType=$playlistType, ytmSync=$ytmSync")
         if (ytmSync) {
             withContext(Dispatchers.IO) {
                 if (playlistType == PlaylistType.LIKE) {
-                    println("[UPLOAD_DEBUG] AutoPlaylistScreen: Calling syncLikedSongs()")
                     viewModel.syncLikedSongs()
                 }
                 if (playlistType == PlaylistType.UPLOADED) {
-                    println("[UPLOAD_DEBUG] AutoPlaylistScreen: Calling syncUploadedSongs()")
                     viewModel.syncUploadedSongs()
                 }
             }
-        } else {
-            println("[UPLOAD_DEBUG] AutoPlaylistScreen: ytmSync is false, not syncing")
         }
     }
 

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -287,13 +287,14 @@ fun AutoPlaylistScreen(
                                     return@forEachIndexed
                                 }
 
-                                val inputStream = context.contentResolver.openInputStream(uri)
-                                val data = inputStream?.readBytes()
-                                inputStream?.close()
+                                val size = context.contentResolver
+                                    .openFileDescriptor(uri, "r")
+                                    ?.use { it.statSize }
+                                    ?: -1L
 
-                                if (data == null) return@forEachIndexed
+                                if (size <= 0L) return@forEachIndexed
 
-                                if (data.size > YouTube.MAX_UPLOAD_SIZE) {
+                                if (size > YouTube.MAX_UPLOAD_SIZE) {
                                     withContext(Dispatchers.Main) {
                                         Toast
                                             .makeText(
@@ -308,7 +309,11 @@ fun AutoPlaylistScreen(
                                 val result =
                                     YouTube.uploadSong(
                                         filename = fileName,
-                                        data = data,
+                                        contentLength = size,
+                                        contentSource = {
+                                            context.contentResolver.openInputStream(uri)
+                                                ?: throw java.io.IOException("Cannot open $uri")
+                                        },
                                         onProgress = { progress ->
                                             uploadProgress = progress
                                         },

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -123,6 +123,7 @@ import com.metrolist.music.ui.utils.isScrollingUp
 import com.metrolist.music.utils.makeTimeString
 import com.metrolist.music.utils.rememberEnumPreference
 import com.metrolist.music.utils.rememberPreference
+import com.metrolist.music.utils.withJobRetry
 import com.metrolist.music.viewmodels.AutoPlaylistViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -307,17 +308,19 @@ fun AutoPlaylistScreen(
                                 }
 
                                 val result =
-                                    YouTube.uploadSong(
-                                        filename = fileName,
-                                        contentLength = size,
-                                        contentSource = {
-                                            context.contentResolver.openInputStream(uri)
-                                                ?: throw java.io.IOException("Cannot open $uri")
-                                        },
-                                        onProgress = { progress ->
-                                            uploadProgress = progress
-                                        },
-                                    )
+                                    withJobRetry {
+                                        YouTube.uploadSong(
+                                            filename = fileName,
+                                            contentLength = size,
+                                            contentSource = {
+                                                context.contentResolver.openInputStream(uri)
+                                                    ?: throw java.io.IOException("Cannot open $uri")
+                                            },
+                                            onProgress = { progress ->
+                                                uploadProgress = progress
+                                            },
+                                        )
+                                    }
 
                                 if (result.isSuccess && result.getOrDefault(false)) {
                                     successCount++

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -6,8 +6,6 @@
 package com.metrolist.music.ui.screens.playlist
 
 import android.net.Uri
-import android.provider.OpenableColumns
-import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -40,7 +38,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -55,12 +52,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -87,13 +82,11 @@ import androidx.compose.ui.util.fastForEachReversed
 import androidx.compose.ui.util.fastSumBy
 import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import timber.log.Timber
 import androidx.media3.exoplayer.offline.Download
 import androidx.media3.exoplayer.offline.DownloadRequest
 import androidx.media3.exoplayer.offline.DownloadService
 import androidx.navigation.NavController
 import coil3.compose.AsyncImage
-import com.metrolist.innertube.YouTube
 import com.metrolist.music.LocalDownloadUtil
 import com.metrolist.music.LocalPlayerAwareWindowInsets
 import com.metrolist.music.LocalPlayerConnection
@@ -115,6 +108,7 @@ import com.metrolist.music.ui.component.IconButton
 import com.metrolist.music.ui.component.LocalMenuState
 import com.metrolist.music.ui.component.SongListItem
 import com.metrolist.music.ui.component.SortHeader
+import com.metrolist.music.ui.component.UploadStatusBar
 import com.metrolist.music.ui.menu.AutoPlaylistMenu
 import com.metrolist.music.ui.menu.SelectionSongMenu
 import com.metrolist.music.ui.menu.SongMenu
@@ -123,10 +117,9 @@ import com.metrolist.music.ui.utils.isScrollingUp
 import com.metrolist.music.utils.makeTimeString
 import com.metrolist.music.utils.rememberEnumPreference
 import com.metrolist.music.utils.rememberPreference
-import com.metrolist.music.utils.withJobRetry
 import com.metrolist.music.viewmodels.AutoPlaylistViewModel
+import com.metrolist.music.viewmodels.UploadViewModel
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
@@ -134,14 +127,11 @@ import kotlinx.coroutines.withContext
 fun AutoPlaylistScreen(
     navController: NavController,
     viewModel: AutoPlaylistViewModel = hiltViewModel(),
+    uploadViewModel: UploadViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
     val menuState = LocalMenuState.current
     val haptic = LocalHapticFeedback.current
-    val uploadUnsupportedFormatStr = stringResource(R.string.upload_unsupported_format)
-    val uploadFileTooLargeStr = stringResource(R.string.upload_file_too_large)
-    val uploadFailedStr = stringResource(R.string.upload_failed)
-    val uploadCompleteStr = stringResource(R.string.upload_complete)
     val focusManager = LocalFocusManager.current
     val playerConnection = LocalPlayerConnection.current ?: return
     val isPlaying by playerConnection.isEffectivelyPlaying.collectAsStateWithLifecycle()
@@ -224,145 +214,14 @@ fun AutoPlaylistScreen(
         mutableIntStateOf(Download.STATE_STOPPED)
     }
 
-    val scope = rememberCoroutineScope()
-
-    // Upload state
-    var showUploadDialog by remember { mutableStateOf(false) }
-    var uploadProgress by remember { mutableFloatStateOf(0f) }
-    var currentUploadIndex by remember { mutableIntStateOf(0) }
-    var totalUploads by remember { mutableIntStateOf(0) }
-    var currentFileName by remember { mutableStateOf("") }
-    var isUploading by remember { mutableStateOf(false) }
-    var uploadJob by remember { mutableStateOf<kotlinx.coroutines.Job?>(null) }
+    val uploadJobs by uploadViewModel.jobs.collectAsStateWithLifecycle()
 
     val filePickerLauncher =
         rememberLauncherForActivityResult(
             contract = ActivityResultContracts.OpenMultipleDocuments(),
         ) { uris: List<Uri> ->
             if (uris.isNotEmpty()) {
-                uris.forEach { uri ->
-                    try {
-                        val takeFlags = android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION
-                        context.contentResolver.takePersistableUriPermission(uri, takeFlags)
-                    } catch (e: SecurityException) {
-                        Timber.w(e, "Could not take persistable permission")
-                    }
-                }
-                uploadJob =
-                    scope.launch {
-                        isUploading = true
-                        showUploadDialog = true
-                        totalUploads = uris.size
-                        var successCount = 0
-
-                        uris.forEachIndexed { index, uri ->
-                            currentUploadIndex = index + 1
-                            uploadProgress = 0f
-
-                            try {
-                                // Get actual display name from content resolver
-                                var fileName = uri.lastPathSegment?.substringAfterLast('/') ?: "unknown"
-                                context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
-                                    if (cursor.moveToFirst()) {
-                                        val displayNameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
-                                        if (displayNameIndex >= 0) {
-                                            val name = cursor.getString(displayNameIndex)
-                                            if (!name.isNullOrBlank()) {
-                                                fileName = name
-                                            }
-                                        }
-                                    }
-                                }
-                                currentFileName = fileName
-                                val extension = fileName.substringAfterLast('.', "").lowercase()
-
-                                if (extension !in YouTube.SUPPORTED_UPLOAD_TYPES) {
-                                    withContext(Dispatchers.Main) {
-                                        Toast
-                                            .makeText(
-                                                context,
-                                                uploadUnsupportedFormatStr,
-                                                Toast.LENGTH_SHORT,
-                                            ).show()
-                                    }
-                                    return@forEachIndexed
-                                }
-
-                                val size = context.contentResolver
-                                    .openFileDescriptor(uri, "r")
-                                    ?.use { it.statSize }
-                                    ?: -1L
-
-                                if (size <= 0L) return@forEachIndexed
-
-                                if (size > YouTube.MAX_UPLOAD_SIZE) {
-                                    withContext(Dispatchers.Main) {
-                                        Toast
-                                            .makeText(
-                                                context,
-                                                uploadFileTooLargeStr,
-                                                Toast.LENGTH_SHORT,
-                                            ).show()
-                                    }
-                                    return@forEachIndexed
-                                }
-
-                                val result =
-                                    withJobRetry {
-                                        YouTube.uploadSong(
-                                            filename = fileName,
-                                            contentLength = size,
-                                            contentSource = {
-                                                context.contentResolver.openInputStream(uri)
-                                                    ?: throw java.io.IOException("Cannot open $uri")
-                                            },
-                                            onProgress = { progress ->
-                                                uploadProgress = progress
-                                            },
-                                        )
-                                    }
-
-                                if (result.isSuccess && result.getOrDefault(false)) {
-                                    successCount++
-                                }
-                            } catch (e: Exception) {
-                                withContext(Dispatchers.Main) {
-                                    Toast
-                                        .makeText(
-                                            context,
-                                            uploadFailedStr + ": ${e.message}",
-                                            Toast.LENGTH_SHORT,
-                                        ).show()
-                                }
-                            }
-                        }
-
-                        isUploading = false
-
-                        if (successCount > 0) {
-                            // Show completion briefly
-                            uploadProgress = 1f
-                            currentFileName = uploadCompleteStr
-                            kotlinx.coroutines.delay(1000)
-
-                            // Show toast on main thread
-                            withContext(Dispatchers.Main) {
-                                Toast
-                                    .makeText(
-                                        context,
-                                        uploadCompleteStr,
-                                        Toast.LENGTH_SHORT,
-                                    ).show()
-                            }
-
-                            showUploadDialog = false
-
-                            // Refresh uploaded songs
-                            viewModel.syncUploadedSongs()
-                        } else {
-                            showUploadDialog = false
-                        }
-                    }
+                uploadViewModel.enqueue(uris)
             }
         }
 
@@ -445,55 +304,6 @@ fun AutoPlaylistScreen(
                 }
             },
         )
-    }
-
-    // Upload progress dialog
-    if (showUploadDialog) {
-        DefaultDialog(
-            onDismiss = {
-                if (isUploading) {
-                    uploadJob?.cancel()
-                    isUploading = false
-                }
-                showUploadDialog = false
-            },
-            icon = {
-                Icon(
-                    painter = painterResource(R.drawable.upload),
-                    contentDescription = null,
-                )
-            },
-            title = { Text(stringResource(R.string.uploading)) },
-            buttons = {
-                TextButton(
-                    onClick = {
-                        if (isUploading) {
-                            uploadJob?.cancel()
-                            isUploading = false
-                        }
-                        showUploadDialog = false
-                    },
-                ) {
-                    Text(stringResource(R.string.cancel))
-                }
-            },
-        ) {
-            Text(
-                text = stringResource(R.string.upload_progress, currentUploadIndex, totalUploads),
-                style = MaterialTheme.typography.bodyMedium,
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-            Text(
-                text = currentFileName,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            Spacer(modifier = Modifier.height(16.dp))
-            LinearProgressIndicator(
-                progress = { uploadProgress },
-                modifier = Modifier.fillMaxWidth(),
-            )
-        }
     }
 
     val filteredSongs =
@@ -868,6 +678,17 @@ fun AutoPlaylistScreen(
                     }
                 }
             },
+        )
+
+        UploadStatusBar(
+            jobs = uploadJobs,
+            modifier =
+                Modifier
+                    .align(Alignment.BottomCenter)
+                    .windowInsetsPadding(
+                        LocalPlayerAwareWindowInsets.current
+                            .only(WindowInsetsSides.Bottom + WindowInsetsSides.Horizontal),
+                    ).padding(16.dp),
         )
     }
 }

--- a/app/src/main/kotlin/com/metrolist/music/upload/UploadService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/upload/UploadService.kt
@@ -6,6 +6,7 @@
 package com.metrolist.music.upload
 
 import android.app.Notification
+import android.app.PendingIntent
 import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.os.Build
@@ -20,6 +21,10 @@ import com.metrolist.music.db.entities.UploadQueueEntity
 import com.metrolist.music.db.entities.UploadState
 import com.metrolist.music.utils.withJobRetry
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
@@ -27,6 +32,7 @@ import timber.log.Timber
 import java.io.IOException
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
+import kotlin.coroutines.coroutineContext
 
 /**
  * Foreground service that owns execution of the DB-backed upload queue
@@ -40,8 +46,11 @@ import javax.inject.Inject
  * [MAX_CONCURRENT_UPLOADS] jobs at once via a [Semaphore]. We stop ourselves
  * once no `PENDING`/`RUNNING` rows remain.
  *
- * Cancel/Retry intents (#3604 iter 7) and the post-success
- * `syncUploadedSongs()` call (iter 8) are intentionally not wired here yet.
+ * Cancel & Retry: the status bar and notification deliver `ACTION_CANCEL(id)` /
+ * `ACTION_CANCEL_ALL` intents here (only the service holds the per-row coroutine
+ * [Job] handles needed to abort a live upload). Retry is a pure DB write driven
+ * from the ViewModel, so it has no action here. The post-success
+ * `syncUploadedSongs()` call (iter 8) is intentionally not wired here yet.
  */
 @AndroidEntryPoint
 class UploadService : LifecycleService() {
@@ -50,10 +59,11 @@ class UploadService : LifecycleService() {
 
     private val semaphore = Semaphore(MAX_CONCURRENT_UPLOADS)
 
-    // Rows whose runOne has already been launched. Guards against the pending
-    // collector re-emitting a still-PENDING row (it only leaves the query once
-    // it flips to RUNNING) and double-launching it.
-    private val active: MutableSet<String> = ConcurrentHashMap.newKeySet()
+    // Rows whose runOne has been launched, mapped to their coroutine Job so a
+    // specific row can be cancelled. Guards against the pending collector
+    // re-emitting a still-PENDING row (it only leaves the query once it flips to
+    // RUNNING) and double-launching it.
+    private val active = ConcurrentHashMap<String, Job>()
 
     override fun onCreate() {
         super.onCreate()
@@ -66,15 +76,18 @@ class UploadService : LifecycleService() {
 
             database.observePendingUploads().collect { pending ->
                 pending.forEach { row ->
-                    if (active.add(row.id)) {
-                        launch {
-                            try {
-                                semaphore.withPermit { runOne(row) }
-                            } finally {
-                                active.remove(row.id)
-                                stopIfDone()
+                    if (!active.containsKey(row.id)) {
+                        val job =
+                            launch(start = CoroutineStart.LAZY) {
+                                try {
+                                    semaphore.withPermit { runOne(row) }
+                                } finally {
+                                    active.remove(row.id)
+                                    stopIfDone()
+                                }
                             }
-                        }
+                        active[row.id] = job
+                        job.start()
                     }
                 }
                 stopIfDone()
@@ -82,8 +95,40 @@ class UploadService : LifecycleService() {
         }
     }
 
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        super.onStartCommand(intent, flags, startId)
+        when (intent?.action) {
+            ACTION_CANCEL ->
+                intent.getStringExtra(EXTRA_UPLOAD_ID)?.let { id ->
+                    lifecycleScope.launch { cancelOne(id) }
+                }
+            ACTION_CANCEL_ALL -> lifecycleScope.launch { cancelAll() }
+        }
+        return START_NOT_STICKY
+    }
+
+    /** Cancel a single row: mark it CANCELLED, then abort its job if running. */
+    private suspend fun cancelOne(id: String) {
+        // Mark CANCELLED first so the row leaves the PENDING query and loses the
+        // markUploadRunning race if runOne is just starting.
+        database.updateUploadState(id, UploadState.CANCELLED, completedAt = System.currentTimeMillis())
+        active.remove(id)?.cancel()
+        stopIfDone()
+    }
+
+    /** Cancel the whole queue (notification "Cancel all"). */
+    private suspend fun cancelAll() {
+        database.cancelActiveUploads(System.currentTimeMillis())
+        val jobs = active.values.toList()
+        active.clear()
+        jobs.forEach { it.cancel() }
+        stopIfDone()
+    }
+
     private suspend fun runOne(row: UploadQueueEntity) {
-        database.updateUploadState(row.id, UploadState.RUNNING)
+        // Atomic PENDING -> RUNNING; bail if the row was cancelled in the gap
+        // between the collector reading it and us acquiring the permit.
+        if (database.markUploadRunning(row.id) == 0) return
 
         var lastProgressWrite = 0L
         val result =
@@ -106,6 +151,13 @@ class UploadService : LifecycleService() {
                     },
                 )
             }
+
+        // If this job was cancelled mid-flight, the cancel path already wrote
+        // CANCELLED — propagate the cancellation instead of overwriting it with
+        // FAILED (uploadSong swallows CancellationException into Result.failure,
+        // and withJobRetry returns it without rethrowing).
+        result.exceptionOrNull()?.let { if (it is CancellationException) throw it }
+        coroutineContext.ensureActive()
 
         if (result.isSuccess && result.getOrDefault(false)) {
             database.updateUploadProgress(row.id, 1f)
@@ -161,17 +213,29 @@ class UploadService : LifecycleService() {
         }
     }
 
-    private fun buildNotification(): Notification =
-        NotificationCompat.Builder(this, CHANNEL_ID)
+    private fun buildNotification(): Notification {
+        val cancelAllIntent =
+            PendingIntent.getService(
+                this,
+                0,
+                Intent(this, UploadService::class.java).apply { action = ACTION_CANCEL_ALL },
+                PendingIntent.FLAG_IMMUTABLE,
+            )
+        return NotificationCompat.Builder(this, CHANNEL_ID)
             .setSmallIcon(R.drawable.upload)
             .setContentTitle(getString(R.string.upload_notification_title))
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .setOnlyAlertOnce(true)
             .setOngoing(true)
+            .addAction(R.drawable.close, getString(R.string.upload_cancel_all), cancelAllIntent)
             .build()
+    }
 
     companion object {
         const val CHANNEL_ID = "uploads"
+        const val ACTION_CANCEL = "com.metrolist.music.upload.action.CANCEL"
+        const val ACTION_CANCEL_ALL = "com.metrolist.music.upload.action.CANCEL_ALL"
+        const val EXTRA_UPLOAD_ID = "com.metrolist.music.upload.extra.UPLOAD_ID"
         private const val NOTIFICATION_ID = 9200
         private const val MAX_CONCURRENT_UPLOADS = 2
         private const val PROGRESS_WRITE_INTERVAL_MS = 250L

--- a/app/src/main/kotlin/com/metrolist/music/upload/UploadService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/upload/UploadService.kt
@@ -1,0 +1,179 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.upload
+
+import android.app.Notification
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.net.toUri
+import androidx.lifecycle.LifecycleService
+import androidx.lifecycle.lifecycleScope
+import com.metrolist.innertube.YouTube
+import com.metrolist.music.R
+import com.metrolist.music.db.MusicDatabase
+import com.metrolist.music.db.entities.UploadQueueEntity
+import com.metrolist.music.db.entities.UploadState
+import com.metrolist.music.utils.withJobRetry
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import timber.log.Timber
+import java.io.IOException
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+
+/**
+ * Foreground service that owns execution of the DB-backed upload queue
+ * (`upload_queue`). Moving the queue driver here (it used to live in
+ * [com.metrolist.music.viewmodels.UploadViewModel]'s scope) lets uploads
+ * survive navigation, process death, and OS-driven app shutdown — the
+ * ViewModel is now a thin DB client that just enqueues rows and starts us.
+ *
+ * On start we re-mark any rows orphaned in `RUNNING` by a previous process
+ * back to `PENDING` (before collecting), then run at most
+ * [MAX_CONCURRENT_UPLOADS] jobs at once via a [Semaphore]. We stop ourselves
+ * once no `PENDING`/`RUNNING` rows remain.
+ *
+ * Cancel/Retry intents (#3604 iter 7) and the post-success
+ * `syncUploadedSongs()` call (iter 8) are intentionally not wired here yet.
+ */
+@AndroidEntryPoint
+class UploadService : LifecycleService() {
+    @Inject
+    lateinit var database: MusicDatabase
+
+    private val semaphore = Semaphore(MAX_CONCURRENT_UPLOADS)
+
+    // Rows whose runOne has already been launched. Guards against the pending
+    // collector re-emitting a still-PENDING row (it only leaves the query once
+    // it flips to RUNNING) and double-launching it.
+    private val active: MutableSet<String> = ConcurrentHashMap.newKeySet()
+
+    override fun onCreate() {
+        super.onCreate()
+        startForegroundCompat()
+
+        lifecycleScope.launch {
+            // Reactivate rows the previous process left mid-flight, BEFORE the
+            // collector starts — otherwise stale RUNNING rows never retry.
+            database.resetRunningUploads()
+
+            database.observePendingUploads().collect { pending ->
+                pending.forEach { row ->
+                    if (active.add(row.id)) {
+                        launch {
+                            try {
+                                semaphore.withPermit { runOne(row) }
+                            } finally {
+                                active.remove(row.id)
+                                stopIfDone()
+                            }
+                        }
+                    }
+                }
+                stopIfDone()
+            }
+        }
+    }
+
+    private suspend fun runOne(row: UploadQueueEntity) {
+        database.updateUploadState(row.id, UploadState.RUNNING)
+
+        var lastProgressWrite = 0L
+        val result =
+            withJobRetry {
+                YouTube.uploadSong(
+                    filename = row.displayName,
+                    contentLength = row.sizeBytes,
+                    contentSource = {
+                        contentResolver.openInputStream(row.uri.toUri())
+                            ?: throw IOException("Cannot open ${row.uri}")
+                    },
+                    onProgress = { progress ->
+                        val now = System.currentTimeMillis()
+                        if (now - lastProgressWrite >= PROGRESS_WRITE_INTERVAL_MS) {
+                            lastProgressWrite = now
+                            lifecycleScope.launch {
+                                database.updateUploadProgress(row.id, progress)
+                            }
+                        }
+                    },
+                )
+            }
+
+        if (result.isSuccess && result.getOrDefault(false)) {
+            database.updateUploadProgress(row.id, 1f)
+            database.updateUploadState(
+                row.id,
+                UploadState.SUCCESS,
+                completedAt = System.currentTimeMillis(),
+            )
+        } else {
+            database.updateUploadState(
+                row.id,
+                UploadState.FAILED,
+                error = result.exceptionOrNull()?.message,
+                completedAt = System.currentTimeMillis(),
+            )
+        }
+    }
+
+    /** Stop the service once nothing is pending or running. */
+    private suspend fun stopIfDone() {
+        if (active.isEmpty() && database.countActiveUploads() == 0) {
+            stopForeground(STOP_FOREGROUND_REMOVE)
+            stopSelf()
+        }
+    }
+
+    private fun startForegroundCompat() {
+        val notification = buildNotification()
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                startForeground(
+                    NOTIFICATION_ID,
+                    notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+                )
+            } else {
+                startForeground(NOTIFICATION_ID, notification)
+            }
+        } catch (securityException: SecurityException) {
+            Timber.w(securityException, "Unable to start upload foreground service")
+            stopSelf()
+        } catch (runtimeException: RuntimeException) {
+            if (
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+                runtimeException::class.java.name ==
+                "android.app.ForegroundServiceStartNotAllowedException"
+            ) {
+                Timber.w(runtimeException, "Unable to start upload foreground service")
+                stopSelf()
+            } else {
+                throw runtimeException
+            }
+        }
+    }
+
+    private fun buildNotification(): Notification =
+        NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.drawable.upload)
+            .setContentTitle(getString(R.string.upload_notification_title))
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setOnlyAlertOnce(true)
+            .setOngoing(true)
+            .build()
+
+    companion object {
+        const val CHANNEL_ID = "uploads"
+        private const val NOTIFICATION_ID = 9200
+        private const val MAX_CONCURRENT_UPLOADS = 2
+        private const val PROGRESS_WRITE_INTERVAL_MS = 250L
+    }
+}

--- a/app/src/main/kotlin/com/metrolist/music/upload/UploadService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/upload/UploadService.kt
@@ -19,6 +19,7 @@ import com.metrolist.music.R
 import com.metrolist.music.db.MusicDatabase
 import com.metrolist.music.db.entities.UploadQueueEntity
 import com.metrolist.music.db.entities.UploadState
+import com.metrolist.music.utils.SyncUtils
 import com.metrolist.music.utils.withJobRetry
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CancellationException
@@ -31,6 +32,7 @@ import kotlinx.coroutines.sync.withPermit
 import timber.log.Timber
 import java.io.IOException
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import kotlin.coroutines.coroutineContext
 
@@ -49,15 +51,27 @@ import kotlin.coroutines.coroutineContext
  * Cancel & Retry: the status bar and notification deliver `ACTION_CANCEL(id)` /
  * `ACTION_CANCEL_ALL` intents here (only the service holds the per-row coroutine
  * [Job] handles needed to abort a live upload). Retry is a pure DB write driven
- * from the ViewModel, so it has no action here. The post-success
- * `syncUploadedSongs()` call (iter 8) is intentionally not wired here yet.
+ * from the ViewModel, so it has no action here.
+ *
+ * Once a batch goes idle (queue fully drained) and at least one upload
+ * succeeded, we kick a single [SyncUtils.syncUploadedSongs] so the library
+ * reflects the new songs even if no upload screen is open.
  */
 @AndroidEntryPoint
 class UploadService : LifecycleService() {
     @Inject
     lateinit var database: MusicDatabase
 
+    @Inject
+    lateinit var syncUtils: SyncUtils
+
     private val semaphore = Semaphore(MAX_CONCURRENT_UPLOADS)
+
+    // Set when any upload in the current run reaches SUCCESS; consumed once the
+    // queue drains to trigger a single uploaded-songs sync (coalesces a whole
+    // batch into one sync). Atomic because stopIfDone can be entered from both
+    // the collector and a job's finally, interleaving at suspend points.
+    private val hadSuccessfulUpload = AtomicBoolean(false)
 
     // Rows whose runOne has been launched, mapped to their coroutine Job so a
     // specific row can be cancelled. Guards against the pending collector
@@ -166,6 +180,7 @@ class UploadService : LifecycleService() {
                 UploadState.SUCCESS,
                 completedAt = System.currentTimeMillis(),
             )
+            hadSuccessfulUpload.set(true)
         } else {
             database.updateUploadState(
                 row.id,
@@ -179,6 +194,12 @@ class UploadService : LifecycleService() {
     /** Stop the service once nothing is pending or running. */
     private suspend fun stopIfDone() {
         if (active.isEmpty() && database.countActiveUploads() == 0) {
+            // Batch idle: if anything succeeded this run, refresh the library
+            // once. Fire-and-forget on SyncUtils' own scope, so it survives the
+            // stopSelf() below; getAndSet keeps it to a single sync per batch.
+            if (hadSuccessfulUpload.getAndSet(false)) {
+                syncUtils.syncUploadedSongs()
+            }
             stopForeground(STOP_FOREGROUND_REMOVE)
             stopSelf()
         }

--- a/app/src/main/kotlin/com/metrolist/music/utils/Retry.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/Retry.kt
@@ -1,0 +1,39 @@
+package com.metrolist.music.utils
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+
+/**
+ * Retries [block] up to [maxAttempts] times when it returns a [Result.failure],
+ * with exponential backoff between attempts. Returns the final [Result] —
+ * either the first success or the last failure.
+ *
+ * Cancellation: if a returned failure wraps a [CancellationException] (e.g.
+ * the wrapped operation used `runCatching` which swallowed the cancellation),
+ * the failure is returned immediately rather than retried. The [delay] call
+ * between attempts is itself a suspension point and will throw
+ * [CancellationException] on scope cancellation; that throw propagates out
+ * of this helper normally.
+ *
+ * With defaults (maxAttempts=3, initialDelayMs=1000, factor=4.0) the
+ * inter-attempt delays are 1 s, 4 s — total worst-case backoff of 5 s
+ * plus up to 3× the cost of [block].
+ */
+suspend fun <T> withJobRetry(
+    maxAttempts: Int = 3,
+    initialDelayMs: Long = 1000,
+    factor: Double = 4.0,
+    block: suspend () -> Result<T>,
+): Result<T> {
+    var delayMs = initialDelayMs
+    var result = block()
+    var attempts = 1
+    while (result.isFailure && attempts < maxAttempts) {
+        if (result.exceptionOrNull() is CancellationException) return result
+        delay(delayMs)
+        delayMs = (delayMs * factor).toLong()
+        result = block()
+        attempts++
+    }
+    return result
+}

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/UploadViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/UploadViewModel.kt
@@ -10,15 +10,14 @@ import android.content.Intent
 import android.net.Uri
 import android.provider.OpenableColumns
 import android.widget.Toast
-import androidx.core.net.toUri
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.metrolist.innertube.YouTube
 import com.metrolist.music.R
 import com.metrolist.music.db.MusicDatabase
 import com.metrolist.music.db.entities.UploadQueueEntity
-import com.metrolist.music.db.entities.UploadState
-import com.metrolist.music.utils.withJobRetry
+import com.metrolist.music.upload.UploadService
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
@@ -26,23 +25,16 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Semaphore
-import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import timber.log.Timber
-import java.io.IOException
-import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 
 /**
- * Drives the DB-backed upload queue (`upload_queue` table). Replaces the
- * in-Compose upload loop that used to live in `LibrarySongsScreen`.
- *
- * [enqueue] validates the picked URIs and writes `PENDING` rows; a collector
- * in [init] picks those rows up and runs at most [MAX_CONCURRENT_UPLOADS] at a
- * time via [Semaphore]. Execution lives in [viewModelScope] — it survives
- * navigation but **not** process death; moving it to a foreground service is a
- * later iteration (#3604, iter 6).
+ * Thin DB client for the upload queue (`upload_queue` table). [enqueue]
+ * validates picked URIs, writes `PENDING` rows, and starts [UploadService];
+ * the service owns execution (Semaphore, retry, progress writes) so uploads
+ * survive process death. This VM no longer drives the queue itself — it just
+ * exposes [jobs] for the UI and kicks the service.
  */
 @HiltViewModel
 class UploadViewModel
@@ -56,37 +48,26 @@ constructor(
             .observeAllUploads()
             .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
 
-    private val semaphore = Semaphore(MAX_CONCURRENT_UPLOADS)
-
-    // Rows whose runOne has already been launched. Guards against the pending
-    // collector re-emitting a still-PENDING row (it only leaves the query once
-    // it flips to RUNNING) and double-launching it.
-    private val active: MutableSet<String> = ConcurrentHashMap.newKeySet()
-
     init {
-        viewModelScope.launch {
-            database.observePendingUploads().collect { pending ->
-                pending.forEach { row ->
-                    if (active.add(row.id)) {
-                        launch {
-                            try {
-                                semaphore.withPermit { runOne(row) }
-                            } finally {
-                                active.remove(row.id)
-                            }
-                        }
-                    }
-                }
+        // Resume an interrupted batch on app reopen: if the queue still has
+        // PENDING/RUNNING rows (e.g. after a force-stop killed the service),
+        // bring the service back so those rows continue. The service re-marks
+        // orphaned RUNNING rows to PENDING on start.
+        viewModelScope.launch(Dispatchers.IO) {
+            if (database.countActiveUploads() > 0) {
+                startUploadService()
             }
         }
     }
 
     /**
      * Validate the picked [uris] and enqueue the acceptable ones as `PENDING`
-     * rows. Unsupported formats and oversized files are rejected with a toast.
+     * rows, then start [UploadService]. Unsupported formats and oversized files
+     * are rejected with a toast.
      */
     fun enqueue(uris: List<Uri>) {
         viewModelScope.launch(Dispatchers.IO) {
+            var enqueued = 0
             uris.forEach { uri ->
                 try {
                     context.contentResolver.takePersistableUriPermission(
@@ -122,50 +103,20 @@ constructor(
                         sizeBytes = size,
                     ),
                 )
+                enqueued++
+            }
+
+            if (enqueued > 0) {
+                startUploadService()
             }
         }
     }
 
-    private suspend fun runOne(row: UploadQueueEntity) {
-        database.updateUploadState(row.id, UploadState.RUNNING)
-
-        var lastProgressWrite = 0L
-        val result =
-            withJobRetry {
-                YouTube.uploadSong(
-                    filename = row.displayName,
-                    contentLength = row.sizeBytes,
-                    contentSource = {
-                        context.contentResolver.openInputStream(row.uri.toUri())
-                            ?: throw IOException("Cannot open ${row.uri}")
-                    },
-                    onProgress = { progress ->
-                        val now = System.currentTimeMillis()
-                        if (now - lastProgressWrite >= PROGRESS_WRITE_INTERVAL_MS) {
-                            lastProgressWrite = now
-                            viewModelScope.launch {
-                                database.updateUploadProgress(row.id, progress)
-                            }
-                        }
-                    },
-                )
-            }
-
-        if (result.isSuccess && result.getOrDefault(false)) {
-            database.updateUploadProgress(row.id, 1f)
-            database.updateUploadState(
-                row.id,
-                UploadState.SUCCESS,
-                completedAt = System.currentTimeMillis(),
-            )
-        } else {
-            database.updateUploadState(
-                row.id,
-                UploadState.FAILED,
-                error = result.exceptionOrNull()?.message,
-                completedAt = System.currentTimeMillis(),
-            )
-        }
+    private fun startUploadService() {
+        ContextCompat.startForegroundService(
+            context,
+            Intent(context, UploadService::class.java),
+        )
     }
 
     private fun resolveDisplayName(uri: Uri): String {
@@ -188,10 +139,5 @@ constructor(
         withContext(Dispatchers.Main) {
             Toast.makeText(context, context.getString(resId), Toast.LENGTH_SHORT).show()
         }
-    }
-
-    companion object {
-        private const val MAX_CONCURRENT_UPLOADS = 2
-        private const val PROGRESS_WRITE_INTERVAL_MS = 250L
     }
 }

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/UploadViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/UploadViewModel.kt
@@ -1,0 +1,197 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.viewmodels
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.OpenableColumns
+import android.widget.Toast
+import androidx.core.net.toUri
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.metrolist.innertube.YouTube
+import com.metrolist.music.R
+import com.metrolist.music.db.MusicDatabase
+import com.metrolist.music.db.entities.UploadQueueEntity
+import com.metrolist.music.db.entities.UploadState
+import com.metrolist.music.utils.withJobRetry
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.io.IOException
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+
+/**
+ * Drives the DB-backed upload queue (`upload_queue` table). Replaces the
+ * in-Compose upload loop that used to live in `LibrarySongsScreen`.
+ *
+ * [enqueue] validates the picked URIs and writes `PENDING` rows; a collector
+ * in [init] picks those rows up and runs at most [MAX_CONCURRENT_UPLOADS] at a
+ * time via [Semaphore]. Execution lives in [viewModelScope] — it survives
+ * navigation but **not** process death; moving it to a foreground service is a
+ * later iteration (#3604, iter 6).
+ */
+@HiltViewModel
+class UploadViewModel
+@Inject
+constructor(
+    @ApplicationContext private val context: Context,
+    private val database: MusicDatabase,
+) : ViewModel() {
+    val jobs: StateFlow<List<UploadQueueEntity>> =
+        database
+            .observeAllUploads()
+            .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
+    private val semaphore = Semaphore(MAX_CONCURRENT_UPLOADS)
+
+    // Rows whose runOne has already been launched. Guards against the pending
+    // collector re-emitting a still-PENDING row (it only leaves the query once
+    // it flips to RUNNING) and double-launching it.
+    private val active: MutableSet<String> = ConcurrentHashMap.newKeySet()
+
+    init {
+        viewModelScope.launch {
+            database.observePendingUploads().collect { pending ->
+                pending.forEach { row ->
+                    if (active.add(row.id)) {
+                        launch {
+                            try {
+                                semaphore.withPermit { runOne(row) }
+                            } finally {
+                                active.remove(row.id)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Validate the picked [uris] and enqueue the acceptable ones as `PENDING`
+     * rows. Unsupported formats and oversized files are rejected with a toast.
+     */
+    fun enqueue(uris: List<Uri>) {
+        viewModelScope.launch(Dispatchers.IO) {
+            uris.forEach { uri ->
+                try {
+                    context.contentResolver.takePersistableUriPermission(
+                        uri,
+                        Intent.FLAG_GRANT_READ_URI_PERMISSION,
+                    )
+                } catch (e: SecurityException) {
+                    Timber.w(e, "Could not take persistable permission")
+                }
+
+                val fileName = resolveDisplayName(uri)
+                val extension = fileName.substringAfterLast('.', "").lowercase()
+                if (extension !in YouTube.SUPPORTED_UPLOAD_TYPES) {
+                    toast(R.string.upload_unsupported_format)
+                    return@forEach
+                }
+
+                val size =
+                    context.contentResolver
+                        .openFileDescriptor(uri, "r")
+                        ?.use { it.statSize }
+                        ?: -1L
+                if (size <= 0L) return@forEach
+                if (size > YouTube.MAX_UPLOAD_SIZE) {
+                    toast(R.string.upload_file_too_large)
+                    return@forEach
+                }
+
+                database.insert(
+                    UploadQueueEntity(
+                        uri = uri.toString(),
+                        displayName = fileName,
+                        sizeBytes = size,
+                    ),
+                )
+            }
+        }
+    }
+
+    private suspend fun runOne(row: UploadQueueEntity) {
+        database.updateUploadState(row.id, UploadState.RUNNING)
+
+        var lastProgressWrite = 0L
+        val result =
+            withJobRetry {
+                YouTube.uploadSong(
+                    filename = row.displayName,
+                    contentLength = row.sizeBytes,
+                    contentSource = {
+                        context.contentResolver.openInputStream(row.uri.toUri())
+                            ?: throw IOException("Cannot open ${row.uri}")
+                    },
+                    onProgress = { progress ->
+                        val now = System.currentTimeMillis()
+                        if (now - lastProgressWrite >= PROGRESS_WRITE_INTERVAL_MS) {
+                            lastProgressWrite = now
+                            viewModelScope.launch {
+                                database.updateUploadProgress(row.id, progress)
+                            }
+                        }
+                    },
+                )
+            }
+
+        if (result.isSuccess && result.getOrDefault(false)) {
+            database.updateUploadProgress(row.id, 1f)
+            database.updateUploadState(
+                row.id,
+                UploadState.SUCCESS,
+                completedAt = System.currentTimeMillis(),
+            )
+        } else {
+            database.updateUploadState(
+                row.id,
+                UploadState.FAILED,
+                error = result.exceptionOrNull()?.message,
+                completedAt = System.currentTimeMillis(),
+            )
+        }
+    }
+
+    private fun resolveDisplayName(uri: Uri): String {
+        var fileName = uri.lastPathSegment?.substringAfterLast('/') ?: "unknown"
+        context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+            if (cursor.moveToFirst()) {
+                val index = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                if (index >= 0) {
+                    val name = cursor.getString(index)
+                    if (!name.isNullOrBlank()) {
+                        fileName = name
+                    }
+                }
+            }
+        }
+        return fileName
+    }
+
+    private suspend fun toast(resId: Int) {
+        withContext(Dispatchers.Main) {
+            Toast.makeText(context, context.getString(resId), Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    companion object {
+        private const val MAX_CONCURRENT_UPLOADS = 2
+        private const val PROGRESS_WRITE_INTERVAL_MS = 250L
+    }
+}

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/UploadViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/UploadViewModel.kt
@@ -112,6 +112,43 @@ constructor(
         }
     }
 
+    /** Cancel one queued/running upload. Routed to the service, which holds the job handle. */
+    fun cancel(id: String) {
+        context.startService(
+            Intent(context, UploadService::class.java).apply {
+                action = UploadService.ACTION_CANCEL
+                putExtra(UploadService.EXTRA_UPLOAD_ID, id)
+            },
+        )
+    }
+
+    /** Cancel the entire active queue. */
+    fun cancelAll() {
+        context.startService(
+            Intent(context, UploadService::class.java).apply {
+                action = UploadService.ACTION_CANCEL_ALL
+            },
+        )
+    }
+
+    /**
+     * Retry a FAILED row: flip it back to PENDING and (re)start the service —
+     * a FAILED-only queue has no active rows, so the service has already stopped.
+     */
+    fun retry(id: String) {
+        viewModelScope.launch(Dispatchers.IO) {
+            database.retryUpload(id)
+            startUploadService()
+        }
+    }
+
+    /** Remove all terminal rows (SUCCESS, CANCELLED, FAILED) from the queue. */
+    fun clearCompleted() {
+        viewModelScope.launch(Dispatchers.IO) {
+            database.deleteCompletedUploads()
+        }
+    }
+
     private fun startUploadService() {
         ContextCompat.startForegroundService(
             context,

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -918,6 +918,9 @@
 
     <!-- Upload songs -->
     <string name="upload_songs">Upload songs</string>
+    <string name="upload_channel_name">Uploads</string>
+    <string name="upload_channel_desc">Shows a notification while uploading songs in the background</string>
+    <string name="upload_notification_title">Uploading songs</string>
     <string name="uploading">Uploading…</string>
     <string name="upload_progress">%1$d of %2$d</string>
     <string name="upload_status_summary">Uploading %1$d of %2$d · %3$d%%</string>

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -921,6 +921,10 @@
     <string name="upload_channel_name">Uploads</string>
     <string name="upload_channel_desc">Shows a notification while uploading songs in the background</string>
     <string name="upload_notification_title">Uploading songs</string>
+    <string name="upload_cancel">Cancel</string>
+    <string name="upload_retry">Retry</string>
+    <string name="upload_cancel_all">Cancel all</string>
+    <string name="upload_clear_completed">Clear completed</string>
     <string name="uploading">Uploading…</string>
     <string name="upload_progress">%1$d of %2$d</string>
     <string name="upload_status_summary">Uploading %1$d of %2$d · %3$d%%</string>

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -920,6 +920,7 @@
     <string name="upload_songs">Upload songs</string>
     <string name="uploading">Uploading…</string>
     <string name="upload_progress">%1$d of %2$d</string>
+    <string name="upload_status_summary">Uploading %1$d of %2$d · %3$d%%</string>
     <string name="upload_complete">Upload complete</string>
     <string name="upload_failed">Upload failed</string>
     <string name="upload_file_too_large">File too large (maximum 300MB)</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,6 +60,7 @@ compose-reorderable = { module = "sh.calvin.reorderable:reorderable", version.re
 viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
 viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "lifecycle" }
+lifecycle-service = { module = "androidx.lifecycle:lifecycle-service", version.ref = "lifecycle" }
 
 material3 = { module = "androidx.compose.material3:material3", version.ref = "material3" }
 

--- a/innertube/src/main/kotlin/com/metrolist/innertube/InnerTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/InnerTube.kt
@@ -19,7 +19,11 @@ import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.request.*
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.*
+import io.ktor.http.content.OutgoingContent
 import io.ktor.serialization.kotlinx.json.*
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.jvm.javaio.toByteReadChannel
+import java.io.InputStream
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import java.net.Proxy
@@ -739,12 +743,24 @@ class InnerTube {
 
     /**
      * Upload song data to the provided upload URL.
+     *
+     * Streams the body from [contentSource] rather than buffering the whole file
+     * in memory. The factory is invoked once per attempt — required because
+     * [withRetry] re-executes the post block on IOException and a single
+     * InputStream cannot be re-read.
      */
     suspend fun uploadSongData(
         uploadUrl: String,
-        data: ByteArray,
-        onProgress: ((Float) -> Unit)? = null
+        contentLength: Long,
+        contentSource: () -> InputStream,
+        onProgress: ((Float) -> Unit)? = null,
     ) = withRetry {
+        val body = object : OutgoingContent.ReadChannelContent() {
+            override val contentType = ContentType.Application.OctetStream
+            override val contentLength: Long = contentLength
+            override fun readFrom(): ByteReadChannel =
+                contentSource().toByteReadChannel()
+        }
         httpClient.post(uploadUrl) {
             headers {
                 append("X-Goog-Upload-Command", "upload, finalize")
@@ -759,10 +775,9 @@ class InnerTube {
                     append("Authorization", "SAPISIDHASH ${currentTime}_${sapisidHash}")
                 }
             }
-            contentType(ContentType.Application.OctetStream)
-            setBody(data)
-            onUpload { bytesSentTotal, contentLength ->
-                contentLength?.let {
+            setBody(body)
+            onUpload { bytesSentTotal, total ->
+                total?.let {
                     onProgress?.invoke(bytesSentTotal.toFloat() / it.toFloat())
                 }
             }

--- a/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
@@ -80,6 +80,7 @@ import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
 import timber.log.Timber
+import java.io.InputStream
 import java.net.Proxy
 import kotlin.random.Random
 
@@ -3270,21 +3271,28 @@ object YouTube {
 
     /**
      * Upload a song to YouTube Music.
+     *
+     * The body is streamed from [contentSource], so memory stays flat regardless
+     * of file size. The factory is invoked once per upload attempt — see
+     * [InnerTube.uploadSongData].
+     *
      * @param filename The name of the file
-     * @param data The file data as ByteArray
+     * @param contentLength Exact byte length of the file (required for progress and content-length header)
+     * @param contentSource Factory yielding a fresh InputStream per attempt
      * @param onProgress Callback for upload progress (0.0 to 1.0)
      * @return true if upload succeeded
      */
     suspend fun uploadSong(
         filename: String,
-        data: ByteArray,
+        contentLength: Long,
+        contentSource: () -> InputStream,
         onProgress: ((Float) -> Unit)? = null,
     ): Result<Boolean> =
         runCatching {
             onProgress?.invoke(0f)
 
             // Step 1: Initialize upload (5% of progress)
-            val initResponse = innerTube.initSongUpload(filename, data.size.toLong())
+            val initResponse = innerTube.initSongUpload(filename, contentLength)
             val uploadUrl =
                 initResponse.headers["X-Goog-Upload-URL"]
                     ?: throw Exception("Failed to get upload URL")
@@ -3295,7 +3303,8 @@ object YouTube {
             val uploadResponse =
                 innerTube.uploadSongData(
                     uploadUrl = uploadUrl,
-                    data = data,
+                    contentLength = contentLength,
+                    contentSource = contentSource,
                     onProgress = { uploadProgress ->
                         // Map upload progress (0-1) to overall progress (0.05-1.0)
                         onProgress?.invoke(0.05f + uploadProgress * 0.95f)


### PR DESCRIPTION
## Problem
  The existing "upload to YouTube Music" flow (Library → Songs and the
  "Uploaded" auto-playlist) is unreliable and resource-heavy:

  - **Uploads are killed by navigation/backgrounding.** The loop runs in a 
  Compose `rememberCoroutineScope`, so leaving the screen cancels the whole
  batch.
  - **OOM risk on large files.** Each file is read fully into a `ByteArray`
    (up to ~300 MB) and that same array is handed to Ktor via `setBody(data)` —
    two heap-resident copies per file.
  - **Strictly sequential.** Files upload one-by-one; the next can't start until
    the previous finishes.
  - **No durable retry, no progress UI, no persistence.** A missing
    `X-Goog-Upload-URL` header throws a plain `Exception` that escapes the
    `IOException`-only retry, failing the whole job with just a Toast.
  - **~222 lines of byte-for-byte duplicated upload code** between
    `LibrarySongsScreen` and `AutoPlaylistScreen`.

  ## Cause
  The upload pipeline was implemented as an in-Compose coroutine loop with the
  whole file buffered in memory. Its lifecycle is tied to the composable rather
  than to the work itself, there is no persistent job state, and the retry
  helper
  only wraps a single HTTP request (catching `IOException` only) rather than the
  job as a whole.

  ## Solution
  - **Stream uploads instead of buffering.** `uploadSong`/`uploadSongData` now
  take
    a `contentLength` + `() -> InputStream` factory and stream the body via a
  Ktor
    `ReadChannelContent`; a fresh stream is created per attempt so memory stays
  flat
    regardless of file size.
  - **Persistent upload queue (Room, schema v39).** New `UploadQueueEntity`
    (state/progress/attempts) + DAO, with auto-migration 38→39, as the single
  source
    of truth for job state.
  - **Foreground `UploadService`** owns queue execution so uploads survive
    navigation and process death; orphaned `RUNNING` rows are re-marked
  `PENDING`
    on start.
  - **`UploadViewModel`** drives `PENDING` rows with capped concurrency via a
    `Semaphore` (no longer strictly sequential).
  - **Job-level retry** (`withJobRetry`): exponential backoff, 3 attempts,
  returns
    early on `CancellationException`.
  - **`UploadStatusBar`** — collapsible progress UI; cancel / cancel-all / retry
    wired through the bar and the service notification.
  - **De-duplicated** `LibrarySongsScreen` and `AutoPlaylistScreen` onto the
  shared
    `UploadViewModel` queue.
  - Library auto-syncs (`syncUploadedSongs`) after a run drains with ≥1 success.

  ## Testing
  - Testing was done in Android Studio Pixel 9 with Android 16
  - Queued multiple files from both Library → Songs and the "Uploaded" playlist;
    verified parallel progress in the status bar.
  - Navigated away / backgrounded the app mid-upload — uploads continued via the
    foreground service and the library synced on completion.
  - Verified cancel, cancel-all, and retry from both the status bar and the
    notification.
  - Confirmed large-file uploads complete with flat memory (no `ByteArray`
    buffering).
  - Room migration 38→39 verified against exported schema `39.json`.

  ## Related Issues
  - Closes #3604

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added background upload queue system for managing file uploads.
  * Added upload status bar displaying progress with cancel, retry, and clear completed actions.
  * Added notification channel for upload operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->