### PR TITLE
Remote-updatable cipher configs + stream-source controls

### DIFF
--- a/app/src/main/assets/player_configs.json
+++ b/app/src/main/assets/player_configs.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": 1,
+  "players": {
+    "69e2a55d": { "sig": "Jf(20,3699,INPUT)", "nClass": "iE", "sts": 20611, "aliases": ["70d8066f"] },
+    "9d2ef9ef": { "sig": "v0(35,4499,INPUT)", "nClass": "uY", "sts": 20607, "aliases": ["6fb43da5"] },
+    "16ee6936": { "sig": "mP(4,155,INPUT)", "nClass": "Yx", "sts": 20613, "aliases": ["ca366632"] },
+    "ce74690f": { "sig": "$9(2,6487,INPUT)", "nClass": "cV", "sts": 20612, "aliases": ["a5669e32"] },
+    "6b8eecd5": { "sig": "mP(4,155,INPUT)", "nClass": "Yx", "sts": 20613, "aliases": ["6ea478fa"] },
+    "445213fb": { "sig": "mP(4,155,INPUT)", "nClass": "Yx", "sts": 20613, "aliases": ["d62bd338"] },
+    "a32660fc": { "sig": "mP(4,155,INPUT)", "nClass": "Yx", "sts": 20613, "aliases": ["e786ad71"] },
+    "959dabb2": { "sig": "IR(84,305,INPUT)", "nClass": "Ga", "sts": 20614, "aliases": ["79c1b58e"] },
+    "bb52fe90": { "sig": "Ez(5,408,INPUT)", "nClass": "Oq", "sts": 20615, "aliases": ["f6046ecd"] },
+    "1acfe3aa": { "sig": "na(16,3372,INPUT)", "nClass": "dn", "sts": 20616, "aliases": ["fbcdec38"] },
+    "c7119fda": { "sig": "na(16,3372,INPUT)", "nClass": "dn", "sts": 20616, "aliases": ["bfba3b57"] },
+    "88c25a98": { "sig": "il(16,3372,INPUT)", "nClass": "e4", "sts": 20616, "aliases": ["62100781"] },
+    "712f0810": { "sig": "il(16,3372,INPUT)", "nClass": "e4", "sts": 20616, "aliases": ["02a03f06"] },
+    "ae0b654c": { "sig": "Ge(91,8257,INPUT)", "nClass": "bK", "sts": 20618, "aliases": ["efc5f0ec"] }
+  }
+}

--- a/app/src/main/kotlin/com/metrolist/music/App.kt
+++ b/app/src/main/kotlin/com/metrolist/music/App.kt
@@ -78,10 +78,12 @@ class App :
             Timber.e(e, "Failed to ensure DataStore directory")
         }
 
+        // Plant logging BEFORE cipher init so the synchronous config-store load
+        // (bundled asset + cached overlay) is captured, not just the async remote refresh.
+        Timber.plant(Timber.DebugTree())
+
         // Initialize cipher deobfuscator for WEB_REMIX streaming
         CipherDeobfuscator.initialize(this)
-
-        Timber.plant(Timber.DebugTree())
 
         // Pre-read Coil cache size on background to avoid runBlocking in newImageLoader
         applicationScope.launch(Dispatchers.IO) {

--- a/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
@@ -166,7 +166,6 @@ val StreamSourceTVHTML5Key = booleanPreferencesKey("streamSourceTVHTML5")
 val StreamSourceAndroidVRKey = booleanPreferencesKey("streamSourceAndroidVR")
 val StreamSourceVisionOSKey = booleanPreferencesKey("streamSourceVisionOS")
 val StreamSourceIOSKey = booleanPreferencesKey("streamSourceIOS")
-val StreamSourceIPadOSKey = booleanPreferencesKey("streamSourceIPadOS")
 val StreamSourceWebCreatorKey = booleanPreferencesKey("streamSourceWebCreator")
 val StreamSourceAndroidCreatorKey = booleanPreferencesKey("streamSourceAndroidCreator")
 

--- a/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
@@ -160,6 +160,16 @@ val PauseListenHistoryKey = booleanPreferencesKey("pauseListenHistory")
 val PauseSearchHistoryKey = booleanPreferencesKey("pauseSearchHistory")
 val DisableScreenshotKey = booleanPreferencesKey("disableScreenshot")
 
+// Stream sources — which innertube clients are used for stream resolution (Settings → Stream sources).
+val StreamSourceWebRemixKey = booleanPreferencesKey("streamSourceWebRemix")
+val StreamSourceTVHTML5Key = booleanPreferencesKey("streamSourceTVHTML5")
+val StreamSourceAndroidVRKey = booleanPreferencesKey("streamSourceAndroidVR")
+val StreamSourceVisionOSKey = booleanPreferencesKey("streamSourceVisionOS")
+val StreamSourceIOSKey = booleanPreferencesKey("streamSourceIOS")
+val StreamSourceIPadOSKey = booleanPreferencesKey("streamSourceIPadOS")
+val StreamSourceWebCreatorKey = booleanPreferencesKey("streamSourceWebCreator")
+val StreamSourceAndroidCreatorKey = booleanPreferencesKey("streamSourceAndroidCreator")
+
 val EnableDiscordRPCKey = booleanPreferencesKey("discordRPCEnable")
 val DiscordInfoDismissedKey = booleanPreferencesKey("discordInfoDismissed")
 val DiscordUsernameKey = stringPreferencesKey("discordUsername")

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -98,6 +98,14 @@ import com.metrolist.music.constants.AudioTrackPlaybackParamsKey
 import com.metrolist.music.constants.AutoDownloadOnLikeKey
 import com.metrolist.music.constants.AutoLoadMoreKey
 import com.metrolist.music.constants.AutoSkipNextOnErrorKey
+import com.metrolist.music.constants.StreamSourceAndroidCreatorKey
+import com.metrolist.music.constants.StreamSourceAndroidVRKey
+import com.metrolist.music.constants.StreamSourceIOSKey
+import com.metrolist.music.constants.StreamSourceIPadOSKey
+import com.metrolist.music.constants.StreamSourceTVHTML5Key
+import com.metrolist.music.constants.StreamSourceVisionOSKey
+import com.metrolist.music.constants.StreamSourceWebCreatorKey
+import com.metrolist.music.constants.StreamSourceWebRemixKey
 import com.metrolist.music.constants.AutoplayKey
 import com.metrolist.music.constants.CrossfadeDurationKey
 import com.metrolist.music.constants.CrossfadeEnabledKey
@@ -1122,6 +1130,23 @@ class MusicService :
         }
         scope.launch {
             dataStore.data.map { it[AutoLoadMoreKey] ?: true }.distinctUntilChanged().collect { cachedAutoLoadMore = it }
+        }
+        // Keep YTPlayerUtils in sync with the stream source toggles (Settings → Stream sources).
+        scope.launch {
+            dataStore.data.collect { prefs ->
+                val disabled = mutableSetOf<String>()
+                if (prefs[StreamSourceWebRemixKey] == false) disabled += "WEB_REMIX"
+                if (prefs[StreamSourceTVHTML5Key] == false) disabled += "TVHTML5"
+                if (prefs[StreamSourceAndroidVRKey] == false) disabled += "ANDROID_VR"
+                // IOS/IPADOS share clientName "IOS"; ANDROID_CREATOR needs DroidGuard — these default
+                // OFF (`!= true`: unset or false both disable; only an explicit toggle enables them).
+                if (prefs[StreamSourceIOSKey] != true) disabled += "IOS"
+                if (prefs[StreamSourceIPadOSKey] != true) disabled += "IOS" // IPADOS uses the IOS clientName
+                if (prefs[StreamSourceVisionOSKey] == false) disabled += "VISIONOS"
+                if (prefs[StreamSourceWebCreatorKey] == false) disabled += "WEB_CREATOR"
+                if (prefs[StreamSourceAndroidCreatorKey] != true) disabled += "ANDROID_CREATOR"
+                YTPlayerUtils.disabledStreamClients = disabled
+            }
         }
 
         if (startupPrefs!![PersistentQueueKey] ?: true) {

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -101,7 +101,6 @@ import com.metrolist.music.constants.AutoSkipNextOnErrorKey
 import com.metrolist.music.constants.StreamSourceAndroidCreatorKey
 import com.metrolist.music.constants.StreamSourceAndroidVRKey
 import com.metrolist.music.constants.StreamSourceIOSKey
-import com.metrolist.music.constants.StreamSourceIPadOSKey
 import com.metrolist.music.constants.StreamSourceTVHTML5Key
 import com.metrolist.music.constants.StreamSourceVisionOSKey
 import com.metrolist.music.constants.StreamSourceWebCreatorKey
@@ -1138,10 +1137,10 @@ class MusicService :
                 if (prefs[StreamSourceWebRemixKey] == false) disabled += "WEB_REMIX"
                 if (prefs[StreamSourceTVHTML5Key] == false) disabled += "TVHTML5"
                 if (prefs[StreamSourceAndroidVRKey] == false) disabled += "ANDROID_VR"
-                // IOS/IPADOS share clientName "IOS"; ANDROID_CREATOR needs DroidGuard — these default
-                // OFF (`!= true`: unset or false both disable; only an explicit toggle enables them).
+                // The IOS toggle covers both the iOS and iPadOS clients (they share clientName "IOS");
+                // ANDROID_CREATOR needs DroidGuard — these default OFF (`!= true`: unset or false both
+                // disable; only an explicit toggle enables them).
                 if (prefs[StreamSourceIOSKey] != true) disabled += "IOS"
-                if (prefs[StreamSourceIPadOSKey] != true) disabled += "IOS" // IPADOS uses the IOS clientName
                 if (prefs[StreamSourceVisionOSKey] == false) disabled += "VISIONOS"
                 if (prefs[StreamSourceWebCreatorKey] == false) disabled += "WEB_CREATOR"
                 if (prefs[StreamSourceAndroidCreatorKey] != true) disabled += "ANDROID_CREATOR"

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -1131,21 +1131,26 @@ class MusicService :
             dataStore.data.map { it[AutoLoadMoreKey] ?: true }.distinctUntilChanged().collect { cachedAutoLoadMore = it }
         }
         // Keep YTPlayerUtils in sync with the stream source toggles (Settings → Stream sources).
+        // Map to the derived set + distinctUntilChanged so an unrelated preference write doesn't
+        // rebuild the set and rewrite the @Volatile field on every DataStore emission.
         scope.launch {
-            dataStore.data.collect { prefs ->
-                val disabled = mutableSetOf<String>()
-                if (prefs[StreamSourceWebRemixKey] == false) disabled += "WEB_REMIX"
-                if (prefs[StreamSourceTVHTML5Key] == false) disabled += "TVHTML5"
-                if (prefs[StreamSourceAndroidVRKey] == false) disabled += "ANDROID_VR"
-                // The IOS toggle covers both the iOS and iPadOS clients (they share clientName "IOS");
-                // ANDROID_CREATOR needs DroidGuard — these default OFF (`!= true`: unset or false both
-                // disable; only an explicit toggle enables them).
-                if (prefs[StreamSourceIOSKey] != true) disabled += "IOS"
-                if (prefs[StreamSourceVisionOSKey] == false) disabled += "VISIONOS"
-                if (prefs[StreamSourceWebCreatorKey] == false) disabled += "WEB_CREATOR"
-                if (prefs[StreamSourceAndroidCreatorKey] != true) disabled += "ANDROID_CREATOR"
-                YTPlayerUtils.disabledStreamClients = disabled
-            }
+            dataStore.data
+                .map { prefs ->
+                    buildSet {
+                        if (prefs[StreamSourceWebRemixKey] == false) add("WEB_REMIX")
+                        if (prefs[StreamSourceTVHTML5Key] == false) add("TVHTML5")
+                        if (prefs[StreamSourceAndroidVRKey] == false) add("ANDROID_VR")
+                        // The IOS toggle covers both the iOS and iPadOS clients (they share clientName
+                        // "IOS"); ANDROID_CREATOR needs DroidGuard — these default OFF (`!= true`: unset
+                        // or false both disable; only an explicit toggle enables them).
+                        if (prefs[StreamSourceIOSKey] != true) add("IOS")
+                        if (prefs[StreamSourceVisionOSKey] == false) add("VISIONOS")
+                        if (prefs[StreamSourceWebCreatorKey] == false) add("WEB_CREATOR")
+                        if (prefs[StreamSourceAndroidCreatorKey] != true) add("ANDROID_CREATOR")
+                    }
+                }
+                .distinctUntilChanged()
+                .collect { YTPlayerUtils.disabledStreamClients = it }
         }
 
         if (startupPrefs!![PersistentQueueKey] ?: true) {

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/NavigationBuilder.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/NavigationBuilder.kt
@@ -54,6 +54,7 @@ import com.metrolist.music.ui.screens.settings.PrivacySettings
 import com.metrolist.music.ui.screens.settings.RomanizationSettings
 import com.metrolist.music.ui.screens.settings.SettingsScreen
 import com.metrolist.music.ui.screens.settings.StorageSettings
+import com.metrolist.music.ui.screens.settings.StreamSourcesSettings
 import com.metrolist.music.ui.screens.settings.ThemeScreen
 import com.metrolist.music.ui.screens.settings.UpdaterScreen
 import com.metrolist.music.ui.screens.settings.integrations.DiscordSettings
@@ -370,6 +371,10 @@ fun NavGraphBuilder.navigationBuilder(
 
     composable("settings/player") {
         PlayerSettings(navController)
+    }
+
+    composable("settings/stream_sources") {
+        StreamSourcesSettings(navController)
     }
 
     composable("settings/storage") {

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/SettingsScreen.kt
@@ -98,7 +98,7 @@ fun SettingsScreen(
                     onClick = { navController.navigate("settings/player") }
                 ),
                 Material3SettingsItem(
-                    icon = painterResource(R.drawable.cast),
+                    icon = painterResource(R.drawable.radio),
                     title = { Text(stringResource(R.string.stream_sources)) },
                     onClick = { navController.navigate("settings/stream_sources") }
                 ),

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/SettingsScreen.kt
@@ -98,6 +98,11 @@ fun SettingsScreen(
                     onClick = { navController.navigate("settings/player") }
                 ),
                 Material3SettingsItem(
+                    icon = painterResource(R.drawable.cast),
+                    title = { Text(stringResource(R.string.stream_sources)) },
+                    onClick = { navController.navigate("settings/stream_sources") }
+                ),
+                Material3SettingsItem(
                     icon = painterResource(R.drawable.language),
                     title = { Text(stringResource(R.string.content)) },
                     onClick = { navController.navigate("settings/content") }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/StreamSourcesSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/StreamSourcesSettings.kt
@@ -42,7 +42,6 @@ import com.metrolist.music.R
 import com.metrolist.music.constants.StreamSourceAndroidCreatorKey
 import com.metrolist.music.constants.StreamSourceAndroidVRKey
 import com.metrolist.music.constants.StreamSourceIOSKey
-import com.metrolist.music.constants.StreamSourceIPadOSKey
 import com.metrolist.music.constants.StreamSourceTVHTML5Key
 import com.metrolist.music.constants.StreamSourceVisionOSKey
 import com.metrolist.music.constants.StreamSourceWebCreatorKey
@@ -63,7 +62,6 @@ fun StreamSourcesSettings(
     val (visionOS, onVisionOSChange) = rememberPreference(StreamSourceVisionOSKey, defaultValue = true)
     val (androidVR, onAndroidVRChange) = rememberPreference(StreamSourceAndroidVRKey, defaultValue = true)
     val (ios, onIosChange) = rememberPreference(StreamSourceIOSKey, defaultValue = false)
-    val (ipadOS, onIpadOSChange) = rememberPreference(StreamSourceIPadOSKey, defaultValue = false)
     val (webCreator, onWebCreatorChange) = rememberPreference(StreamSourceWebCreatorKey, defaultValue = true)
     val (androidCreator, onAndroidCreatorChange) = rememberPreference(StreamSourceAndroidCreatorKey, defaultValue = false)
 
@@ -76,7 +74,6 @@ fun StreamSourcesSettings(
         stringResource(R.string.stream_source_tvhtml5) to tvhtml5,
         stringResource(R.string.stream_source_android_vr) to androidVR,
         stringResource(R.string.stream_source_ios) to ios,
-        stringResource(R.string.stream_source_ipados) to ipadOS,
         stringResource(R.string.stream_source_android_creator) to androidCreator,
     ).filter { it.second }.map { it.first }
 
@@ -142,7 +139,6 @@ fun StreamSourcesSettings(
                 streamClientItem(R.string.stream_source_visionos, R.string.stream_source_visionos_desc, visionOS, onVisionOSChange),
                 streamClientItem(R.string.stream_source_android_vr, R.string.stream_source_android_vr_desc, androidVR, onAndroidVRChange),
                 streamClientItem(R.string.stream_source_ios, R.string.stream_source_ios_desc, ios, onIosChange),
-                streamClientItem(R.string.stream_source_ipados, R.string.stream_source_ipados_desc, ipadOS, onIpadOSChange),
             )
         )
 

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/StreamSourcesSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/StreamSourcesSettings.kt
@@ -6,24 +6,32 @@
 package com.metrolist.music.ui.screens.settings
 
 import androidx.annotation.StringRes
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -59,6 +67,19 @@ fun StreamSourcesSettings(
     val (webCreator, onWebCreatorChange) = rememberPreference(StreamSourceWebCreatorKey, defaultValue = true)
     val (androidCreator, onAndroidCreatorChange) = rememberPreference(StreamSourceAndroidCreatorKey, defaultValue = false)
 
+    // Effective resolution order: WEB_REMIX (main client) then the fallback clients, mirroring the
+    // order in YTPlayerUtils. Only enabled clients appear; the ANDROID_VR variants collapse to one.
+    val streamOrder = listOf(
+        stringResource(R.string.stream_source_web_remix) to webRemix,
+        stringResource(R.string.stream_source_visionos) to visionOS,
+        stringResource(R.string.stream_source_web_creator) to webCreator,
+        stringResource(R.string.stream_source_tvhtml5) to tvhtml5,
+        stringResource(R.string.stream_source_android_vr) to androidVR,
+        stringResource(R.string.stream_source_ios) to ios,
+        stringResource(R.string.stream_source_ipados) to ipadOS,
+        stringResource(R.string.stream_source_android_creator) to androidCreator,
+    ).filter { it.second }.map { it.first }
+
     Column(
         Modifier
             .windowInsetsPadding(
@@ -74,6 +95,36 @@ fun StreamSourcesSettings(
                 LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Top)
             )
         )
+
+        Text(
+            text = stringResource(R.string.stream_source_order),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(top = 8.dp, bottom = 8.dp),
+        )
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState()),
+        ) {
+            streamOrder.forEachIndexed { index, name ->
+                Surface(
+                    shape = RoundedCornerShape(50),
+                    color = MaterialTheme.colorScheme.secondaryContainer,
+                ) {
+                    Text(
+                        text = "${index + 1}. $name",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSecondaryContainer,
+                        modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                    )
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(20.dp))
 
         Material3SettingsGroup(
             title = stringResource(R.string.stream_source_web_clients),

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/StreamSourcesSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/StreamSourcesSettings.kt
@@ -1,0 +1,151 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.ui.screens.settings
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import com.metrolist.music.LocalPlayerAwareWindowInsets
+import com.metrolist.music.R
+import com.metrolist.music.constants.StreamSourceAndroidCreatorKey
+import com.metrolist.music.constants.StreamSourceAndroidVRKey
+import com.metrolist.music.constants.StreamSourceIOSKey
+import com.metrolist.music.constants.StreamSourceIPadOSKey
+import com.metrolist.music.constants.StreamSourceTVHTML5Key
+import com.metrolist.music.constants.StreamSourceVisionOSKey
+import com.metrolist.music.constants.StreamSourceWebCreatorKey
+import com.metrolist.music.constants.StreamSourceWebRemixKey
+import com.metrolist.music.ui.component.IconButton
+import com.metrolist.music.ui.component.Material3SettingsGroup
+import com.metrolist.music.ui.component.Material3SettingsItem
+import com.metrolist.music.ui.utils.backToMain
+import com.metrolist.music.utils.rememberPreference
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StreamSourcesSettings(
+    navController: NavController
+) {
+    val (webRemix, onWebRemixChange) = rememberPreference(StreamSourceWebRemixKey, defaultValue = true)
+    val (tvhtml5, onTvhtml5Change) = rememberPreference(StreamSourceTVHTML5Key, defaultValue = true)
+    val (visionOS, onVisionOSChange) = rememberPreference(StreamSourceVisionOSKey, defaultValue = true)
+    val (androidVR, onAndroidVRChange) = rememberPreference(StreamSourceAndroidVRKey, defaultValue = true)
+    val (ios, onIosChange) = rememberPreference(StreamSourceIOSKey, defaultValue = false)
+    val (ipadOS, onIpadOSChange) = rememberPreference(StreamSourceIPadOSKey, defaultValue = false)
+    val (webCreator, onWebCreatorChange) = rememberPreference(StreamSourceWebCreatorKey, defaultValue = true)
+    val (androidCreator, onAndroidCreatorChange) = rememberPreference(StreamSourceAndroidCreatorKey, defaultValue = false)
+
+    Column(
+        Modifier
+            .windowInsetsPadding(
+                LocalPlayerAwareWindowInsets.current.only(
+                    WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
+                )
+            )
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp)
+    ) {
+        Spacer(
+            Modifier.windowInsetsPadding(
+                LocalPlayerAwareWindowInsets.current.only(WindowInsetsSides.Top)
+            )
+        )
+
+        Material3SettingsGroup(
+            title = stringResource(R.string.stream_source_web_clients),
+            items = listOf(
+                streamClientItem(R.string.stream_source_web_remix, R.string.stream_source_web_remix_desc, webRemix, onWebRemixChange),
+                streamClientItem(R.string.stream_source_tvhtml5, R.string.stream_source_tvhtml5_desc, tvhtml5, onTvhtml5Change),
+            )
+        )
+
+        Spacer(modifier = Modifier.height(27.dp))
+
+        Material3SettingsGroup(
+            title = stringResource(R.string.stream_source_native_clients),
+            items = listOf(
+                streamClientItem(R.string.stream_source_visionos, R.string.stream_source_visionos_desc, visionOS, onVisionOSChange),
+                streamClientItem(R.string.stream_source_android_vr, R.string.stream_source_android_vr_desc, androidVR, onAndroidVRChange),
+                streamClientItem(R.string.stream_source_ios, R.string.stream_source_ios_desc, ios, onIosChange),
+                streamClientItem(R.string.stream_source_ipados, R.string.stream_source_ipados_desc, ipadOS, onIpadOSChange),
+            )
+        )
+
+        Spacer(modifier = Modifier.height(27.dp))
+
+        Material3SettingsGroup(
+            title = stringResource(R.string.stream_source_creator_clients),
+            items = listOf(
+                streamClientItem(R.string.stream_source_web_creator, R.string.stream_source_web_creator_desc, webCreator, onWebCreatorChange),
+                streamClientItem(R.string.stream_source_android_creator, R.string.stream_source_android_creator_desc, androidCreator, onAndroidCreatorChange),
+            )
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+    }
+
+    TopAppBar(
+        title = { Text(stringResource(R.string.stream_sources)) },
+        navigationIcon = {
+            IconButton(
+                onClick = navController::navigateUp,
+                onLongClick = navController::backToMain,
+            ) {
+                Icon(
+                    painterResource(R.drawable.arrow_back),
+                    contentDescription = null,
+                )
+            }
+        }
+    )
+}
+
+@Composable
+private fun streamClientItem(
+    @StringRes titleRes: Int,
+    @StringRes descriptionRes: Int,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+): Material3SettingsItem = Material3SettingsItem(
+    icon = painterResource(R.drawable.play),
+    title = { Text(stringResource(titleRes)) },
+    description = { Text(stringResource(descriptionRes)) },
+    trailingContent = {
+        Switch(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+            thumbContent = {
+                Icon(
+                    painter = painterResource(id = if (checked) R.drawable.check else R.drawable.close),
+                    contentDescription = null,
+                    modifier = Modifier.size(SwitchDefaults.IconSize),
+                )
+            }
+        )
+    },
+    onClick = { onCheckedChange(!checked) },
+)

--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/ShowMediaInfo.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/ShowMediaInfo.kt
@@ -156,6 +156,8 @@ fun ShowMediaInfo(videoId: String) {
                     // Player hash + cipher support date apply only to deciphered web clients;
                     // direct-URL clients (VISIONOS/ANDROID_VR/IOS) never run the cipher.
                     val isWebStream = currentStreamClient in setOf("WEB_REMIX", "WEB_CREATOR", "TVHTML5", "WEB")
+                    // Read the moving global once so the hash row and its cipher-date row stay consistent.
+                    val playerHash = if (isWebStream) CipherDeobfuscator.lastUsedPlayerHash else null
 
                     val measuredLufs: Double? = currentFormat?.perceptualLoudnessDb ?: currentFormat?.loudnessDb?.let { it + LoudnessLevel.AGGRESSIVE.targetLufs }
 
@@ -167,9 +169,9 @@ fun ShowMediaInfo(videoId: String) {
                             "Itag" to currentFormat?.itag?.toString(),
                             stringResource(R.string.stream_client) to currentStreamClient,
                             stringResource(R.string.format_player_hash) to
-                                    (if (isWebStream) CipherDeobfuscator.lastUsedPlayerHash else notApplicable),
+                                    (if (isWebStream) playerHash else notApplicable),
                             stringResource(R.string.format_cipher_support_added) to
-                                    (if (isWebStream) PlayerDatesStore.get(CipherDeobfuscator.lastUsedPlayerHash) else notApplicable),
+                                    (if (isWebStream) PlayerDatesStore.get(playerHash) else notApplicable),
                             stringResource(R.string.mime_type) to currentFormat?.mimeType,
                             stringResource(R.string.codecs) to currentFormat?.codecs,
                             stringResource(R.string.bitrate) to currentFormat?.bitrate?.let { "${it / 1000} Kbps" },

--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/ShowMediaInfo.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/ShowMediaInfo.kt
@@ -141,7 +141,7 @@ fun ShowMediaInfo(videoId: String) {
                         R.drawable.key,
                         R.drawable.play,
                         R.drawable.lock,
-                        R.drawable.key,
+                        R.drawable.key_vertical,
                         R.drawable.info,
                         R.drawable.radio,
                         R.drawable.gradient,

--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/ShowMediaInfo.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/ShowMediaInfo.kt
@@ -49,6 +49,8 @@ import com.metrolist.music.constants.LoudnessLevelKey
 import com.metrolist.music.db.entities.FormatEntity
 import com.metrolist.music.db.entities.Song
 import com.metrolist.music.ui.component.Material3SettingsGroup
+import com.metrolist.music.utils.cipher.CipherDeobfuscator
+import com.metrolist.music.utils.cipher.PlayerDatesStore
 import com.metrolist.music.ui.component.Material3SettingsItem
 import com.metrolist.music.ui.component.shimmer.ShimmerHost
 import com.metrolist.music.ui.component.shimmer.TextPlaceholder
@@ -138,6 +140,8 @@ fun ShowMediaInfo(videoId: String) {
                         R.drawable.media3_icon_thumb_down_unfilled,
                         R.drawable.key,
                         R.drawable.play,
+                        R.drawable.lock,
+                        R.drawable.key,
                         R.drawable.info,
                         R.drawable.radio,
                         R.drawable.gradient,
@@ -148,6 +152,11 @@ fun ShowMediaInfo(videoId: String) {
                         R.drawable.content_copy
                     )
 
+                    val notApplicable = stringResource(R.string.not_applicable)
+                    // Player hash + cipher support date apply only to deciphered web clients;
+                    // direct-URL clients (VISIONOS/ANDROID_VR/IOS) never run the cipher.
+                    val isWebStream = currentStreamClient in setOf("WEB_REMIX", "WEB_CREATOR", "TVHTML5", "WEB")
+
                     val measuredLufs: Double? = currentFormat?.perceptualLoudnessDb ?: currentFormat?.loudnessDb?.let { it + LoudnessLevel.AGGRESSIVE.targetLufs }
 
                     val extendedList = if (currentFormat != null) {
@@ -157,6 +166,10 @@ fun ShowMediaInfo(videoId: String) {
                             stringResource(R.string.dislikes) to info?.dislike?.let(::numberFormatter).orEmpty(),
                             "Itag" to currentFormat?.itag?.toString(),
                             stringResource(R.string.stream_client) to currentStreamClient,
+                            stringResource(R.string.format_player_hash) to
+                                    (if (isWebStream) CipherDeobfuscator.lastUsedPlayerHash else notApplicable),
+                            stringResource(R.string.format_cipher_support_added) to
+                                    (if (isWebStream) PlayerDatesStore.get(CipherDeobfuscator.lastUsedPlayerHash) else notApplicable),
                             stringResource(R.string.mime_type) to currentFormat?.mimeType,
                             stringResource(R.string.codecs) to currentFormat?.codecs,
                             stringResource(R.string.bitrate) to currentFormat?.bitrate?.let { "${it / 1000} Kbps" },

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -19,6 +19,7 @@ import com.metrolist.innertube.models.YouTubeClient.Companion.IOS
 import com.metrolist.innertube.models.YouTubeClient.Companion.IPADOS
 import com.metrolist.innertube.models.YouTubeClient.Companion.MOBILE
 import com.metrolist.innertube.models.YouTubeClient.Companion.TVHTML5
+import com.metrolist.innertube.models.YouTubeClient.Companion.TVHTML5_SIMPLY_EMBEDDED_PLAYER
 import com.metrolist.innertube.models.YouTubeClient.Companion.VISIONOS
 import com.metrolist.innertube.models.YouTubeClient.Companion.WEB
 import com.metrolist.innertube.models.YouTubeClient.Companion.WEB_CREATOR
@@ -49,14 +50,16 @@ object YTPlayerUtils {
     private val MAIN_CLIENT: YouTubeClient = WEB_REMIX
 
     // VISIONOS first (its CDN URL has no spc throttle gate, so it streams whole songs with no
-    // poToken/cipher — the most reliable fallback), then WEB_CREATOR, the TVHTML5 clients, the
-    // ANDROID_VR variants, then the spc-gated IOS/IPADOS as last-ditch attempts.
+    // poToken/cipher — the most reliable fallback), then WEB_CREATOR, TVHTML5, the ANDROID_VR
+    // variants, then TVHTML5_SIMPLY_EMBEDDED_PLAYER (login-free, bypasses age-restriction for
+    // logged-out users), then the spc-gated IOS/IPADOS as last-ditch attempts.
     private val STREAM_FALLBACK_CLIENTS: Array<YouTubeClient> = arrayOf(
         VISIONOS,
         WEB_CREATOR,
         TVHTML5,
         ANDROID_VR_1_43_32,
         ANDROID_VR_1_61_48,
+        TVHTML5_SIMPLY_EMBEDDED_PLAYER,
         IOS,
         IPADOS,
         ANDROID_CREATOR,

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -592,38 +592,45 @@ object YTPlayerUtils {
 
     private suspend fun getSignatureTimestampOrNull(videoId: String): SignatureTimestampResult {
         Timber.tag(logTag).d("Getting signature timestamp for videoId: $videoId")
+
+        // Prefer the STS of the player the cipher actually deciphers with. The STS decides which
+        // player generation YouTube mints the signatureCipher for; during A/B rollouts NewPipe's
+        // independently fetched player can be a DIFFERENT generation, and a sig minted for one
+        // player but deciphered by another 403s on the CDN. NewPipe is kept for age-restriction
+        // detection and as the STS source only when the cipher player fetch fails.
+        val cipherSts = runCatching { CipherDeobfuscator.signatureTimestamp() }
+            .onSuccess { Timber.tag(logTag).d("Signature timestamp from cipher player: $it") }
+            .onFailure { Timber.tag(logTag).e(it, "Cipher player STS fetch failed") }
+            .getOrNull()
+
         val result = NewPipeExtractor.getSignatureTimestamp(videoId)
         return result.fold(
             onSuccess = { timestamp ->
-                Timber.tag(logTag).d("Signature timestamp obtained via NewPipe: $timestamp")
-                SignatureTimestampResult(timestamp, isAgeRestricted = false)
+                val chosen = cipherSts ?: timestamp
+                Timber.tag(logTag).d("Signature timestamp resolved: cipher=$cipherSts newpipe=$timestamp -> using $chosen")
+                SignatureTimestampResult(chosen, isAgeRestricted = false)
             },
             onFailure = { error ->
                 val isAgeRestricted = error.message?.contains("age-restricted", ignoreCase = true) == true ||
                     error.cause?.message?.contains("age-restricted", ignoreCase = true) == true
-                if (isAgeRestricted) {
-                    Timber.tag(logTag).d("Age-restricted content detected from NewPipe")
-                    Timber.tag(TAG).i("Age-restricted detected early via NewPipe: videoId=$videoId")
-                } else {
-                    Timber.tag(logTag).e(error, "Failed to get signature timestamp via NewPipe")
-                    reportException(error)
+                when {
+                    isAgeRestricted -> {
+                        Timber.tag(logTag).d("Age-restricted content detected from NewPipe")
+                        Timber.tag(TAG).i("Age-restricted detected early via NewPipe: videoId=$videoId")
+                    }
+                    cipherSts != null -> {
+                        // Non-fatal: the cipher player's STS already covers us, so NewPipe is just
+                        // a fallback here — don't report its failure as an exception (avoids noise).
+                        Timber.tag(logTag).w("NewPipe STS unavailable, using cipher player STS: ${error.message}")
+                    }
+                    else -> {
+                        Timber.tag(logTag).e(error, "Failed to get signature timestamp via NewPipe")
+                        reportException(error)
+                    }
                 }
-                // Fallback: extract signatureTimestamp directly from player.js when NewPipe fails.
-                // This keeps playback working when the NewPipe extractor is outdated for a new
-                // player version, as long as the player.js still embeds signatureTimestamp inline.
-                val fallbackSts = runCatching {
-                    Timber.tag(logTag).d("Trying player.js fallback for signature timestamp")
-                    val (playerJs, hash) = PlayerJsFetcher.getPlayerJs()
-                        ?: error("PlayerJsFetcher returned null")
-                    Timber.tag(logTag).d("Got player.js (hash=$hash), extracting signatureTimestamp")
-                    FunctionNameExtractor.extractSignatureTimestamp(playerJs)
-                        ?: error("extractSignatureTimestamp returned null for hash=$hash")
-                }.onSuccess { sts ->
-                    Timber.tag(logTag).d("Signature timestamp obtained via player.js fallback: $sts")
-                }.onFailure { e ->
-                    Timber.tag(logTag).e(e, "player.js fallback for signature timestamp also failed")
-                }.getOrNull()
-                SignatureTimestampResult(fallbackSts, isAgeRestricted)
+                // The cipher player's STS is exactly the one the cipher will decipher with.
+                Timber.tag(logTag).d("Signature timestamp resolved: cipher=$cipherSts (NewPipe failed)")
+                SignatureTimestampResult(cipherSts, isAgeRestricted)
             }
         )
     }

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -315,6 +315,8 @@ object YTPlayerUtils {
                             streamUrl = "${streamUrl}${separator}pot=${Uri.encode(poToken.streamingDataPoToken)}"
                             Timber.tag(TAG).d("  Final URL length (with pot): ${streamUrl.length}")
                         }
+                    } catch (e: kotlinx.coroutines.CancellationException) {
+                        throw e // request superseded/cancelled — abort cleanly, don't validate an un-transformed URL
                     } catch (e: Exception) {
                         Timber.tag(TAG).e(e, "N-transform or pot append failed: ${e.message}")
                         Timber.tag(TAG).e("Stack trace: ${e.stackTraceToString().take(500)}")
@@ -598,10 +600,15 @@ object YTPlayerUtils {
         // independently fetched player can be a DIFFERENT generation, and a sig minted for one
         // player but deciphered by another 403s on the CDN. NewPipe is kept for age-restriction
         // detection and as the STS source only when the cipher player fetch fails.
-        val cipherSts = runCatching { CipherDeobfuscator.signatureTimestamp() }
-            .onSuccess { Timber.tag(logTag).d("Signature timestamp from cipher player: $it") }
-            .onFailure { Timber.tag(logTag).e(it, "Cipher player STS fetch failed") }
-            .getOrNull()
+        val cipherSts = try {
+            CipherDeobfuscator.signatureTimestamp()
+                ?.also { Timber.tag(logTag).d("Signature timestamp from cipher player: $it") }
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e // cooperative cancellation: don't swallow, let the playback coroutine unwind
+        } catch (e: Exception) {
+            Timber.tag(logTag).e(e, "Cipher player STS fetch failed")
+            null
+        }
 
         val result = NewPipeExtractor.getSignatureTimestamp(videoId)
         return result.fold(

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -19,7 +19,6 @@ import com.metrolist.innertube.models.YouTubeClient.Companion.IOS
 import com.metrolist.innertube.models.YouTubeClient.Companion.IPADOS
 import com.metrolist.innertube.models.YouTubeClient.Companion.MOBILE
 import com.metrolist.innertube.models.YouTubeClient.Companion.TVHTML5
-import com.metrolist.innertube.models.YouTubeClient.Companion.TVHTML5_SIMPLY_EMBEDDED_PLAYER
 import com.metrolist.innertube.models.YouTubeClient.Companion.VISIONOS
 import com.metrolist.innertube.models.YouTubeClient.Companion.WEB
 import com.metrolist.innertube.models.YouTubeClient.Companion.WEB_CREATOR
@@ -49,10 +48,12 @@ object YTPlayerUtils {
 
     private val MAIN_CLIENT: YouTubeClient = WEB_REMIX
 
+    // VISIONOS first (its CDN URL has no spc throttle gate, so it streams whole songs with no
+    // poToken/cipher — the most reliable fallback), then WEB_CREATOR, the TVHTML5 clients, the
+    // ANDROID_VR variants, then the spc-gated IOS/IPADOS as last-ditch attempts.
     private val STREAM_FALLBACK_CLIENTS: Array<YouTubeClient> = arrayOf(
         VISIONOS,
         WEB_CREATOR,
-        TVHTML5_SIMPLY_EMBEDDED_PLAYER,
         TVHTML5,
         ANDROID_VR_1_43_32,
         ANDROID_VR_1_61_48,
@@ -63,6 +64,10 @@ object YTPlayerUtils {
         MOBILE,
         WEB,
     )
+
+    /** Client names disabled by the user in Settings → Stream sources. Updated reactively by MusicService. */
+    @Volatile
+    var disabledStreamClients: Set<String> = emptySet()
 
     data class PlaybackData(
         val audioConfig: PlayerResponse.PlayerConfig.AudioConfig?,
@@ -197,12 +202,21 @@ object YTPlayerUtils {
             if (clientIndex == -1) {
                 // try with streams from main client first (use retry response if available)
                 client = MAIN_CLIENT
+                if (client.clientName in disabledStreamClients) {
+                    Timber.tag(logTag).d("Skipping MAIN_CLIENT ${client.clientName} — disabled in stream sources")
+                    continue
+                }
                 streamPlayerResponse = retryMainPlayerResponse ?: mainPlayerResponse
                 Timber.tag(logTag).d("Trying stream from MAIN_CLIENT: ${client.clientName}")
             } else {
                 // after main client use fallback clients
                 client = STREAM_FALLBACK_CLIENTS[clientIndex]
                 Timber.tag(logTag).d("Trying fallback client ${clientIndex + 1}/${STREAM_FALLBACK_CLIENTS.size}: ${client.clientName}")
+
+                if (client.clientName in disabledStreamClients) {
+                    Timber.tag(logTag).d("Skipping client ${client.clientName} — disabled in stream sources")
+                    continue
+                }
 
                 if (client.loginRequired && !isLoggedIn && YouTube.cookie == null) {
                     // skip client if it requires login but user is not logged in

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherDeobfuscator.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherDeobfuscator.kt
@@ -31,11 +31,22 @@ object CipherDeobfuscator {
         PlayerConfigStore.initialize(appContext)
         Timber.tag(TAG).d("Known config hashes after init: ${PlayerConfigStore.knownHashes().sorted().joinToString()}")
         PlayerConfigStore.scheduleStartupRefresh()
+        // Cosmetic "cipher support added" dates for the song-details sheet — pulled purely from a
+        // remote file and decoupled from the decipher path (any failure just yields an unknown date).
+        PlayerDatesStore.initialize(appContext)
         Timber.tag(TAG).d("CipherDeobfuscator initialized")
     }
 
     private var cipherWebView: CipherWebView? = null
     private var currentPlayerHash: String? = null
+
+    /**
+     * The player_ias hash last used to decipher a web stream (sig/n), or null if none yet.
+     * Diagnostic only — surfaced in the song-details sheet. Direct-URL clients (ANDROID_VR/IOS)
+     * never run the cipher, so this reflects the last web stream.
+     */
+    val lastUsedPlayerHash: String? get() = currentPlayerHash
+
     private val deobfuscateMutex = Mutex()
 
     /**

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherDeobfuscator.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherDeobfuscator.kt
@@ -38,6 +38,10 @@ object CipherDeobfuscator {
     }
 
     private var cipherWebView: CipherWebView? = null
+
+    // Written on the decipher coroutine (Dispatchers.IO) but read via lastUsedPlayerHash from the
+    // Compose UI thread (song-details sheet), so @Volatile to publish the write across threads.
+    @Volatile
     private var currentPlayerHash: String? = null
 
     /**

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherDeobfuscator.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherDeobfuscator.kt
@@ -23,12 +23,37 @@ object CipherDeobfuscator {
     fun initialize(context: Context) {
         Timber.tag(TAG).d("CipherDeobfuscator initializing...")
         appContext = context.applicationContext
+        // Load the player-config table (bundled asset + last-good cached remote overlay) so
+        // configs exist before any lookup, then kick a non-blocking TTL-gated refresh against
+        // the remote config file. Order is load-bearing: synchronous load first, async refresh after.
+        Timber.tag(TAG).d("Initializing PlayerConfigStore (bundled + cached overlay)...")
+        PlayerConfigStore.initialize(appContext)
+        Timber.tag(TAG).d("Known config hashes after init: ${PlayerConfigStore.knownHashes().sorted().joinToString()}")
+        PlayerConfigStore.scheduleStartupRefresh()
         Timber.tag(TAG).d("CipherDeobfuscator initialized")
     }
 
     private var cipherWebView: CipherWebView? = null
     private var currentPlayerHash: String? = null
     private val deobfuscateMutex = Mutex()
+
+    /**
+     * SignatureTimestamp of the player JS this cipher actually deciphers with, fetching (or
+     * reusing the cached) player JS if needed. API callers must send THIS value in the
+     * /player request: during A/B rollouts other sources (e.g. NewPipe's own player fetch)
+     * can land on a different player generation, and a sig minted for one player but
+     * deciphered by another produces a URL the CDN 403s.
+     */
+    suspend fun signatureTimestamp(): Int? {
+        Timber.tag(TAG).d("Resolving cipher player signatureTimestamp...")
+        val (playerJs, hash) = PlayerJsFetcher.getPlayerJs(forceRefresh = false) ?: run {
+            Timber.tag(TAG).w("signatureTimestamp: could not fetch player JS")
+            return null
+        }
+        val sts = FunctionNameExtractor.extractSignatureTimestamp(playerJs)
+        Timber.tag(TAG).d("Cipher player STS (hash=$hash): $sts")
+        return sts
+    }
 
     /**
      * Deobfuscate a signatureCipher stream URL.
@@ -191,7 +216,21 @@ object CipherDeobfuscator {
 
         // Run full analysis for logging - pass the known hash from PlayerJsFetcher
         Timber.tag(TAG).d("Analyzing player JS for cipher functions (knownHash=$hash)...")
-        val analysis = FunctionNameExtractor.analyzePlayerJs(playerJs, knownHash = hash)
+        var analysis = FunctionNameExtractor.analyzePlayerJs(playerJs, knownHash = hash)
+
+        // Mid-session self-heal: a rotated player_ias whose validated config may already be
+        // published in the remote config file. If EITHER transform is missing, force a config
+        // refresh and re-extract once. forceRefresh returns true only when the hash is now in
+        // the table, so the re-extraction runs exactly when it can succeed.
+        if (analysis.sigInfo == null || analysis.nFuncInfo == null) {
+            Timber.tag(TAG).w("Incomplete extraction for player $hash (sig=${analysis.sigInfo != null}, n=${analysis.nFuncInfo != null}) — forcing remote config refresh")
+            val healed = PlayerConfigStore.forceRefresh(missingHash = hash)
+            Timber.tag(TAG).d("forceRefresh($hash) -> hashNowKnown=$healed")
+            if (healed) {
+                analysis = FunctionNameExtractor.analyzePlayerJs(playerJs, knownHash = hash)
+                Timber.tag(TAG).d("Re-extracted after refresh: sig=${analysis.sigInfo != null}, n=${analysis.nFuncInfo != null}")
+            }
+        }
 
         if (analysis.sigInfo == null) {
             Timber.tag(TAG).e("Could not extract signature function info from player JS")

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherDeobfuscator.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherDeobfuscator.kt
@@ -2,6 +2,7 @@ package com.metrolist.music.utils.cipher
 
 import android.content.Context
 import android.net.Uri
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -68,12 +69,16 @@ object CipherDeobfuscator {
     suspend fun deobfuscateStreamUrl(signatureCipher: String, videoId: String): String? = deobfuscateMutex.withLock {
         try {
             deobfuscateInternal(signatureCipher, videoId, isRetry = false)
+        } catch (e: CancellationException) {
+            throw e // request superseded/cancelled — propagate, don't treat as a decipher failure
         } catch (e: Exception) {
             Timber.tag(TAG).e(e, "Cipher deobfuscation failed, retrying with fresh JS: ${e.message}")
             try {
                 PlayerJsFetcher.invalidateCache()
                 closeWebView()
                 deobfuscateInternal(signatureCipher, videoId, isRetry = true)
+            } catch (retryE: CancellationException) {
+                throw retryE
             } catch (retryE: Exception) {
                 Timber.tag(TAG).e(retryE, "Cipher deobfuscation retry also failed: ${retryE.message}")
                 null
@@ -138,6 +143,8 @@ object CipherDeobfuscator {
 
         return try {
             transformNInternal(url)
+        } catch (e: CancellationException) {
+            throw e // request superseded/cancelled — propagate rather than masking as a no-op transform
         } catch (e: Exception) {
             Timber.tag(TAG).e(e, "N-transform failed, returning original URL: ${e.message}")
             url
@@ -219,16 +226,23 @@ object CipherDeobfuscator {
         var analysis = FunctionNameExtractor.analyzePlayerJs(playerJs, knownHash = hash)
 
         // Mid-session self-heal: a rotated player_ias whose validated config may already be
-        // published in the remote config file. If EITHER transform is missing, force a config
-        // refresh and re-extract once. forceRefresh returns true only when the hash is now in
-        // the table, so the re-extraction runs exactly when it can succeed.
-        if (analysis.sigInfo == null || analysis.nFuncInfo == null) {
-            Timber.tag(TAG).w("Incomplete extraction for player $hash (sig=${analysis.sigInfo != null}, n=${analysis.nFuncInfo != null}) — forcing remote config refresh")
+        // published in the remote config file. Trigger when EITHER transform is missing OR was
+        // resolved by the legacy regex heuristics (isHardcoded == false) instead of a validated
+        // config. The regexes are unanchored and can false-match anywhere in the ~2 MB player JS,
+        // returning a non-null but WRONG result; gating on null alone would let that shadow the
+        // validated config and silently break playback. forceRefresh returns true only when the
+        // hash is now in the table, so re-extraction runs exactly when it can succeed; a genuine
+        // old-style regex player with no config simply gets false back (one cooldown-gated fetch)
+        // and keeps its working regex result.
+        val sigFromConfig = analysis.sigInfo?.isHardcoded == true
+        val nFromConfig = analysis.nFuncInfo?.isHardcoded == true
+        if (!sigFromConfig || !nFromConfig) {
+            Timber.tag(TAG).w("Extraction not fully config-backed for player $hash (sigConfig=$sigFromConfig, nConfig=$nFromConfig; sig=${analysis.sigInfo != null}, n=${analysis.nFuncInfo != null}) — forcing remote config refresh")
             val healed = PlayerConfigStore.forceRefresh(missingHash = hash)
             Timber.tag(TAG).d("forceRefresh($hash) -> hashNowKnown=$healed")
             if (healed) {
                 analysis = FunctionNameExtractor.analyzePlayerJs(playerJs, knownHash = hash)
-                Timber.tag(TAG).d("Re-extracted after refresh: sig=${analysis.sigInfo != null}, n=${analysis.nFuncInfo != null}")
+                Timber.tag(TAG).d("Re-extracted after refresh: sigConfig=${analysis.sigInfo?.isHardcoded == true}, nConfig=${analysis.nFuncInfo?.isHardcoded == true}")
             }
         }
 

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/FunctionNameExtractor.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/FunctionNameExtractor.kt
@@ -50,357 +50,6 @@ object FunctionNameExtractor {
         val signatureTimestamp: Int
     )
 
-    // ==================== KNOWN PLAYER CONFIGS ====================
-
-    /**
-     * Known player.js configurations indexed by hash
-     *
-     * Player hash 74edf1a3 (March 2026):
-     * - Signature: JI(48, 1918, f1(1, 6528, sig)) -> reverse, swap(0, 57%), reverse
-     * - N-transform: GU(6, 6010, n) with 87-element self-referential array
-     */
-    private val KNOWN_PLAYER_CONFIGS = mapOf(
-        "74edf1a3" to HardcodedPlayerConfig(
-            sigFuncName = "JI",
-            sigConstantArg = 48, // Legacy
-            sigConstantArgs = listOf(48, 1918), // JI(48, 1918, processedSig)
-            sigPreprocessFunc = "f1", // sig must be preprocessed through f1()
-            sigPreprocessArgs = listOf(1, 6528), // f1(1, 6528, sig)
-            nFuncName = "GU",
-            nArrayIndex = null, // Direct function, not array access
-            nConstantArgs = listOf(6, 6010), // GU(6, 6010, n) - the function requires 3 args!
-            signatureTimestamp = 20522
-        ),
-        "f4c47414" to HardcodedPlayerConfig(
-            sigFuncName = "hJ",
-            sigConstantArg = 6,
-            sigConstantArgs = listOf(6), // hJ(6, decodeURIComponent(h.s))
-            sigPreprocessFunc = null, // No preprocessing needed
-            sigPreprocessArgs = null,
-            nFuncName = "", // Will be extracted via regex
-            nArrayIndex = null,
-            nConstantArgs = null,
-            signatureTimestamp = 20543
-        ),
-        // May 2026: direct URLs, no client-side cipher or n-transform
-        "57f5d44f" to HardcodedPlayerConfig(
-            sigFuncName = "",
-            sigConstantArg = null,
-            sigConstantArgs = null,
-            sigPreprocessFunc = null,
-            sigPreprocessArgs = null,
-            nFuncName = "",
-            nArrayIndex = null,
-            nConstantArgs = null,
-            signatureTimestamp = 20591
-        ),
-        // player_ias 69e2a55d (2026-06-08): VM-dispatch via Jf/C6/iE. STS 20611.
-        "69e2a55d" to HardcodedPlayerConfig(
-            sigFuncName = "_expr_sig",
-            sigConstantArg = null,
-            sigJsExpression = "Jf(20,3699,INPUT)",
-            nFuncName = "_expr_n",
-            nArrayIndex = null,
-            nConstantArgs = null,
-            nJsExpression = "(function(n){try{var u=new g.iE('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
-            signatureTimestamp = 20611
-        ),
-        // MD5-fallback alias for 69e2a55d
-        "70d8066f" to HardcodedPlayerConfig(
-            sigFuncName = "_expr_sig",
-            sigConstantArg = null,
-            sigJsExpression = "Jf(20,3699,INPUT)",
-            nFuncName = "_expr_n",
-            nArrayIndex = null,
-            nConstantArgs = null,
-            nJsExpression = "(function(n){try{var u=new g.iE('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
-            signatureTimestamp = 20611
-        ),
-        // player_ias 9d2ef9ef (2026-06-08): VM-dispatch via v0/n7/uY. STS 20607.
-        "9d2ef9ef" to HardcodedPlayerConfig(
-            sigFuncName = "_expr_sig",
-            sigConstantArg = null,
-            sigJsExpression = "v0(35,4499,INPUT)",
-            nFuncName = "_expr_n",
-            nArrayIndex = null,
-            nConstantArgs = null,
-            nJsExpression = "(function(n){try{var u=new g.uY('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
-            signatureTimestamp = 20607
-        ),
-        // MD5-fallback alias for 9d2ef9ef
-        "6fb43da5" to HardcodedPlayerConfig(
-            sigFuncName = "_expr_sig",
-            sigConstantArg = null,
-            sigJsExpression = "v0(35,4499,INPUT)",
-            nFuncName = "_expr_n",
-            nArrayIndex = null,
-            nConstantArgs = null,
-            nJsExpression = "(function(n){try{var u=new g.uY('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
-            signatureTimestamp = 20607
-        ),
-        // player_ias 16ee6936 (2026-06-09): VM-dispatch via mP/Yx. STS 20613.
-        // sig=mP(4,155,sig) (inner call is decodeURIComponent, pre-decoded); n=g.Yx URL-param trick.
-        // Validated against the live CDN (HTTP 206).
-        "16ee6936" to HardcodedPlayerConfig(
-            sigFuncName = "_expr_sig",
-            sigConstantArg = null,
-            sigJsExpression = "mP(4,155,INPUT)",
-            nFuncName = "_expr_n",
-            nArrayIndex = null,
-            nConstantArgs = null,
-            nJsExpression = "(function(n){try{var u=new g.Yx('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
-            signatureTimestamp = 20613
-        ),
-        // MD5-fallback alias for 16ee6936
-        "ca366632" to HardcodedPlayerConfig(
-            sigFuncName = "_expr_sig",
-            sigConstantArg = null,
-            sigJsExpression = "mP(4,155,INPUT)",
-            nFuncName = "_expr_n",
-            nArrayIndex = null,
-            nConstantArgs = null,
-            nJsExpression = "(function(n){try{var u=new g.Yx('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
-            signatureTimestamp = 20613
-        ),
-        // player_ias ce74690f (2026-06-09): VM-dispatch via $9/cV. STS 20612.
-        // sig=$9(2,6487,sig) (inner f3(4,1144,.) is decodeURIComponent, pre-decoded); n=g.cV trick.
-        // Validated against the live CDN (HTTP 206).
-        "ce74690f" to HardcodedPlayerConfig(
-            sigFuncName = "_expr_sig",
-            sigConstantArg = null,
-            sigJsExpression = "\$9(2,6487,INPUT)",
-            nFuncName = "_expr_n",
-            nArrayIndex = null,
-            nConstantArgs = null,
-            nJsExpression = "(function(n){try{var u=new g.cV('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
-            signatureTimestamp = 20612
-        ),
-        // MD5-fallback alias for ce74690f
-        "a5669e32" to HardcodedPlayerConfig(
-            sigFuncName = "_expr_sig",
-            sigConstantArg = null,
-            sigJsExpression = "\$9(2,6487,INPUT)",
-            nFuncName = "_expr_n",
-            nArrayIndex = null,
-            nConstantArgs = null,
-            nJsExpression = "(function(n){try{var u=new g.cV('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
-            signatureTimestamp = 20612
-        ),
-        // player_ias 6b8eecd5 (2026-06-10): 16ee6936's mP/Yx generation under a new URL hash. STS 20613.
-        // Validated against the live CDN (HTTP 206).
-        "6b8eecd5" to HardcodedPlayerConfig(
-            sigFuncName = "_expr_sig",
-            sigConstantArg = null,
-            sigJsExpression = "mP(4,155,INPUT)",
-            nFuncName = "_expr_n",
-            nArrayIndex = null,
-            nConstantArgs = null,
-            nJsExpression = "(function(n){try{var u=new g.Yx('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
-            signatureTimestamp = 20613
-        ),
-        // MD5-fallback alias for 6b8eecd5
-        "6ea478fa" to HardcodedPlayerConfig(
-            sigFuncName = "_expr_sig",
-            sigConstantArg = null,
-            sigJsExpression = "mP(4,155,INPUT)",
-            nFuncName = "_expr_n",
-            nArrayIndex = null,
-            nConstantArgs = null,
-            nJsExpression = "(function(n){try{var u=new g.Yx('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
-            signatureTimestamp = 20613
-        ),
-        // ===== player_ias configs for the last 7 days of player rotations =====
-        // player_ias 445213fb / d62bd338 (2026-06-10): mP(4,155,INPUT) via g.Yx. STS 20613. CDN-validated (HTTP 206).
-        "445213fb" to HardcodedPlayerConfig(
-            sigFuncName = "_expr_sig",
-            sigConstantArg = null,
-            sigJsExpression = "mP(4,155,INPUT)",
-            nFuncName = "_expr_n",
-            nArrayIndex = null,
-            nConstantArgs = null,
-            nJsExpression = "(function(n){try{var u=new g.Yx('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
-            signatureTimestamp = 20613
-        ),
-        "d62bd338" to HardcodedPlayerConfig(
-            sigFuncName = "_expr_sig",
-            sigConstantArg = null,
-            sigJsExpression = "mP(4,155,INPUT)",
-            nFuncName = "_expr_n",
-            nArrayIndex = null,
-            nConstantArgs = null,
-            nJsExpression = "(function(n){try{var u=new g.Yx('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
-            signatureTimestamp = 20613
-        ),
-        // player_ias a32660fc / e786ad71 (2026-06-10): mP(4,155,INPUT) via g.Yx. STS 20613. CDN-validated (HTTP 206).
-        "a32660fc" to HardcodedPlayerConfig(
-            sigFuncName = "_expr_sig",
-            sigConstantArg = null,
-            sigJsExpression = "mP(4,155,INPUT)",
-            nFuncName = "_expr_n",
-            nArrayIndex = null,
-            nConstantArgs = null,
-            nJsExpression = "(function(n){try{var u=new g.Yx('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
-            signatureTimestamp = 20613
-        ),
-        "e786ad71" to HardcodedPlayerConfig(
-            sigFuncName = "_expr_sig",
-            sigConstantArg = null,
-            sigJsExpression = "mP(4,155,INPUT)",
-            nFuncName = "_expr_n",
-            nArrayIndex = null,
-            nConstantArgs = null,
-            nJsExpression = "(function(n){try{var u=new g.Yx('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
-            signatureTimestamp = 20613
-        ),
-        // player_ias 959dabb2 / 79c1b58e (2026-06-12): IR(84,305,INPUT) via g.Ga. STS 20614. CDN-validated (HTTP 206).
-        "959dabb2" to HardcodedPlayerConfig(
-            sigFuncName = "_expr_sig",
-            sigConstantArg = null,
-            sigJsExpression = "IR(84,305,INPUT)",
-            nFuncName = "_expr_n",
-            nArrayIndex = null,
-            nConstantArgs = null,
-            nJsExpression = "(function(n){try{var u=new g.Ga('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
-            signatureTimestamp = 20614
-        ),
-        "79c1b58e" to HardcodedPlayerConfig(
-            sigFuncName = "_expr_sig",
-            sigConstantArg = null,
-            sigJsExpression = "IR(84,305,INPUT)",
-            nFuncName = "_expr_n",
-            nArrayIndex = null,
-            nConstantArgs = null,
-            nJsExpression = "(function(n){try{var u=new g.Ga('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
-            signatureTimestamp = 20614
-        ),
-        // player_ias bb52fe90 / f6046ecd (2026-06-12): Ez(5,408,INPUT) via g.Oq. STS 20615. CDN-validated (HTTP 206).
-        "bb52fe90" to HardcodedPlayerConfig(
-            sigFuncName = "_expr_sig",
-            sigConstantArg = null,
-            sigJsExpression = "Ez(5,408,INPUT)",
-            nFuncName = "_expr_n",
-            nArrayIndex = null,
-            nConstantArgs = null,
-            nJsExpression = "(function(n){try{var u=new g.Oq('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
-            signatureTimestamp = 20615
-        ),
-        "f6046ecd" to HardcodedPlayerConfig(
-            sigFuncName = "_expr_sig",
-            sigConstantArg = null,
-            sigJsExpression = "Ez(5,408,INPUT)",
-            nFuncName = "_expr_n",
-            nArrayIndex = null,
-            nConstantArgs = null,
-            nJsExpression = "(function(n){try{var u=new g.Oq('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
-            signatureTimestamp = 20615
-        ),
-        // player_ias 1acfe3aa / fbcdec38 (2026-06-12): na(16,3372,INPUT) via g.dn. STS 20616. CDN-validated (HTTP 206).
-        "1acfe3aa" to HardcodedPlayerConfig(
-            sigFuncName = "_expr_sig",
-            sigConstantArg = null,
-            sigJsExpression = "na(16,3372,INPUT)",
-            nFuncName = "_expr_n",
-            nArrayIndex = null,
-            nConstantArgs = null,
-            nJsExpression = "(function(n){try{var u=new g.dn('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
-            signatureTimestamp = 20616
-        ),
-        "fbcdec38" to HardcodedPlayerConfig(
-            sigFuncName = "_expr_sig",
-            sigConstantArg = null,
-            sigJsExpression = "na(16,3372,INPUT)",
-            nFuncName = "_expr_n",
-            nArrayIndex = null,
-            nConstantArgs = null,
-            nJsExpression = "(function(n){try{var u=new g.dn('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
-            signatureTimestamp = 20616
-        ),
-        // player_ias c7119fda / bfba3b57 (2026-06-12): na(16,3372,INPUT) via g.dn. STS 20616. CDN-validated (HTTP 206).
-        "c7119fda" to HardcodedPlayerConfig(
-            sigFuncName = "_expr_sig",
-            sigConstantArg = null,
-            sigJsExpression = "na(16,3372,INPUT)",
-            nFuncName = "_expr_n",
-            nArrayIndex = null,
-            nConstantArgs = null,
-            nJsExpression = "(function(n){try{var u=new g.dn('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
-            signatureTimestamp = 20616
-        ),
-        "bfba3b57" to HardcodedPlayerConfig(
-            sigFuncName = "_expr_sig",
-            sigConstantArg = null,
-            sigJsExpression = "na(16,3372,INPUT)",
-            nFuncName = "_expr_n",
-            nArrayIndex = null,
-            nConstantArgs = null,
-            nJsExpression = "(function(n){try{var u=new g.dn('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
-            signatureTimestamp = 20616
-        ),
-        // player_ias 88c25a98 / 62100781 (2026-06-13): il(16,3372,INPUT) via g.e4. STS 20616. CDN-validated (HTTP 206).
-        "88c25a98" to HardcodedPlayerConfig(
-            sigFuncName = "_expr_sig",
-            sigConstantArg = null,
-            sigJsExpression = "il(16,3372,INPUT)",
-            nFuncName = "_expr_n",
-            nArrayIndex = null,
-            nConstantArgs = null,
-            nJsExpression = "(function(n){try{var u=new g.e4('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
-            signatureTimestamp = 20616
-        ),
-        "62100781" to HardcodedPlayerConfig(
-            sigFuncName = "_expr_sig",
-            sigConstantArg = null,
-            sigJsExpression = "il(16,3372,INPUT)",
-            nFuncName = "_expr_n",
-            nArrayIndex = null,
-            nConstantArgs = null,
-            nJsExpression = "(function(n){try{var u=new g.e4('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
-            signatureTimestamp = 20616
-        ),
-        // player_ias 712f0810 / 02a03f06 (2026-06-13): il(16,3372,INPUT) via g.e4. STS 20616. CDN-validated (HTTP 206).
-        "712f0810" to HardcodedPlayerConfig(
-            sigFuncName = "_expr_sig",
-            sigConstantArg = null,
-            sigJsExpression = "il(16,3372,INPUT)",
-            nFuncName = "_expr_n",
-            nArrayIndex = null,
-            nConstantArgs = null,
-            nJsExpression = "(function(n){try{var u=new g.e4('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
-            signatureTimestamp = 20616
-        ),
-        "02a03f06" to HardcodedPlayerConfig(
-            sigFuncName = "_expr_sig",
-            sigConstantArg = null,
-            sigJsExpression = "il(16,3372,INPUT)",
-            nFuncName = "_expr_n",
-            nArrayIndex = null,
-            nConstantArgs = null,
-            nJsExpression = "(function(n){try{var u=new g.e4('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
-            signatureTimestamp = 20616
-        ),
-        // player_ias ae0b654c / efc5f0ec (2026-06-15): Ge(91,8257,INPUT) via g.bK. STS 20618. CDN-validated (HTTP 206).
-        "ae0b654c" to HardcodedPlayerConfig(
-            sigFuncName = "_expr_sig",
-            sigConstantArg = null,
-            sigJsExpression = "Ge(91,8257,INPUT)",
-            nFuncName = "_expr_n",
-            nArrayIndex = null,
-            nConstantArgs = null,
-            nJsExpression = "(function(n){try{var u=new g.bK('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
-            signatureTimestamp = 20618
-        ),
-        "efc5f0ec" to HardcodedPlayerConfig(
-            sigFuncName = "_expr_sig",
-            sigConstantArg = null,
-            sigJsExpression = "Ge(91,8257,INPUT)",
-            nFuncName = "_expr_n",
-            nArrayIndex = null,
-            nConstantArgs = null,
-            nJsExpression = "(function(n){try{var u=new g.bK('https://x.googlevideo.com/videoplayback?n='+n,true);var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)",
-            signatureTimestamp = 20618
-        ),
-    )
-
     // ==================== DETECTION PATTERNS ====================
 
     // Detect Q-array obfuscation: var Q="...".split("}")
@@ -492,51 +141,43 @@ object FunctionNameExtractor {
     }
 
     /**
-     * Get hardcoded config for a known player.js hash
+     * Get the validated config for a known player.js hash from [PlayerConfigStore] (the
+     * bundled asset overlaid by the remote table). Replaces the former hardcoded map — new
+     * players are now added by pushing to player_configs.json, not by editing this file.
      */
     fun getHardcodedConfig(playerHash: String): HardcodedPlayerConfig? {
-        val config = KNOWN_PLAYER_CONFIGS[playerHash]
+        val config = PlayerConfigStore.get(playerHash)
         if (config != null) {
-            Timber.tag(TAG).d("Found hardcoded config for hash $playerHash:")
+            Timber.tag(TAG).d("Found config for hash $playerHash:")
             Timber.tag(TAG).d("  sigFunc=${config.sigFuncName}(${config.sigConstantArg}, ...)")
+            Timber.tag(TAG).d("  sigExpr=${config.sigJsExpression}")
             Timber.tag(TAG).d("  nFunc=${config.nFuncName}[${config.nArrayIndex}]")
             Timber.tag(TAG).d("  signatureTimestamp=${config.signatureTimestamp}")
         } else {
-            Timber.tag(TAG).w("No hardcoded config for hash: $playerHash")
-            Timber.tag(TAG).w("Known hashes: ${KNOWN_PLAYER_CONFIGS.keys.joinToString()}")
+            Timber.tag(TAG).w("No config for hash: $playerHash")
+            Timber.tag(TAG).w("Known hashes: ${PlayerConfigStore.knownHashes().sorted().joinToString()}")
         }
         return config
     }
 
     /**
-     * Extract signature function info from player.js
+     * Extract signature function info from player.js.
      *
-     * Uses regex patterns first, falls back to hardcoded config if Q-array detected
+     * Validated config FIRST, legacy regex heuristics only as a fallback: config entries are
+     * proven against the live CDN (HTTP 206) before they ship, while the patterns below are
+     * unanchored heuristics that can false-match anywhere in the ~2 MB player JS. A heuristic
+     * must never shadow a validated config — and a false positive here must not block the
+     * unknown-player forced refresh in CipherDeobfuscator.
      * @param playerJs The player.js content
-     * @param knownHash Optional hash for hardcoded config lookup
+     * @param knownHash Optional hash for config lookup
      */
     fun extractSigFunctionInfo(playerJs: String, knownHash: String? = null): SigFunctionInfo? {
         Timber.tag(TAG).d("========== EXTRACTING SIG FUNCTION ==========")
         Timber.tag(TAG).d("Player.js size: ${playerJs.length} chars")
 
-        // Try regex patterns first
-        for ((index, pattern) in SIG_FUNCTION_PATTERNS.withIndex()) {
-            Timber.tag(TAG).v("Trying sig pattern $index: ${pattern.pattern.take(60)}...")
-            val match = pattern.find(playerJs)
-            if (match != null) {
-                val name = match.groupValues[1]
-                val constArg = if (match.groupValues.size > 2) match.groupValues[2].toIntOrNull() else null
-                Timber.tag(TAG).d("SIG FUNCTION FOUND via pattern $index:")
-                Timber.tag(TAG).d("  name=$name, constantArg=$constArg")
-                Timber.tag(TAG).d("  match context: ...${playerJs.substring(maxOf(0, match.range.first - 20), minOf(playerJs.length, match.range.last + 20))}...")
-                return SigFunctionInfo(name, constArg, isHardcoded = false)
-            }
-        }
-
-        Timber.tag(TAG).w("No sig pattern matched, trying hardcoded config...")
-
+        // Validated config first.
         val hashToUse = knownHash ?: extractPlayerHash(playerJs)
-        Timber.tag(TAG).d("Using hash for hardcoded lookup: $hashToUse (knownHash=$knownHash)")
+        Timber.tag(TAG).d("Using hash for config lookup: $hashToUse (knownHash=$knownHash)")
         if (hashToUse != null) {
             val config = getHardcodedConfig(hashToUse)
             if (config != null) {
@@ -558,23 +199,56 @@ object FunctionNameExtractor {
             }
         }
 
+        Timber.tag(TAG).w("No config for hash $hashToUse, trying legacy sig patterns...")
+
+        for ((index, pattern) in SIG_FUNCTION_PATTERNS.withIndex()) {
+            Timber.tag(TAG).v("Trying sig pattern $index: ${pattern.pattern.take(60)}...")
+            val match = pattern.find(playerJs)
+            if (match != null) {
+                val name = match.groupValues[1]
+                val constArg = if (match.groupValues.size > 2) match.groupValues[2].toIntOrNull() else null
+                Timber.tag(TAG).d("SIG FUNCTION FOUND via pattern $index:")
+                Timber.tag(TAG).d("  name=$name, constantArg=$constArg")
+                Timber.tag(TAG).d("  match context: ...${playerJs.substring(maxOf(0, match.range.first - 20), minOf(playerJs.length, match.range.last + 20))}...")
+                return SigFunctionInfo(name, constArg, isHardcoded = false)
+            }
+        }
+
         Timber.tag(TAG).e("========== SIG FUNCTION EXTRACTION FAILED ==========")
         Timber.tag(TAG).e("Could not find signature deobfuscation function name")
         return null
     }
 
     /**
-     * Extract N-transform function info from player.js
+     * Extract N-transform function info from player.js.
      *
-     * Uses regex patterns first, falls back to hardcoded config if Q-array detected
+     * Validated config FIRST, legacy regex heuristics only as a fallback — same precedence
+     * rationale as [extractSigFunctionInfo].
      * @param playerJs The player.js content
-     * @param knownHash Optional hash for hardcoded config lookup
+     * @param knownHash Optional hash for config lookup
      */
     fun extractNFunctionInfo(playerJs: String, knownHash: String? = null): NFunctionInfo? {
         Timber.tag(TAG).d("========== EXTRACTING N-FUNCTION ==========")
         Timber.tag(TAG).d("Player.js size: ${playerJs.length} chars")
 
-        // Try regex patterns first
+        // Validated config first.
+        val hashToUse = knownHash ?: extractPlayerHash(playerJs)
+        Timber.tag(TAG).d("Using hash for config lookup: $hashToUse (knownHash=$knownHash)")
+        if (hashToUse != null) {
+            val config = getHardcodedConfig(hashToUse)
+            if (config != null) {
+                if (config.nJsExpression != null) {
+                    Timber.tag(TAG).d("USING EXPRESSION-BASED N-FUNCTION: ${config.nJsExpression.take(60)}")
+                } else {
+                    Timber.tag(TAG).d("USING HARDCODED N-FUNCTION: ${config.nFuncName}[${config.nArrayIndex}]")
+                    Timber.tag(TAG).d("N-function constant args: ${config.nConstantArgs}")
+                }
+                return NFunctionInfo(config.nFuncName, config.nArrayIndex, config.nConstantArgs, config.nJsExpression, isHardcoded = true)
+            }
+        }
+
+        Timber.tag(TAG).w("No config for hash $hashToUse, trying legacy n-func patterns...")
+
         for ((index, pattern) in N_FUNCTION_PATTERNS.withIndex()) {
             Timber.tag(TAG).v("Trying n-func pattern $index: ${pattern.pattern.take(60)}...")
             val match = pattern.find(playerJs)
@@ -608,23 +282,6 @@ object FunctionNameExtractor {
                         return NFunctionInfo(name, null, isHardcoded = false)
                     }
                 }
-            }
-        }
-
-        Timber.tag(TAG).w("No n-func pattern matched, trying hardcoded config...")
-
-        val hashToUse = knownHash ?: extractPlayerHash(playerJs)
-        Timber.tag(TAG).d("Using hash for hardcoded lookup: $hashToUse (knownHash=$knownHash)")
-        if (hashToUse != null) {
-            val config = getHardcodedConfig(hashToUse)
-            if (config != null) {
-                if (config.nJsExpression != null) {
-                    Timber.tag(TAG).d("USING EXPRESSION-BASED N-FUNCTION: ${config.nJsExpression.take(60)}")
-                } else {
-                    Timber.tag(TAG).d("USING HARDCODED N-FUNCTION: ${config.nFuncName}[${config.nArrayIndex}]")
-                    Timber.tag(TAG).d("N-function constant args: ${config.nConstantArgs}")
-                }
-                return NFunctionInfo(config.nFuncName, config.nArrayIndex, config.nConstantArgs, config.nJsExpression, isHardcoded = true)
             }
         }
 

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/PlayerConfigParser.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/PlayerConfigParser.kt
@@ -1,0 +1,145 @@
+package com.metrolist.music.utils.cipher
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+
+/**
+ * Parses and validates the player-config JSON (bundled asset and remote copies).
+ *
+ * Pure JVM on purpose: no Android or Timber imports, so the full validation surface is
+ * coverable by plain unit tests. Android concerns (assets, cache files, fetching) live in
+ * [PlayerConfigStore].
+ *
+ * Security boundary: every value in this file ends up evaluated as JavaScript inside the
+ * cipher WebView, so entries are regex-locked to shapes that cannot carry arbitrary JS —
+ * `sig` must be a single `name(int,int,INPUT)` call and `nClass` a bare identifier; the
+ * n-transform IIFE is built locally from [buildNJsExpression], never taken from the file.
+ */
+object PlayerConfigParser {
+    const val SUPPORTED_SCHEMA_VERSION = 1
+
+    private val SIG_RE = Regex("""^[A-Za-z0-9${'$'}_]{1,8}\(\d+,\d+,INPUT\)$""")
+    private val NCLASS_RE = Regex("""^[A-Za-z0-9${'$'}_]{1,8}$""")
+    private val HASH_RE = Regex("""^[a-f0-9]{8}$""")
+
+    sealed class ParseResult {
+        data class Success(
+            val configs: Map<String, FunctionNameExtractor.HardcodedPlayerConfig>,
+            val skippedEntries: List<String>,
+        ) : ParseResult()
+
+        data class Failure(val reason: String) : ParseResult()
+    }
+
+    fun buildNJsExpression(nClass: String): String =
+        "(function(n){try{var u=new g.$nClass('https://x.googlevideo.com/videoplayback?n='+n,true);" +
+            "var t=u.get('n');return(t&&t!==n)?t:n;}catch(e){return n;}})(INPUT)"
+
+    /**
+     * Parses [jsonText]. File-level problems (malformed JSON, missing/unsupported
+     * schemaVersion, missing `players`) return [ParseResult.Failure] — callers keep their
+     * previous map. Invalid individual entries are skipped and reported in
+     * [ParseResult.Success.skippedEntries] so one bad entry can't poison the rest.
+     */
+    fun parse(jsonText: String): ParseResult {
+        val root = try {
+            Json.parseToJsonElement(jsonText) as? JsonObject
+                ?: return ParseResult.Failure("root is not a JSON object")
+        } catch (e: Exception) {
+            return ParseResult.Failure("malformed JSON: ${e.message}")
+        }
+
+        // Non-string primitive only (like sts): a string-typed "1" must fail identically
+        // here and in the harness loader, or the two readers drift on the same file.
+        val schemaVersion = (root["schemaVersion"] as? JsonPrimitive)
+            ?.takeIf { !it.isString }?.content?.toIntOrNull()
+            ?: return ParseResult.Failure("schemaVersion missing or not an int")
+        if (schemaVersion <= 0) return ParseResult.Failure("schemaVersion must be positive")
+        if (schemaVersion > SUPPORTED_SCHEMA_VERSION) {
+            return ParseResult.Failure("unsupported schemaVersion $schemaVersion (supported: $SUPPORTED_SCHEMA_VERSION)")
+        }
+
+        val players = root["players"] as? JsonObject
+            ?: return ParseResult.Failure("players missing or not an object")
+
+        val configs = mutableMapOf<String, FunctionNameExtractor.HardcodedPlayerConfig>()
+        val skipped = mutableListOf<String>()
+
+        for ((hash, entryElement) in players) {
+            val entry = parseEntry(hash, entryElement as? JsonObject)
+            if (entry == null) {
+                skipped += hash
+                continue
+            }
+            val (config, aliases) = entry
+            // A key collision (an alias duplicating another entry's hash or alias, or its
+            // own primary) makes the table ambiguous — which entry wins would depend on
+            // iteration order. That is a file-level defect, not a bad entry: reject the
+            // whole file so callers keep their previous table.
+            val keys = listOf(hash) + aliases
+            val duplicate = keys.firstOrNull { it in configs }
+                ?: keys.groupingBy { it }.eachCount().entries.firstOrNull { it.value > 1 }?.key
+            if (duplicate != null) {
+                return ParseResult.Failure("duplicate hash/alias '$duplicate' (entry $hash)")
+            }
+            configs[hash] = config
+            for (alias in aliases) configs[alias] = config
+        }
+
+        return ParseResult.Success(configs, skipped)
+    }
+
+    private fun parseEntry(
+        hash: String,
+        obj: JsonObject?,
+    ): Pair<FunctionNameExtractor.HardcodedPlayerConfig, List<String>>? {
+        if (obj == null || !HASH_RE.matches(hash)) return null
+
+        val sig = (obj["sig"] as? JsonPrimitive)?.takeIf { it.isString }?.content ?: return null
+        if (!SIG_RE.matches(sig)) return null
+
+        val nClass = (obj["nClass"] as? JsonPrimitive)?.takeIf { it.isString }?.content ?: return null
+        if (!NCLASS_RE.matches(nClass)) return null
+
+        val stsPrimitive = (obj["sts"] as? JsonPrimitive)?.takeIf { !it.isString } ?: return null
+        val sts = stsPrimitive.content.toIntOrNull() ?: return null
+        if (sts <= 0) return null
+
+        val aliases = when (val aliasesElement = obj["aliases"]) {
+            null -> emptyList()
+            else -> {
+                val array = try {
+                    aliasesElement.jsonArray
+                } catch (e: Exception) {
+                    return null
+                }
+                array.map { element ->
+                    val alias = (element as? JsonPrimitive)?.takeIf { it.isString }?.content ?: return null
+                    if (!HASH_RE.matches(alias)) return null
+                    alias
+                }
+            }
+        }
+
+        val config = FunctionNameExtractor.HardcodedPlayerConfig(
+            sigFuncName = "_expr_sig",
+            sigConstantArg = null,
+            sigJsExpression = sig,
+            nFuncName = "_expr_n",
+            nArrayIndex = null,
+            nConstantArgs = null,
+            nJsExpression = buildNJsExpression(nClass),
+            signatureTimestamp = sts,
+        )
+        return config to aliases
+    }
+
+    /** Overlay [remote] onto [bundled]: remote wins per key; bundled-only keys survive. */
+    fun merge(
+        bundled: Map<String, FunctionNameExtractor.HardcodedPlayerConfig>,
+        remote: Map<String, FunctionNameExtractor.HardcodedPlayerConfig>,
+    ): Map<String, FunctionNameExtractor.HardcodedPlayerConfig> = bundled + remote
+}

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/PlayerConfigStore.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/PlayerConfigStore.kt
@@ -41,9 +41,8 @@ object PlayerConfigStore {
     private const val FORCE_REFRESH_COOLDOWN_MS = 5 * 60 * 1000L
 
     // Note: names must not start with "player_" — PlayerJsFetcher.writeToCache() purges
-    // "player_*" from this shared dir on every player-JS refresh (and invalidateCache()
-    // wipes it entirely; that is benign — the in-memory map survives and the next refresh
-    // refetches without an ETag).
+    // "player_*" from this shared dir on every player-JS refresh. PlayerJsFetcher.invalidateCache()
+    // deletes only player_*/current_hash.txt, so the config cache + ETag survive cipher retries.
     private const val CACHE_FILE = "configs_remote.json"
     private const val META_FILE = "configs_remote.meta"
 
@@ -68,10 +67,13 @@ object PlayerConfigStore {
     private val refreshMutex = Mutex()
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
-    private val httpClient: OkHttpClient
-        get() = OkHttpClient.Builder()
+    // Built once on first use (mirrors PlayerJsFetcher's single client) so config refreshes
+    // reuse one connection pool/dispatcher instead of allocating a fresh client per fetch.
+    private val httpClient: OkHttpClient by lazy {
+        OkHttpClient.Builder()
             .apply { YouTube.proxy?.let { proxy(it) } }
             .build()
+    }
 
     /**
      * Synchronous: loads the bundled asset and, if present and valid, the last-good cached

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/PlayerConfigStore.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/PlayerConfigStore.kt
@@ -1,0 +1,336 @@
+package com.metrolist.music.utils.cipher
+
+import android.content.Context
+import com.metrolist.innertube.YouTube
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import timber.log.Timber
+import java.io.File
+
+/**
+ * Owns the player-config table at runtime: bundled asset as the offline default, overlaid
+ * by the same JSON fetched from the zemer-cipher repo so rotated players are fixed without
+ * an APK update. Parsing/validation is delegated to [PlayerConfigParser]; only validated
+ * payloads ever replace the in-memory map or touch the disk cache.
+ *
+ * Read path is lock-free: lookups hit an immutable map behind a @Volatile reference that
+ * refreshes swap wholesale.
+ */
+object PlayerConfigStore {
+    private const val TAG = "Metrolist_CipherConfig"
+    private const val ASSET_NAME = "player_configs.json"
+
+    // Points at zemer-cipher upstream: every device pulls zemer's live, CDN-validated
+    // configs automatically (6 h TTL + failure-triggered self-heal), so a player rotation
+    // zemer has already solved is fixed fleet-wide without a Metrolist-fix APK release.
+    private const val REMOTE_URL =
+        "https://raw.githubusercontent.com/ZemerTeam/zemer-cipher/master/library/src/main/assets/player_configs.json"
+
+    // Mirrors PlayerJsFetcher.CACHE_TTL_MS.
+    private const val REFRESH_TTL_MS = 6 * 60 * 60 * 1000L
+
+    // Failure-triggered refreshes are rate-limited so a player that is unknown both locally
+    // and remotely doesn't turn every song into a GitHub request.
+    private const val FORCE_REFRESH_COOLDOWN_MS = 5 * 60 * 1000L
+
+    // Note: names must not start with "player_" — PlayerJsFetcher.writeToCache() purges
+    // "player_*" from this shared dir on every player-JS refresh (and invalidateCache()
+    // wipes it entirely; that is benign — the in-memory map survives and the next refresh
+    // refetches without an ETag).
+    private const val CACHE_FILE = "configs_remote.json"
+    private const val META_FILE = "configs_remote.meta"
+
+    @Volatile
+    private var appContext: Context? = null
+
+    @Volatile
+    private var bundledConfigs: Map<String, FunctionNameExtractor.HardcodedPlayerConfig> = emptyMap()
+
+    @Volatile
+    private var mergedConfigs: Map<String, FunctionNameExtractor.HardcodedPlayerConfig> = emptyMap()
+
+    @Volatile
+    private var lastForcedAttemptMs = 0L
+
+    // True when the most recent fetch got ANY HTTP response (200/304/404/...). The forced-refresh
+    // cooldown only arms in that case — it exists to protect the config host from repeat hits,
+    // not to delay recovery after a pure network failure (e.g. rotation hit while offline).
+    @Volatile
+    private var lastAttemptReachedServer = false
+
+    private val refreshMutex = Mutex()
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private val httpClient: OkHttpClient
+        get() = OkHttpClient.Builder()
+            .apply { YouTube.proxy?.let { proxy(it) } }
+            .build()
+
+    /**
+     * Synchronous: loads the bundled asset and, if present and valid, the last-good cached
+     * remote copy. Cheap (a ~1.5 KB asset + at most one small file) and guarantees configs
+     * exist before any lookup.
+     */
+    fun initialize(context: Context) {
+        appContext = context.applicationContext
+
+        bundledConfigs = when (val result = parseSource("bundled asset") { loadBundledJson(context) }) {
+            null -> emptyMap()
+            else -> result
+        }
+        if (bundledConfigs.isEmpty()) {
+            Timber.tag(TAG).e("Bundled $ASSET_NAME missing or invalid — config table starts empty")
+        } else {
+            Timber.tag(TAG).d("Loaded bundled configs (${bundledConfigs.size} hashes)")
+        }
+
+        applyCachedOverlay()
+    }
+
+    /**
+     * Overlays the last-good cached remote copy onto the bundled table. On ANY failure to
+     * load it, the cache body AND the meta file are deleted together: an ETag surviving a
+     * corrupt/missing body would make every subsequent conditional fetch 304 without a
+     * re-download, locking the device on bundled-only configs until the remote content
+     * happens to change. (No-op deletes on a clean first run.)
+     */
+    internal fun applyCachedOverlay() {
+        val cached = parseSource("cached remote copy") { cacheFile()?.takeIf { it.exists() }?.readText() }
+        mergedConfigs = if (cached != null) {
+            Timber.tag(TAG).d("Overlaying cached remote configs (${cached.size} hashes)")
+            PlayerConfigParser.merge(bundledConfigs, cached)
+        } else {
+            cacheFile()?.delete()
+            metaFile()?.delete()
+            bundledConfigs
+        }
+    }
+
+    /** Non-blocking TTL-gated refresh, kicked once from CipherDeobfuscator.initialize(). */
+    fun scheduleStartupRefresh() {
+        scope.launch {
+            try {
+                refreshIfStale()
+            } catch (e: Exception) {
+                Timber.tag(TAG).w(e, "Startup config refresh failed: ${e.message}")
+            }
+        }
+    }
+
+    fun get(hash: String): FunctionNameExtractor.HardcodedPlayerConfig? {
+        val configs = mergedConfigs
+        if (configs.isEmpty()) {
+            Timber.tag(TAG).w("Config table is empty (initialize not called or bundled asset broken)")
+        }
+        return configs[hash]
+    }
+
+    fun knownHashes(): Set<String> = mergedConfigs.keys
+
+    /** Test-only: swaps the in-memory table without touching disk, context, or network. */
+    internal fun setTableForTest(configs: Map<String, FunctionNameExtractor.HardcodedPlayerConfig>) {
+        mergedConfigs = configs
+    }
+
+    /**
+     * Failure-triggered refresh: called when a player-hash lookup misses. Single-flight, with
+     * the cooldown decided under the lock (a check-then-set outside it would let concurrent
+     * misses race). Returns true iff [missingHash] is now in the table — whether THIS call's
+     * fetch did the work or a concurrent/just-finished refresh already brought it in — so
+     * callers retry extraction exactly when it can succeed.
+     */
+    suspend fun forceRefresh(missingHash: String): Boolean = withContext(Dispatchers.IO) {
+        refreshMutex.withLock {
+            // A refresh that held the lock while we waited (startup TTL, another miss) may
+            // have just landed this config — don't burn a fetch or arm the cooldown.
+            if (mergedConfigs.containsKey(missingHash)) {
+                Timber.tag(TAG).d("forceRefresh: $missingHash arrived via concurrent refresh")
+                return@withLock true
+            }
+
+            val now = System.currentTimeMillis()
+            if (now - lastForcedAttemptMs < FORCE_REFRESH_COOLDOWN_MS) {
+                Timber.tag(TAG).d("forceRefresh skipped (cooldown)")
+                return@withLock false
+            }
+            lastForcedAttemptMs = now
+            fetchAndApply()
+            if (!lastAttemptReachedServer) lastForcedAttemptMs = 0L
+            mergedConfigs.containsKey(missingHash)
+        }
+    }
+
+    private suspend fun refreshIfStale() {
+        val lastFetchMs = readMeta()?.second ?: 0L
+        if (System.currentTimeMillis() - lastFetchMs < REFRESH_TTL_MS) {
+            Timber.tag(TAG).d("Remote configs fresh (fetched ${System.currentTimeMillis() - lastFetchMs} ms ago)")
+            return
+        }
+        withContext(Dispatchers.IO) {
+            refreshMutex.withLock { fetchAndApply() }
+        }
+    }
+
+    /**
+     * Fetches the remote JSON (with If-None-Match) and applies it when valid. Any failure —
+     * HTTP error (including the 404 served until the file lands on the repo's default
+     * branch), network exception, or validation failure — keeps the previous map and cache.
+     * lastFetchMs is only advanced on 200/304 so transient failures retry on the next trigger.
+     */
+    private fun fetchAndApply(): Boolean {
+        lastAttemptReachedServer = false
+        try {
+            val etag = readMeta()?.first
+            val request = Request.Builder()
+                .url(REMOTE_URL)
+                .header("User-Agent", "Mozilla/5.0")
+                .apply { if (!etag.isNullOrEmpty()) header("If-None-Match", etag) }
+                .build()
+
+            httpClient.newCall(request).execute().use { response ->
+                lastAttemptReachedServer = true
+                if (response.code == 304) {
+                    Timber.tag(TAG).d("Remote configs unchanged (304)")
+                    writeMeta(etag.orEmpty(), System.currentTimeMillis())
+                    return false
+                }
+                if (!response.isSuccessful) {
+                    Timber.tag(TAG).w("Remote config fetch HTTP ${response.code} — keeping previous configs")
+                    return false
+                }
+
+                val body = response.body?.string()
+                if (body.isNullOrEmpty()) {
+                    Timber.tag(TAG).w("Remote config fetch returned empty body — keeping previous configs")
+                    return false
+                }
+
+                val remote = when (val result = PlayerConfigParser.parse(body)) {
+                    is PlayerConfigParser.ParseResult.Failure -> {
+                        Timber.tag(TAG).w("Remote configs rejected: ${result.reason} — keeping previous configs")
+                        return false
+                    }
+                    is PlayerConfigParser.ParseResult.Success -> {
+                        if (result.skippedEntries.isNotEmpty()) {
+                            Timber.tag(TAG).w("Remote configs: skipped invalid entries ${result.skippedEntries}")
+                        }
+                        result.configs
+                    }
+                }
+
+                return applyRemote(remote, body, response.header("ETag").orEmpty())
+            }
+        } catch (e: Exception) {
+            Timber.tag(TAG).w(e, "Remote config fetch failed: ${e.message} — keeping previous configs")
+            return false
+        }
+    }
+
+    /**
+     * Applies a validated remote table to memory FIRST, then best-effort persists the raw
+     * body + meta. A disk failure (full disk, IO error) must never discard an in-hand
+     * validated fix — losing the cache only costs a refetch on the next start, while losing
+     * the memory update costs working playback now. Returns whether the table changed.
+     */
+    internal fun applyRemote(
+        remote: Map<String, FunctionNameExtractor.HardcodedPlayerConfig>,
+        body: String,
+        etag: String,
+    ): Boolean {
+        val merged = PlayerConfigParser.merge(bundledConfigs, remote)
+        val changed = merged != mergedConfigs
+        mergedConfigs = merged
+        Timber.tag(TAG).d("Remote configs applied (${remote.size} hashes, merged=${merged.size}, changed=$changed)")
+
+        try {
+            cacheFile()?.let { writeAtomic(it, body) }
+            writeMeta(etag, System.currentTimeMillis())
+        } catch (e: Exception) {
+            Timber.tag(TAG).w(e, "Could not persist remote configs (kept in memory): ${e.message}")
+        }
+        return changed
+    }
+
+    private fun parseSource(
+        label: String,
+        read: () -> String?,
+    ): Map<String, FunctionNameExtractor.HardcodedPlayerConfig>? {
+        val text = try {
+            read() ?: return null
+        } catch (e: Exception) {
+            Timber.tag(TAG).w(e, "Could not read $label: ${e.message}")
+            return null
+        }
+        return when (val result = PlayerConfigParser.parse(text)) {
+            is PlayerConfigParser.ParseResult.Failure -> {
+                Timber.tag(TAG).w("Rejected $label: ${result.reason}")
+                null
+            }
+            is PlayerConfigParser.ParseResult.Success -> {
+                if (result.skippedEntries.isNotEmpty()) {
+                    Timber.tag(TAG).w("$label: skipped invalid entries ${result.skippedEntries}")
+                }
+                result.configs
+            }
+        }
+    }
+
+    private fun loadBundledJson(context: Context): String? =
+        context.assets.open(ASSET_NAME).bufferedReader().use { it.readText() }
+
+    // Test seam: unit tests point this at a temp dir; production resolves from appContext.
+    internal var cacheDirForTest: File? = null
+
+    private fun cacheDir(): File? {
+        cacheDirForTest?.let { return it.apply { if (!exists()) mkdirs() } }
+        val context = appContext ?: return null
+        return File(context.filesDir, "cipher_cache").apply { if (!exists()) mkdirs() }
+    }
+
+    private fun cacheFile(): File? = cacheDir()?.let { File(it, CACHE_FILE) }
+
+    private fun metaFile(): File? = cacheDir()?.let { File(it, META_FILE) }
+
+    /** Meta file: line 1 = ETag (may be empty), line 2 = lastFetchMs. */
+    private fun readMeta(): Pair<String, Long>? {
+        return try {
+            val file = metaFile()?.takeIf { it.exists() } ?: return null
+            val lines = file.readText().split("\n")
+            if (lines.size < 2) return null
+            val lastFetchMs = lines[1].toLongOrNull() ?: return null
+            lines[0] to lastFetchMs
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun writeMeta(etag: String, lastFetchMs: Long) {
+        try {
+            metaFile()?.let { writeAtomic(it, "$etag\n$lastFetchMs") }
+        } catch (e: Exception) {
+            Timber.tag(TAG).w(e, "Could not write config meta: ${e.message}")
+        }
+    }
+
+    /**
+     * Temp-file + rename so a process death mid-write can't leave a truncated file (a
+     * corrupt cache body beside a valid ETag is exactly the 304-lock state
+     * [applyCachedOverlay] defends against).
+     */
+    internal fun writeAtomic(file: File, content: String) {
+        val tmp = File(file.parentFile, "${file.name}.tmp")
+        tmp.writeText(content)
+        if (!tmp.renameTo(file)) {
+            // renameTo can fail on some filesystems — fall back to a direct write.
+            file.writeText(content)
+            tmp.delete()
+        }
+    }
+}

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/PlayerDatesStore.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/PlayerDatesStore.kt
@@ -74,11 +74,15 @@ object PlayerDatesStore {
     private fun fetchRemote(): String {
         val url = URL(REMOTE_URL)
         val conn = (YouTube.proxy?.let { url.openConnection(it) } ?: url.openConnection()) as HttpURLConnection
-        return conn.run {
-            connectTimeout = 10_000
-            readTimeout = 10_000
-            setRequestProperty("User-Agent", "Mozilla/5.0")
-            inputStream.bufferedReader().use { it.readText() }
+        return try {
+            conn.run {
+                connectTimeout = 10_000
+                readTimeout = 10_000
+                setRequestProperty("User-Agent", "Mozilla/5.0")
+                inputStream.bufferedReader().use { it.readText() }
+            }
+        } finally {
+            conn.disconnect() // release the socket immediately, including on the error path
         }
     }
 }

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/PlayerDatesStore.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/PlayerDatesStore.kt
@@ -1,0 +1,84 @@
+package com.metrolist.music.utils.cipher
+
+import android.content.Context
+import com.metrolist.innertube.YouTube
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import timber.log.Timber
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+
+/**
+ * Cosmetic "when did we add cipher support for this player" dates, shown in the song-details
+ * sheet next to the player hash.
+ *
+ * Pulled **purely from a remote file** on the cipher repo — `player_dates.json` is NOT bundled
+ * in the APK, so adding a date is just a push to that file and already-installed apps pick it
+ * up with no APK update. A small on-disk cache makes it instant/offline on later launches.
+ *
+ * Deliberately decoupled from [PlayerConfigStore] and the decipher path: it is a separate file
+ * old apps never fetch (so it cannot affect them), it is parsed tolerantly, and every failure
+ * (no network, bad JSON, no cache yet) just yields an unknown date — playback is never touched.
+ *
+ * File shape — a flat map, no schemaVersion, no validation:
+ *   { "959dabb2": "2026-06-12", "445213fb": "2026-06-10", ... }
+ */
+object PlayerDatesStore {
+    private const val TAG = "Metrolist_CipherDates"
+    private const val REMOTE_URL =
+        "https://raw.githubusercontent.com/ZemerTeam/zemer-cipher/master/player_dates.json"
+
+    // Own dir, NOT the shared cipher_cache (PlayerJsFetcher purges/wipes that one).
+    private const val CACHE_DIR = "cipher_dates"
+    private const val CACHE_FILE = "player_dates.json"
+
+    @Volatile
+    private var dates: Map<String, String> = emptyMap()
+
+    /** Tolerant parse of a flat `hash -> date` object. Non-string values are skipped; never throws. */
+    internal fun parse(text: String): Map<String, String> =
+        runCatching {
+            val root = Json.parseToJsonElement(text) as? JsonObject ?: return emptyMap()
+            buildMap {
+                for ((hash, value) in root) {
+                    (value as? JsonPrimitive)?.takeIf { it.isString }?.content?.let { put(hash, it) }
+                }
+            }
+        }.getOrDefault(emptyMap())
+
+    /** Load the last-fetched cache (instant/offline), then refresh from the remote file in the background. */
+    fun initialize(context: Context) {
+        val cache = File(File(context.filesDir, CACHE_DIR).apply { mkdirs() }, CACHE_FILE)
+
+        dates = runCatching {
+            if (cache.exists()) parse(cache.readText()) else emptyMap()
+        }.getOrDefault(emptyMap())
+
+        Thread {
+            runCatching {
+                val body = fetchRemote()
+                val remote = parse(body)
+                if (remote.isNotEmpty()) {
+                    dates = remote // the remote file is the single source of truth
+                    runCatching { cache.writeText(body) } // persist for the next launch / offline
+                }
+            }.onFailure { Timber.tag(TAG).d("dates refresh skipped: ${it.message}") }
+        }.apply { isDaemon = true; name = "PlayerDatesRefresh" }.start()
+    }
+
+    /** Onboarding date for [hash] (`YYYY-MM-DD`), or null if unknown. */
+    fun get(hash: String?): String? = hash?.let { dates[it] }
+
+    private fun fetchRemote(): String {
+        val url = URL(REMOTE_URL)
+        val conn = (YouTube.proxy?.let { url.openConnection(it) } ?: url.openConnection()) as HttpURLConnection
+        return conn.run {
+            connectTimeout = 10_000
+            readTimeout = 10_000
+            setRequestProperty("User-Agent", "Mozilla/5.0")
+            inputStream.bufferedReader().use { it.readText() }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/PlayerJsFetcher.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/PlayerJsFetcher.kt
@@ -102,8 +102,14 @@ object PlayerJsFetcher {
         try {
             val cacheDir = getCacheDir()
             if (cacheDir.exists()) {
-                val files = cacheDir.listFiles()
-                Timber.tag(TAG).d("Deleting ${files?.size ?: 0} cache files")
+                // Only the player.js cache (player_*.js + current_hash.txt) belongs to this fetcher.
+                // The dir is shared with PlayerConfigStore (configs_remote.json/.meta) — do NOT wipe
+                // those, or every decipher retry destroys the config ETag and forces a full
+                // non-conditional re-download of the config file.
+                val files = cacheDir.listFiles()?.filter {
+                    it.name.startsWith("player_") || it.name == "current_hash.txt"
+                }
+                Timber.tag(TAG).d("Deleting ${files?.size ?: 0} player-JS cache files")
                 files?.forEach {
                     Timber.tag(TAG).v("Deleting: ${it.name}")
                     it.delete()

--- a/app/src/main/res/drawable/key_vertical.xml
+++ b/app/src/main/res/drawable/key_vertical.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:strokeColor="@android:color/white"
+      android:strokeWidth="1.9"
+      android:strokeLineCap="round"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:pathData="M12,2.5 C13.93,2.5 15.5,4.07 15.5,6 C15.5,7.93 13.93,9.5 12,9.5 C10.07,9.5 8.5,7.93 8.5,6 C8.5,4.07 10.07,2.5 12,2.5 Z M12,9.5 L12,20.5 M12,15.5 L15,15.5 M12,18 L14,18" />
+</vector>

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -976,4 +976,26 @@
     <string name="widget_playlists_description">Playlist shortcuts with mini-player controls</string>
     <string name="choose_something_below">Choose something below</string>
     <string name="stream_client">Stream client</string>
+
+    <!-- Stream sources -->
+    <string name="stream_sources">Stream sources</string>
+    <string name="stream_source_web_clients">Web clients</string>
+    <string name="stream_source_native_clients">Native clients</string>
+    <string name="stream_source_creator_clients">Creator clients</string>
+    <string name="stream_source_web_remix">WEB_REMIX</string>
+    <string name="stream_source_web_remix_desc">Primary client. Authenticated; covers most tracks.</string>
+    <string name="stream_source_tvhtml5">TVHTML5</string>
+    <string name="stream_source_tvhtml5_desc">TV client. Reliable fallback.</string>
+    <string name="stream_source_visionos">visionOS</string>
+    <string name="stream_source_visionos_desc">Apple Vision. No throttle gate; very reliable.</string>
+    <string name="stream_source_android_vr">Android VR</string>
+    <string name="stream_source_android_vr_desc">Android VR clients (all versions).</string>
+    <string name="stream_source_ios">iOS</string>
+    <string name="stream_source_ios_desc">Apple iOS. Off by default; throttle-gated past ~1 MiB.</string>
+    <string name="stream_source_ipados">iPadOS</string>
+    <string name="stream_source_ipados_desc">Apple iPadOS. Off by default; shares the iOS client.</string>
+    <string name="stream_source_web_creator">WEB_CREATOR</string>
+    <string name="stream_source_web_creator_desc">Creator web client.</string>
+    <string name="stream_source_android_creator">ANDROID_CREATOR</string>
+    <string name="stream_source_android_creator_desc">Android creator client. Off by default; needs DroidGuard.</string>
 </resources>

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -979,6 +979,7 @@
 
     <!-- Stream sources -->
     <string name="stream_sources">Stream sources</string>
+    <string name="stream_source_order">Stream order</string>
     <string name="stream_source_web_clients">Web clients</string>
     <string name="stream_source_native_clients">Native clients</string>
     <string name="stream_source_creator_clients">Creator clients</string>

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -994,10 +994,8 @@
     <string name="stream_source_visionos_desc">Apple Vision. No throttle gate; very reliable.</string>
     <string name="stream_source_android_vr">Android VR</string>
     <string name="stream_source_android_vr_desc">Android VR clients (all versions).</string>
-    <string name="stream_source_ios">iOS</string>
-    <string name="stream_source_ios_desc">Apple iOS. Off by default; throttle-gated past ~1 MiB.</string>
-    <string name="stream_source_ipados">iPadOS</string>
-    <string name="stream_source_ipados_desc">Apple iPadOS. Off by default; shares the iOS client.</string>
+    <string name="stream_source_ios">iOS / iPadOS</string>
+    <string name="stream_source_ios_desc">Apple iOS and iPadOS clients. Off by default; throttle-gated past ~1 MiB.</string>
     <string name="stream_source_web_creator">WEB_CREATOR</string>
     <string name="stream_source_web_creator_desc">Creator web client.</string>
     <string name="stream_source_android_creator">ANDROID_CREATOR</string>

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -976,6 +976,9 @@
     <string name="widget_playlists_description">Playlist shortcuts with mini-player controls</string>
     <string name="choose_something_below">Choose something below</string>
     <string name="stream_client">Stream client</string>
+    <string name="format_player_hash">Player hash</string>
+    <string name="format_cipher_support_added">Cipher support added</string>
+    <string name="not_applicable">N/A</string>
 
     <!-- Stream sources -->
     <string name="stream_sources">Stream sources</string>


### PR DESCRIPTION
## What this does
Ship YouTube player-cipher fixes **without an APK update**, add user-facing
stream-source controls, and harden signature-timestamp resolution.

### Remote-updatable player configs  ← headline
The hardcoded player-config map is replaced by a bundled `player_configs.json`
overlaid by the same file fetched at runtime (6 h TTL + failure-triggered
self-heal). When YouTube rotates `player_ias` and breaks sig/n deciphering,
**publishing the new config fixes every installed device automatically — no
release required.** Payloads are schema-validated and regex-locked before use;
any fetch/parse error falls back to the last-good (or bundled) configs, so
playback is never blocked on the network.

### Stream Sources screen
Toggle which innertube clients are used for stream resolution and view the
effective resolution order. iOS/iPadOS share one underlying client, so they're
a single toggle.

When a client is completely broken, you can toggle it off to avoid trying on every single song, and instead use what works until a fix is pushed.

### Reliability
- Prefer the cipher player's own signature timestamp to avoid CDN 403s when
  YouTube A/B-rolls a different player generation; cooperative cancellation
  across the decipher path.

### Song details
Show the player hash and the date cipher support was added.

> Remote configs (and the cosmetic "cipher support added" dates) are fetched
> from `ZemerTeam/zemer-cipher`. Offline/failure → bundled asset only.

### Screenshots

<img width="250" alt="Screenshot_20260615-134817" src="https://github.com/user-attachments/assets/2ae673cf-9158-403f-998a-72717a9cf07c" />
<img width="250" alt="Screenshot_20260615-134838_com metrolist music debug" src="https://github.com/user-attachments/assets/475183b1-f661-4268-af99-64b53d07fb41" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a “Stream sources” settings section to enable/disable stream clients and control their priority order.
  * Added additional media info details for web stream formatting (e.g., player hash and cipher support status).
* **Bug Fixes**
  * Playback now avoids attempting disabled stream clients and improves stream fallback ordering.
  * Improved handling of in-flight request cancellations to prevent masking errors.
* **UI / Content**
  * Added new strings and an icon for stream-source display and formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
