### PR TITLE
fix(cipher): add player_ias configs for recent player rotations (incl. live 445213fb)

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/FunctionNameExtractor.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/FunctionNameExtractor.kt
@@ -208,7 +208,176 @@ object FunctionNameExtractor {
             nConstantArgs = null,
             nJsExpression = "(function(n){try{var u=new g.Yx('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
             signatureTimestamp = 20613
-        )
+        ),
+        // ===== player_ias configs for the last 7 days of player rotations =====
+        // player_ias 445213fb / d62bd338 (2026-06-10): mP(4,155,INPUT) via g.Yx. STS 20613. CDN-validated (HTTP 206).
+        "445213fb" to HardcodedPlayerConfig(
+            sigFuncName = "_expr_sig",
+            sigConstantArg = null,
+            sigJsExpression = "mP(4,155,INPUT)",
+            nFuncName = "_expr_n",
+            nArrayIndex = null,
+            nConstantArgs = null,
+            nJsExpression = "(function(n){try{var u=new g.Yx('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
+            signatureTimestamp = 20613
+        ),
+        "d62bd338" to HardcodedPlayerConfig(
+            sigFuncName = "_expr_sig",
+            sigConstantArg = null,
+            sigJsExpression = "mP(4,155,INPUT)",
+            nFuncName = "_expr_n",
+            nArrayIndex = null,
+            nConstantArgs = null,
+            nJsExpression = "(function(n){try{var u=new g.Yx('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
+            signatureTimestamp = 20613
+        ),
+        // player_ias a32660fc / e786ad71 (2026-06-10): mP(4,155,INPUT) via g.Yx. STS 20613. CDN-validated (HTTP 206).
+        "a32660fc" to HardcodedPlayerConfig(
+            sigFuncName = "_expr_sig",
+            sigConstantArg = null,
+            sigJsExpression = "mP(4,155,INPUT)",
+            nFuncName = "_expr_n",
+            nArrayIndex = null,
+            nConstantArgs = null,
+            nJsExpression = "(function(n){try{var u=new g.Yx('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
+            signatureTimestamp = 20613
+        ),
+        "e786ad71" to HardcodedPlayerConfig(
+            sigFuncName = "_expr_sig",
+            sigConstantArg = null,
+            sigJsExpression = "mP(4,155,INPUT)",
+            nFuncName = "_expr_n",
+            nArrayIndex = null,
+            nConstantArgs = null,
+            nJsExpression = "(function(n){try{var u=new g.Yx('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
+            signatureTimestamp = 20613
+        ),
+        // player_ias 959dabb2 / 79c1b58e (2026-06-12): IR(84,305,INPUT) via g.Ga. STS 20614. CDN-validated (HTTP 206).
+        "959dabb2" to HardcodedPlayerConfig(
+            sigFuncName = "_expr_sig",
+            sigConstantArg = null,
+            sigJsExpression = "IR(84,305,INPUT)",
+            nFuncName = "_expr_n",
+            nArrayIndex = null,
+            nConstantArgs = null,
+            nJsExpression = "(function(n){try{var u=new g.Ga('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
+            signatureTimestamp = 20614
+        ),
+        "79c1b58e" to HardcodedPlayerConfig(
+            sigFuncName = "_expr_sig",
+            sigConstantArg = null,
+            sigJsExpression = "IR(84,305,INPUT)",
+            nFuncName = "_expr_n",
+            nArrayIndex = null,
+            nConstantArgs = null,
+            nJsExpression = "(function(n){try{var u=new g.Ga('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
+            signatureTimestamp = 20614
+        ),
+        // player_ias bb52fe90 / f6046ecd (2026-06-12): Ez(5,408,INPUT) via g.Oq. STS 20615. CDN-validated (HTTP 206).
+        "bb52fe90" to HardcodedPlayerConfig(
+            sigFuncName = "_expr_sig",
+            sigConstantArg = null,
+            sigJsExpression = "Ez(5,408,INPUT)",
+            nFuncName = "_expr_n",
+            nArrayIndex = null,
+            nConstantArgs = null,
+            nJsExpression = "(function(n){try{var u=new g.Oq('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
+            signatureTimestamp = 20615
+        ),
+        "f6046ecd" to HardcodedPlayerConfig(
+            sigFuncName = "_expr_sig",
+            sigConstantArg = null,
+            sigJsExpression = "Ez(5,408,INPUT)",
+            nFuncName = "_expr_n",
+            nArrayIndex = null,
+            nConstantArgs = null,
+            nJsExpression = "(function(n){try{var u=new g.Oq('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
+            signatureTimestamp = 20615
+        ),
+        // player_ias 1acfe3aa / fbcdec38 (2026-06-12): na(16,3372,INPUT) via g.dn. STS 20616. CDN-validated (HTTP 206).
+        "1acfe3aa" to HardcodedPlayerConfig(
+            sigFuncName = "_expr_sig",
+            sigConstantArg = null,
+            sigJsExpression = "na(16,3372,INPUT)",
+            nFuncName = "_expr_n",
+            nArrayIndex = null,
+            nConstantArgs = null,
+            nJsExpression = "(function(n){try{var u=new g.dn('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
+            signatureTimestamp = 20616
+        ),
+        "fbcdec38" to HardcodedPlayerConfig(
+            sigFuncName = "_expr_sig",
+            sigConstantArg = null,
+            sigJsExpression = "na(16,3372,INPUT)",
+            nFuncName = "_expr_n",
+            nArrayIndex = null,
+            nConstantArgs = null,
+            nJsExpression = "(function(n){try{var u=new g.dn('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
+            signatureTimestamp = 20616
+        ),
+        // player_ias c7119fda / bfba3b57 (2026-06-12): na(16,3372,INPUT) via g.dn. STS 20616. CDN-validated (HTTP 206).
+        "c7119fda" to HardcodedPlayerConfig(
+            sigFuncName = "_expr_sig",
+            sigConstantArg = null,
+            sigJsExpression = "na(16,3372,INPUT)",
+            nFuncName = "_expr_n",
+            nArrayIndex = null,
+            nConstantArgs = null,
+            nJsExpression = "(function(n){try{var u=new g.dn('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
+            signatureTimestamp = 20616
+        ),
+        "bfba3b57" to HardcodedPlayerConfig(
+            sigFuncName = "_expr_sig",
+            sigConstantArg = null,
+            sigJsExpression = "na(16,3372,INPUT)",
+            nFuncName = "_expr_n",
+            nArrayIndex = null,
+            nConstantArgs = null,
+            nJsExpression = "(function(n){try{var u=new g.dn('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
+            signatureTimestamp = 20616
+        ),
+        // player_ias 88c25a98 / 62100781 (2026-06-13): il(16,3372,INPUT) via g.e4. STS 20616. CDN-validated (HTTP 206).
+        "88c25a98" to HardcodedPlayerConfig(
+            sigFuncName = "_expr_sig",
+            sigConstantArg = null,
+            sigJsExpression = "il(16,3372,INPUT)",
+            nFuncName = "_expr_n",
+            nArrayIndex = null,
+            nConstantArgs = null,
+            nJsExpression = "(function(n){try{var u=new g.e4('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
+            signatureTimestamp = 20616
+        ),
+        "62100781" to HardcodedPlayerConfig(
+            sigFuncName = "_expr_sig",
+            sigConstantArg = null,
+            sigJsExpression = "il(16,3372,INPUT)",
+            nFuncName = "_expr_n",
+            nArrayIndex = null,
+            nConstantArgs = null,
+            nJsExpression = "(function(n){try{var u=new g.e4('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
+            signatureTimestamp = 20616
+        ),
+        // player_ias 712f0810 / 02a03f06 (2026-06-13): il(16,3372,INPUT) via g.e4. STS 20616. CDN-validated (HTTP 206).
+        "712f0810" to HardcodedPlayerConfig(
+            sigFuncName = "_expr_sig",
+            sigConstantArg = null,
+            sigJsExpression = "il(16,3372,INPUT)",
+            nFuncName = "_expr_n",
+            nArrayIndex = null,
+            nConstantArgs = null,
+            nJsExpression = "(function(n){try{var u=new g.e4('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
+            signatureTimestamp = 20616
+        ),
+        "02a03f06" to HardcodedPlayerConfig(
+            sigFuncName = "_expr_sig",
+            sigConstantArg = null,
+            sigJsExpression = "il(16,3372,INPUT)",
+            nFuncName = "_expr_n",
+            nArrayIndex = null,
+            nConstantArgs = null,
+            nJsExpression = "(function(n){try{var u=new g.e4('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
+            signatureTimestamp = 20616
+        ),
     )
 
     // ==================== DETECTION PATTERNS ====================


### PR DESCRIPTION
## Summary

Adds hardcoded `player_ias` cipher configs for the players YouTube has rotated through recently — **including the current live player `445213fb`**, which neither the regex extractor nor the existing `KNOWN_PLAYER_CONFIGS` table covers. Without these, WEB_REMIX signature deobfuscation fails on the live player and the app silently falls back to another client (logcat: `Metrolist_CipherFnExtract: ... EXTRACTION FAILED` → `Trying fallback client 1/12: VISIONOS`).

Because these entries supply both the signature (`sig`) call and the n-transform class, they restore:

- **WEB_REMIX** (the main client) and the other web / cipher-based fallback clients.
- **Age-restricted** songs, which require the web n-transform — only runnable once the player's cipher config is known.
- **Uploaded** songs, which likewise depend on that n-transform.

This builds on the existing `_expr_sig` / `_expr_n` mechanism already in `FunctionNameExtractor.kt`; it only adds new map entries (no behavior change for existing players).

## Entries added

Each as an `_expr_sig` / `_expr_n` `HardcodedPlayerConfig`, with its md5-of-first-10000-bytes fallback alias:

| player (+ alias) | sig | n-class | STS |
|---|---|---|---|
| `445213fb` / `d62bd338` *(current live)* | `mP(4,155)` | `g.Yx` | 20613 |
| `a32660fc` / `e786ad71` | `mP(4,155)` | `g.Yx` | 20613 |
| `959dabb2` / `79c1b58e` | `IR(84,305)` | `g.Ga` | 20614 |
| `bb52fe90` / `f6046ecd` | `Ez(5,408)` | `g.Oq` | 20615 |
| `1acfe3aa` / `fbcdec38` | `na(16,3372)` | `g.dn` | 20616 |
| `c7119fda` / `bfba3b57` | `na(16,3372)` | `g.dn` | 20616 |
| `88c25a98` / `62100781` | `il(16,3372)` | `g.e4` | 20616 |
| `712f0810` / `02a03f06` | `il(16,3372)` | `g.e4` | 20616 |

## Validation

- Each config was validated against the live googlevideo CDN (**HTTP 206** on a real stream) — ground truth, not just regex extraction.
- `:app:assembleFossDebug` builds green on top of current `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated YouTube player support configuration to keep signature handling compatible with recent `player.js` rotations, improving reliability after platform updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->