### PR TITLE
fix: ensure cached songs are registered in cache playlist

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -1624,6 +1624,14 @@ class MusicService :
                 if (song.song.isVideo != mediaMetadata.isVideoSong) {
                     updatedSong = updatedSong.copy(isVideo = mediaMetadata.isVideoSong)
                 }
+                // Set dateDownload when song is cached during playback
+                // This ensures cached songs appear in the Cache Playlist
+                if (updatedSong.dateDownload == null && updatedSong.isDownloaded == false) {
+                    val contentLength = song.format?.contentLength
+                    if (contentLength != null && playerCache.isCached(mediaId, 0, contentLength)) {
+                        updatedSong = updatedSong.copy(dateDownload = java.time.LocalDateTime.now())
+                    }
+                }
                 if (updatedSong != song.song) {
                     update(updatedSong)
                 }


### PR DESCRIPTION
This fix addresses the issue where cached songs were not being properly registered in the cache playlist. The problem was that when songs were cached during playback, their dateDownload field was not being set, causing them to not appear in the Cache Playlist screen.

The fix adds logic in the recoverSong() method to check if a song is fully cached in the player cache, and if so, sets the dateDownload timestamp. This ensures that all songs that are cached during playback are properly tracked and appear in the Cache Playlist.

Changes:
- Modified recoverSong() in MusicService.kt to update dateDownload when a song is cached during playback
- Added cache validation check using playerCache.isCached() with the song's content length


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where cached songs weren't properly tracked as downloaded. The app now correctly identifies and marks cached songs with their download status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->