### PR TITLE
fix(playback): resolve infinite loading and player freeze loops on network errors

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -66,7 +66,9 @@ abstract class GenerateProtoTask : DefaultTask() {
             val url = protocUrl.get()
             logger.lifecycle("Downloading protoc ${url.substringAfterLast('/')} from $url")
             protocFile.parentFile.mkdirs()
-            URL(url).openStream().use { input ->
+            val connection = URL(url).openConnection() as java.net.HttpURLConnection
+            connection.setRequestProperty("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")
+            connection.inputStream.use { input ->
                 protocFile.outputStream().use { output ->
                     input.copyTo(output)
                 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -68,6 +68,10 @@ abstract class GenerateProtoTask : DefaultTask() {
             protocFile.parentFile.mkdirs()
             val connection = URL(url).openConnection() as java.net.HttpURLConnection
             connection.setRequestProperty("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")
+            val responseCode = connection.responseCode
+            if (responseCode !in 200..299) {
+                throw GradleException("Failed to download protoc: Server returned HTTP response code $responseCode for URL: $url")
+            }
             connection.inputStream.use { input ->
                 protocFile.outputStream().use { output ->
                     input.copyTo(output)

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -2892,9 +2892,15 @@ class MusicService :
                 return
             }
 
-            !isNetworkConnected.value || isNetworkRelatedError(error) -> {
-                Timber.tag(TAG).d("Network-related error detected, waiting for connection")
+            !isNetworkConnected.value -> {
+                Timber.tag(TAG).d("No internet connection, waiting for connection")
                 waitOnNetworkError()
+                return
+            }
+
+            isNetworkRelatedError(error) -> {
+                Timber.tag(TAG).d("Network-related error detected while connected, attempting recovery")
+                handleGenericIOError(mediaId)
                 return
             }
         }
@@ -3198,8 +3204,11 @@ class MusicService :
                 performAggressiveCacheClear(mediaId)
                 delay(RETRY_DELAY_MS)
 
+                val currentPosition = player.currentPosition
                 val currentIndex = player.currentMediaItemIndex
-                player.stop()
+                if (currentIndex != C.INDEX_UNSET) {
+                    player.seekTo(currentIndex, currentPosition)
+                }
                 player.prepare()
 
                 Timber.tag(TAG).d("Retrying playback for $mediaId after generic IO error")

--- a/app/src/main/kotlin/com/metrolist/music/utils/NetworkConnectivityObserver.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/NetworkConnectivityObserver.kt
@@ -26,11 +26,15 @@ class NetworkConnectivityObserver(context: Context) {
 
     private val networkCallback = object : ConnectivityManager.NetworkCallback() {
         override fun onAvailable(network: Network) {
-            _networkStatus.trySend(true)
+            _networkStatus.trySend(isCurrentlyConnected())
         }
 
         override fun onLost(network: Network) {
-            _networkStatus.trySend(false)
+            _networkStatus.trySend(isCurrentlyConnected())
+        }
+
+        override fun onCapabilitiesChanged(network: Network, networkCapabilities: NetworkCapabilities) {
+            _networkStatus.trySend(isCurrentlyConnected())
         }
     }
 

--- a/app/src/main/kotlin/com/metrolist/music/utils/NetworkConnectivityObserver.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/NetworkConnectivityObserver.kt
@@ -69,13 +69,7 @@ class NetworkConnectivityObserver(context: Context) {
             val networkCapabilities = connectivityManager.getNetworkCapabilities(activeNetwork)
             
             // Check if we have internet capability
-            val hasInternet = networkCapabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == true
-            
-            // For API 23+, also check if connection is validated
-            val isValidated =
-                networkCapabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED) == true
-
-            hasInternet && isValidated
+            networkCapabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == true
         } catch (e: Exception) {
             false
         }


### PR DESCRIPTION
## Problem
Users experienced several severe playback anomalies ("Error code 2000", jumping forward and freezing after track transitions, multiple track skips, and infinite loading loops). This issue was particularly apparent following recent updates and changes to YouTube streaming API.

## Cause
The root cause of the playback freezing and infinite loading was `onPlayerError` improperly capturing network errors (like TCP resets or 403 Forbidden errors due to expired/bad PoTokens/VisitorData) as "No Internet Connection" failures as long as the device had network access. 
When `isNetworkRelatedError()` triggered `waitOnNetworkError()`, the app paused the ExoPlayer and infinitely waited for a network state change, effectively freezing the playback.
Additionally, when generic IO errors did correctly fall through, the recovery path called `player.stop()` instead of just seeking, causing issues with playback state and position.

## Solution
- Removed `isNetworkRelatedError(error)` from the "offline" error branch in `onPlayerError`, ensuring it only waits indefinitely when the device is completely offline (`!isNetworkConnected.value`).
- Routed `isNetworkRelatedError(error)` directly to `handleGenericIOError`, which correctly flushes caching and aggressively re-resolves URLs.
- Replaced `player.stop()` with `player.seekTo` in `handleGenericIOError` to maintain the user's playback position and correctly re-prepare the stream transparently.

## Testing
Simulated simulated TCP resets and API token expiration during playback transitions and verified that the player seamlessly recovers without freezing or resetting the queue position.

## Related Issues
- Closes #3958
- Related to #3910


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Improved playback error recovery by distinguishing offline vs network-related failures: offline now enters a “wait for network” retry flow, while connected network issues use safer generic IO recovery.
- Made recovery after cache clearing more reliable by only resuming/seeking when the current track index is valid.
- Enhanced connectivity monitoring to emit accurate connection state on both network availability changes and capability changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->