### PR TITLE
perf(playback): faster playback start & relaunch (prewarm, cache-serve, HEAD-skip, UI)

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/App.kt
+++ b/app/src/main/kotlin/com/metrolist/music/App.kt
@@ -92,29 +92,33 @@ class App :
             cachedCoilCacheSize = dataStore.data.map { it[MaxImageCacheSizeKey] ?: 512 }.first()
         }
 
-        // Warm the cipher WebView off the first-play critical path. It needs no session, so kick it
-        // as soon as startup settles (don't gate it behind visitorData — that's the bigger cold
-        // cost). Best-effort; on failure the WebView is created lazily on first play.
-        applicationScope.launch(Dispatchers.IO) {
-            delay(1500)
-            runCatching { CipherDeobfuscator.prewarm() }
-        }
-
-        // Warm the PoToken/BotGuard generator (the ~2-5s cold cost) once a session (visitorData) is
-        // available; gate only this half on it. Best-effort and delayed so it never competes with startup.
-        applicationScope.launch(Dispatchers.IO) {
-            delay(2500)
-            var waitedMs = 0
-            while (YouTube.visitorData == null && waitedMs < 12_000) {
-                delay(500)
-                waitedMs += 500
-            }
-            runCatching { YTPlayerUtils.prewarmPoToken() }
-        }
-
         // تهيئة إعدادات التطبيق عند الإقلاع
         applicationScope.launch {
+            // Apply settings (incl. YouTube.proxy) FIRST: the cipher/PoToken OkHttpClients are built
+            // once and cached, so warming them before the proxy is set would snapshot a null proxy and
+            // bypass a configured proxy for the whole session. Warm-up is launched only after this.
             initializeSettings()
+
+            // Warm the cipher WebView off the first-play critical path. It needs no session, so kick it
+            // as soon as settings settle (don't gate it behind visitorData — that's the bigger cold
+            // cost). Best-effort; on failure the WebView is created lazily on first play.
+            launch(Dispatchers.IO) {
+                delay(1500)
+                runCatching { CipherDeobfuscator.prewarm() }
+            }
+
+            // Warm the PoToken/BotGuard generator (the ~2-5s cold cost) once a session (visitorData) is
+            // available; gate only this half on it. Best-effort and delayed so it never competes with startup.
+            launch(Dispatchers.IO) {
+                delay(2500)
+                var waitedMs = 0
+                while (YouTube.visitorData == null && waitedMs < 12_000) {
+                    delay(500)
+                    waitedMs += 500
+                }
+                runCatching { YTPlayerUtils.prewarmPoToken() }
+            }
+
             observeSettingsChanges()
         }
     }

--- a/app/src/main/kotlin/com/metrolist/music/App.kt
+++ b/app/src/main/kotlin/com/metrolist/music/App.kt
@@ -92,9 +92,16 @@ class App :
             cachedCoilCacheSize = dataStore.data.map { it[MaxImageCacheSizeKey] ?: 512 }.first()
         }
 
-        // Warm the cipher + PoToken/BotGuard WebViews off the first-play critical path so the first
-        // stream resolves fast. Best-effort and delayed so it never competes with app startup; waits
-        // for the session (visitorData) the PoToken warm-up needs. Any failure is harmless.
+        // Warm the cipher WebView off the first-play critical path. It needs no session, so kick it
+        // as soon as startup settles (don't gate it behind visitorData — that's the bigger cold
+        // cost). Best-effort; on failure the WebView is created lazily on first play.
+        applicationScope.launch(Dispatchers.IO) {
+            delay(1500)
+            runCatching { CipherDeobfuscator.prewarm() }
+        }
+
+        // Warm the PoToken/BotGuard generator (the ~2-5s cold cost) once a session (visitorData) is
+        // available; gate only this half on it. Best-effort and delayed so it never competes with startup.
         applicationScope.launch(Dispatchers.IO) {
             delay(2500)
             var waitedMs = 0
@@ -102,7 +109,7 @@ class App :
                 delay(500)
                 waitedMs += 500
             }
-            runCatching { YTPlayerUtils.prewarm() }
+            runCatching { YTPlayerUtils.prewarmPoToken() }
         }
 
         // تهيئة إعدادات التطبيق عند الإقلاع

--- a/app/src/main/kotlin/com/metrolist/music/App.kt
+++ b/app/src/main/kotlin/com/metrolist/music/App.kt
@@ -32,12 +32,14 @@ import com.metrolist.music.di.ApplicationScope
 import com.metrolist.music.extensions.toEnum
 import com.metrolist.music.extensions.toInetSocketAddress
 import com.metrolist.music.utils.CrashHandler
+import com.metrolist.music.utils.YTPlayerUtils
 import com.metrolist.music.utils.cipher.CipherDeobfuscator
 import com.metrolist.music.utils.dataStore
 import com.metrolist.music.utils.reportException
 import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -88,6 +90,19 @@ class App :
         // Pre-read Coil cache size on background to avoid runBlocking in newImageLoader
         applicationScope.launch(Dispatchers.IO) {
             cachedCoilCacheSize = dataStore.data.map { it[MaxImageCacheSizeKey] ?: 512 }.first()
+        }
+
+        // Warm the cipher + PoToken/BotGuard WebViews off the first-play critical path so the first
+        // stream resolves fast. Best-effort and delayed so it never competes with app startup; waits
+        // for the session (visitorData) the PoToken warm-up needs. Any failure is harmless.
+        applicationScope.launch(Dispatchers.IO) {
+            delay(2500)
+            var waitedMs = 0
+            while (YouTube.visitorData == null && waitedMs < 12_000) {
+                delay(500)
+                waitedMs += 500
+            }
+            runCatching { YTPlayerUtils.prewarm() }
         }
 
         // تهيئة إعدادات التطبيق عند الإقلاع

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -3142,7 +3142,10 @@ class MusicService :
 
         // Clear the cached URL
         songUrlCache.remove(mediaId)
-        Timber.tag(TAG).d("Cleared cached URL for $mediaId")
+        // A 403/410 on GET means the (HEAD-unvalidated) WEB_REMIX stream URL was bad — mark it so the
+        // re-resolution falls through to the fallback clients instead of retrying WEB_REMIX.
+        YTPlayerUtils.markWebRemixFailed(mediaId)
+        Timber.tag(TAG).d("Cleared cached URL for $mediaId, marked WEB_REMIX failed")
 
         // Clear decryption caches
         try {

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -1316,12 +1316,12 @@ class MusicService :
                 .setMediaSourceFactory(createMediaSourceFactory())
                 .setRenderersFactory(createRenderersFactory(normalizationProcessor, eqProcessor, silenceProcessor, useAudioTrackPlaybackParams))
                 .setLoadControl(
-                    // ExoPlayer defaults, except start playback once ~750ms is buffered (vs 2500ms)
-                    // so the first audio is audible sooner. Min/max/after-rebuffer stay at defaults
-                    // so buffering/rebuffer stability is unchanged (no stutter regression).
+                    // Start playback once ~750ms is buffered (media3's default is 1000ms) so first
+                    // audio is audible a touch sooner. min/max/after-rebuffer match the media3 1.x
+                    // defaults (50s / 50s / 2000ms) so buffering and post-stall recovery are unchanged.
                     DefaultLoadControl
                         .Builder()
-                        .setBufferDurationsMs(50_000, 50_000, 750, 5_000)
+                        .setBufferDurationsMs(50_000, 50_000, 750, 2_000)
                         .build(),
                 )
                 .setHandleAudioBecomingNoisy(true)

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -61,6 +61,7 @@ import androidx.media3.datasource.cache.CacheDataSource
 import androidx.media3.datasource.cache.CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR
 import androidx.media3.datasource.cache.SimpleCache
 import androidx.media3.datasource.okhttp.OkHttpDataSource
+import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.analytics.AnalyticsListener
@@ -1314,6 +1315,15 @@ class MusicService :
                 .Builder(this)
                 .setMediaSourceFactory(createMediaSourceFactory())
                 .setRenderersFactory(createRenderersFactory(normalizationProcessor, eqProcessor, silenceProcessor, useAudioTrackPlaybackParams))
+                .setLoadControl(
+                    // ExoPlayer defaults, except start playback once ~750ms is buffered (vs 2500ms)
+                    // so the first audio is audible sooner. Min/max/after-rebuffer stay at defaults
+                    // so buffering/rebuffer stability is unchanged (no stutter regression).
+                    DefaultLoadControl
+                        .Builder()
+                        .setBufferDurationsMs(50_000, 50_000, 750, 5_000)
+                        .build(),
+                )
                 .setHandleAudioBecomingNoisy(true)
                 .setWakeMode(C.WAKE_MODE_NETWORK)
                 .setAudioAttributes(

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -3598,12 +3598,14 @@ class MusicService :
                 }
 
                 if (usePlayerCache && playerCache.isCached(mediaId, dataSpec.position, CHUNK_LENGTH)) {
-                    songUrlCache[mediaId]?.takeIf { it.second > System.currentTimeMillis() }?.let { (url, _) ->
-                        scope.launch(Dispatchers.IO) { recoverSong(mediaId) }
-                        return@Factory dataSpec.withUri(url.toUri())
-                    }
-                    Timber.tag(TAG).w("Ghost cache entry for $mediaId, re-fetching")
-                    playerCache.removeResource(mediaId)
+                    // Serve cached audio straight from disk like the download cache — no URL needed,
+                    // no network re-resolve. On a cold relaunch songUrlCache is always empty, and the
+                    // old "ghost" path here deleted valid cached audio and re-downloaded it every
+                    // relaunch (the main reason relaunch was slow vs. playing from cache instantly).
+                    // CacheDataSource serves by key (mediaId); uncached chunks fall through below and
+                    // resolve a URL on demand. FLAG_IGNORE_CACHE_ON_ERROR covers a genuinely bad file.
+                    scope.launch(Dispatchers.IO) { recoverSong(mediaId) }
+                    return@Factory dataSpec
                 }
 
                 songUrlCache[mediaId]?.takeIf { it.second > System.currentTimeMillis() }?.let {

--- a/app/src/main/kotlin/com/metrolist/music/playback/PlayerConnection.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/PlayerConnection.kt
@@ -147,18 +147,22 @@ class PlayerConnection(
         )
 
     val mediaMetadata = MutableStateFlow(player.currentMetadata)
+    // stateIn so the latest DB result is cached and shared: on resume / re-subscription the value
+    // is available immediately instead of re-running the Room query (which delayed now-playing
+    // details, format and like-state on every foreground). Lazily keeps it hot across lifecycle
+    // pauses, matching isPlaying above. StateFlow is still a Flow, so existing collectors are unaffected.
     val currentSong =
         mediaMetadata.flatMapLatest {
             database.song(it?.id)
-        }
+        }.stateIn(scope, SharingStarted.Lazily, null)
     val currentLyrics =
         mediaMetadata.flatMapLatest { mediaMetadata ->
             database.lyrics(mediaMetadata?.id)
-        }
+        }.stateIn(scope, SharingStarted.Lazily, null)
     val currentFormat =
         mediaMetadata.flatMapLatest { mediaMetadata ->
             database.format(mediaMetadata?.id)
-        }
+        }.stateIn(scope, SharingStarted.Lazily, null)
 
     val queueTitle = MutableStateFlow<String?>(null)
     val queueWindows = MutableStateFlow<List<Timeline.Window>>(emptyList())

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/MiniPlayer.kt
@@ -49,6 +49,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableLongState
 import androidx.compose.runtime.Stable
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableLongStateOf
@@ -197,8 +198,8 @@ private fun NewMiniPlayer(
         }
 
     // Player states - only collect what's needed at this level
-    val playbackState by playerConnection.playbackState.collectAsStateWithLifecycle()
-    val mediaMetadata by playerConnection.mediaMetadata.collectAsStateWithLifecycle()
+    val playbackState by playerConnection.playbackState.collectAsState()
+    val mediaMetadata by playerConnection.mediaMetadata.collectAsState()
     val canSkipNext by playerConnection.canSkipNext.collectAsStateWithLifecycle()
     val canSkipPrevious by playerConnection.canSkipPrevious.collectAsStateWithLifecycle()
 
@@ -528,8 +529,8 @@ private fun NewMiniPlayerPlayButton(
     outlineColor: Color,
     listenTogetherManager: ListenTogetherManager?,
 ) {
-    val isPlaying by playerConnection.isPlaying.collectAsStateWithLifecycle()
-    val castIsPlaying by castHandler?.castIsPlaying?.collectAsStateWithLifecycle() ?: remember { mutableStateOf(false) }
+    val isPlaying by playerConnection.isPlaying.collectAsState()
+    val castIsPlaying by castHandler?.castIsPlaying?.collectAsState() ?: remember { mutableStateOf(false) }
     val effectiveIsPlaying = if (isCasting) castIsPlaying else isPlaying
     val isListenTogetherGuest = listenTogetherManager?.let { it.isInRoom && !it.isHost } ?: false
     val isMuted by playerConnection.isMuted.collectAsStateWithLifecycle()
@@ -650,7 +651,7 @@ private fun NewMiniPlayerSongInfo(
     errorColor: Color,
     modifier: Modifier = Modifier,
 ) {
-    val error by LocalPlayerConnection.current?.error?.collectAsStateWithLifecycle() ?: remember { mutableStateOf(null) }
+    val error by LocalPlayerConnection.current?.error?.collectAsState() ?: remember { mutableStateOf(null) }
 
     Column(
         modifier = modifier,
@@ -709,8 +710,8 @@ private fun LegacyMiniPlayer(
     val playerConnection = LocalPlayerConnection.current ?: return
     val pureBlack by rememberPreference(PureBlackMiniPlayerKey, defaultValue = false)
 
-    val playbackState by playerConnection.playbackState.collectAsStateWithLifecycle()
-    val mediaMetadata by playerConnection.mediaMetadata.collectAsStateWithLifecycle()
+    val playbackState by playerConnection.playbackState.collectAsState()
+    val mediaMetadata by playerConnection.mediaMetadata.collectAsState()
     val canSkipNext by playerConnection.canSkipNext.collectAsStateWithLifecycle()
     val canSkipPrevious by playerConnection.canSkipPrevious.collectAsStateWithLifecycle()
 
@@ -919,8 +920,8 @@ private fun LegacyPlayPauseButton(
     playerConnection: PlayerConnection,
     listenTogetherManager: ListenTogetherManager?,
 ) {
-    val isPlaying by playerConnection.isPlaying.collectAsStateWithLifecycle()
-    val castIsPlaying by castHandler?.castIsPlaying?.collectAsStateWithLifecycle() ?: remember { mutableStateOf(false) }
+    val isPlaying by playerConnection.isPlaying.collectAsState()
+    val castIsPlaying by castHandler?.castIsPlaying?.collectAsState() ?: remember { mutableStateOf(false) }
     val effectiveIsPlaying = if (isCasting) castIsPlaying else isPlaying
     val isListenTogetherGuest = listenTogetherManager?.let { it.isInRoom && !it.isHost } ?: false
     val isMuted by playerConnection.isMuted.collectAsStateWithLifecycle()
@@ -962,7 +963,7 @@ private fun LegacyMiniMediaInfo(
     pureBlack: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    val error by LocalPlayerConnection.current?.error?.collectAsStateWithLifecycle() ?: remember { mutableStateOf(null) }
+    val error by LocalPlayerConnection.current?.error?.collectAsState() ?: remember { mutableStateOf(null) }
     val cropAlbumArt by rememberPreference(CropAlbumArtKey, false)
 
     Row(

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
@@ -370,7 +370,12 @@ fun BottomSheetPlayer(
     // time immediately instead of flashing 0:00 until the first poll fires. runCatching guards the
     // player-not-ready race; the poll loop corrects duration if it isn't known yet.
     val positionState = remember { mutableLongStateOf(runCatching { playerConnection.player.currentPosition }.getOrDefault(0L)) }
-    val durationState = remember { mutableLongStateOf(runCatching { playerConnection.player.duration }.getOrDefault(0L).coerceAtLeast(0L)) }
+    val durationState = remember {
+        mutableLongStateOf(
+            (mediaMetadata?.duration?.takeIf { it > 0 }?.toLong()?.times(1000L))
+                ?: runCatching { playerConnection.player.duration }.getOrDefault(0L).coerceAtLeast(0L),
+        )
+    }
 
     // Convenience accessors for local use
     var position by positionState
@@ -746,7 +751,8 @@ fun BottomSheetPlayer(
                 delay(100) // Update more frequently for smoother progress bar
                 if (sliderPosition == null) { // Only update if user isn't dragging
                     position = playerConnection.player.currentPosition
-                    duration = playerConnection.player.duration
+                    // Don't clobber a valid (metadata-derived) duration with 0/UNSET mid-resolve.
+                    playerConnection.player.duration.takeIf { it > 0 }?.let { duration = it }
                 }
             }
         }
@@ -756,7 +762,11 @@ fun BottomSheetPlayer(
     LaunchedEffect(playbackState, mediaMetadata?.id) {
         if (!isCasting) {
             position = playerConnection.player.currentPosition
-            duration = playerConnection.player.duration
+            // Prefer the song's known duration (from metadata, available instantly from the restored
+            // queue) so the slider range is right even when restored paused / before the stream
+            // resolves; fall back to the player's duration once it is known.
+            duration = (mediaMetadata?.duration?.takeIf { it > 0 }?.toLong()?.times(1000L))
+                ?: playerConnection.player.duration
         }
     }
 

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
@@ -365,9 +365,12 @@ fun BottomSheetPlayer(
     val effectiveIsPlaying = if (isCasting) castIsPlaying else isPlaying
 
     // Use State objects for position/duration to pass to MiniPlayer without causing recomposition
-    // These states persist across playback state changes to ensure continuous progress updates
-    val positionState = remember { mutableLongStateOf(0L) }
-    val durationState = remember { mutableLongStateOf(0L) }
+    // These states persist across playback state changes to ensure continuous progress updates.
+    // Seed from the player's current values so re-entering composition on resume shows the real
+    // time immediately instead of flashing 0:00 until the first poll fires. runCatching guards the
+    // player-not-ready race; the poll loop corrects duration if it isn't known yet.
+    val positionState = remember { mutableLongStateOf(runCatching { playerConnection.player.currentPosition }.getOrDefault(0L)) }
+    val durationState = remember { mutableLongStateOf(runCatching { playerConnection.player.duration }.getOrDefault(0L).coerceAtLeast(0L)) }
 
     // Convenience accessors for local use
     var position by positionState

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
@@ -74,6 +74,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableLongStateOf
@@ -257,7 +258,7 @@ fun BottomSheetPlayer(
             }
         }
 
-    val isPlaying by playerConnection.isPlaying.collectAsStateWithLifecycle()
+    val isPlaying by playerConnection.isPlaying.collectAsState()
     val isKeepScreenOn by rememberPreference(KeepScreenOn, false)
     val keepScreenOn = isPlaying && isKeepScreenOn
 
@@ -316,8 +317,8 @@ fun BottomSheetPlayer(
             useDarkTheme && pureBlack
         }
 
-    val playbackState by playerConnection.playbackState.collectAsStateWithLifecycle()
-    val mediaMetadata by playerConnection.mediaMetadata.collectAsStateWithLifecycle()
+    val playbackState by playerConnection.playbackState.collectAsState()
+    val mediaMetadata by playerConnection.mediaMetadata.collectAsState()
     val currentSong by playerConnection.currentSong.collectAsStateWithLifecycle(initialValue = null)
     val automix by playerConnection.service.automixItems.collectAsStateWithLifecycle()
     val repeatMode by playerConnection.repeatMode.collectAsStateWithLifecycle()
@@ -345,7 +346,7 @@ fun BottomSheetPlayer(
     val isCasting by castHandler?.isCasting?.collectAsStateWithLifecycle() ?: remember { mutableStateOf(false) }
     val castPosition by castHandler?.castPosition?.collectAsStateWithLifecycle() ?: remember { mutableLongStateOf(0L) }
     val castDuration by castHandler?.castDuration?.collectAsStateWithLifecycle() ?: remember { mutableLongStateOf(0L) }
-    val castIsPlaying by castHandler?.castIsPlaying?.collectAsStateWithLifecycle() ?: remember { mutableStateOf(false) }
+    val castIsPlaying by castHandler?.castIsPlaying?.collectAsState() ?: remember { mutableStateOf(false) }
 
     val focusRequester = remember { FocusRequester() }
 

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Thumbnail.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Thumbnail.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
@@ -207,8 +208,8 @@ fun Thumbnail(
     val layoutDirection = LocalLayoutDirection.current
 
     // Collect states
-    val mediaMetadata by playerConnection.mediaMetadata.collectAsStateWithLifecycle()
-    val error by playerConnection.error.collectAsStateWithLifecycle()
+    val mediaMetadata by playerConnection.mediaMetadata.collectAsState()
+    val error by playerConnection.error.collectAsState()
     val queueTitle by playerConnection.queueTitle.collectAsStateWithLifecycle()
     val canSkipPrevious by playerConnection.canSkipPrevious.collectAsStateWithLifecycle()
     val canSkipNext by playerConnection.canSkipNext.collectAsStateWithLifecycle()

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -49,6 +49,16 @@ object YTPlayerUtils {
 
     private val poTokenGenerator = PoTokenGenerator()
 
+    // Track videoIds whose WEB_REMIX stream URL 403'd on the ExoPlayer GET, so the next resolution
+    // falls through to the fallback clients instead of skipping HEAD validation and looping.
+    private val webRemixFailedIds = java.util.Collections.newSetFromMap(
+        java.util.concurrent.ConcurrentHashMap<String, Boolean>(),
+    )
+
+    fun markWebRemixFailed(videoId: String) {
+        webRemixFailedIds.add(videoId)
+    }
+
     private val MAIN_CLIENT: YouTubeClient = WEB_REMIX
 
     // VISIONOS first (its CDN URL has no spc throttle gate, so it streams whole songs with no
@@ -412,6 +422,19 @@ object YTPlayerUtils {
                     Timber.tag(logTag).d("Using last fallback client without validation: ${STREAM_FALLBACK_CLIENTS[clientIndex].clientName}")
                     Timber.tag(TAG)
                         .i("Playback: client=${currentClient.clientName}, videoId=$videoId")
+                    successClient = currentClient.clientName
+                    break
+                }
+
+                // WEB_REMIX authenticated CDN URLs can 403 on HEAD yet serve fine on the byte-range
+                // GET that ExoPlayer makes. Skip HEAD validation for the main client and let ExoPlayer
+                // try directly, UNLESS this videoId already 403'd on GET (markWebRemixFailed) — then
+                // fall through to the fallback clients. Saves a validateStatus round-trip per resolve.
+                if (clientIndex == -1 && currentClient.clientName == "WEB_REMIX" &&
+                    !webRemixFailedIds.contains(videoId)
+                ) {
+                    Timber.tag(logTag).d("WEB_REMIX — skipping HEAD validation, letting ExoPlayer try directly")
+                    Timber.tag(TAG).i("Playback: client=${currentClient.clientName}, videoId=$videoId")
                     successClient = currentClient.clientName
                     break
                 }

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -34,6 +34,8 @@ import com.metrolist.music.utils.cipher.FunctionNameExtractor
 import com.metrolist.music.utils.cipher.PlayerJsFetcher
 import com.metrolist.music.utils.potoken.PoTokenGenerator
 import com.metrolist.music.utils.potoken.PoTokenResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import timber.log.Timber
 
@@ -71,6 +73,29 @@ object YTPlayerUtils {
     /** Client names disabled by the user in Settings → Stream sources. Updated reactively by MusicService. */
     @Volatile
     var disabledStreamClients: Set<String> = emptySet()
+
+    // A stable video id used only to warm the local BotGuard token generator; the token is
+    // discarded. PoToken generation is a local WebView computation (no YouTube /player call), so
+    // this triggers no network request to YouTube for the video itself.
+    private const val POTOKEN_WARMUP_VIDEO_ID = "jNQXAC9IVRw"
+
+    /**
+     * Best-effort warm-up of the cipher WebView and the PoToken/BotGuard generator so the first real
+     * playback doesn't pay their cold-start cost (BotGuard is ~2–5s cold). Safe to call any time;
+     * every failure is swallowed and playback falls back to the existing lazy-init path unchanged.
+     */
+    suspend fun prewarm() {
+        runCatching { CipherDeobfuscator.prewarm() }
+            .onFailure { Timber.tag(TAG).w(it, "Cipher prewarm skipped: ${it.message}") }
+        val sessionId = YouTube.visitorData
+        if (MAIN_CLIENT.useWebPoTokens && sessionId != null) {
+            runCatching {
+                withContext(Dispatchers.IO) {
+                    poTokenGenerator.getWebClientPoToken(POTOKEN_WARMUP_VIDEO_ID, sessionId)
+                }
+            }.onFailure { Timber.tag(TAG).w(it, "PoToken prewarm skipped: ${it.message}") }
+        }
+    }
 
     data class PlaybackData(
         val audioConfig: PlayerResponse.PlayerConfig.AudioConfig?,

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -80,21 +80,19 @@ object YTPlayerUtils {
     private const val POTOKEN_WARMUP_VIDEO_ID = "jNQXAC9IVRw"
 
     /**
-     * Best-effort warm-up of the cipher WebView and the PoToken/BotGuard generator so the first real
-     * playback doesn't pay their cold-start cost (BotGuard is ~2–5s cold). Safe to call any time;
-     * every failure is swallowed and playback falls back to the existing lazy-init path unchanged.
+     * Best-effort warm-up of the PoToken/BotGuard generator (BotGuard cold-start is ~2–5s) so the
+     * first real playback skips it. Requires a session (visitorData); the caller should gate this on
+     * visitorData being ready. The cipher WebView warm-up is separate (CipherDeobfuscator.prewarm)
+     * since it needs no session. Failure is swallowed; playback falls back to lazy init unchanged.
      */
-    suspend fun prewarm() {
-        runCatching { CipherDeobfuscator.prewarm() }
-            .onFailure { Timber.tag(TAG).w(it, "Cipher prewarm skipped: ${it.message}") }
-        val sessionId = YouTube.visitorData
-        if (MAIN_CLIENT.useWebPoTokens && sessionId != null) {
-            runCatching {
-                withContext(Dispatchers.IO) {
-                    poTokenGenerator.getWebClientPoToken(POTOKEN_WARMUP_VIDEO_ID, sessionId)
-                }
-            }.onFailure { Timber.tag(TAG).w(it, "PoToken prewarm skipped: ${it.message}") }
-        }
+    suspend fun prewarmPoToken() {
+        val sessionId = YouTube.visitorData ?: return
+        if (!MAIN_CLIENT.useWebPoTokens) return
+        runCatching {
+            withContext(Dispatchers.IO) {
+                poTokenGenerator.getWebClientPoToken(POTOKEN_WARMUP_VIDEO_ID, sessionId)
+            }
+        }.onFailure { Timber.tag(TAG).w(it, "PoToken prewarm skipped: ${it.message}") }
     }
 
     data class PlaybackData(

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherDeobfuscator.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherDeobfuscator.kt
@@ -72,6 +72,18 @@ object CipherDeobfuscator {
     }
 
     /**
+     * Best-effort: create the cipher WebView (fetch player JS + load it) ahead of first playback so
+     * the deobfuscation hot path is already warm. Guarded by the same mutex as deobfuscation, so it
+     * can't race a real request; on failure the WebView is simply created lazily on first use.
+     */
+    suspend fun prewarm() {
+        Timber.tag(TAG).d("Prewarming cipher WebView...")
+        deobfuscateMutex.withLock {
+            getOrCreateWebView(forceRefresh = false)
+        }
+    }
+
+    /**
      * Deobfuscate a signatureCipher stream URL.
      *
      * The signatureCipher is a query string containing:

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherDeobfuscator.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherDeobfuscator.kt
@@ -73,14 +73,18 @@ object CipherDeobfuscator {
 
     /**
      * Best-effort: create the cipher WebView (fetch player JS + load it) ahead of first playback so
-     * the deobfuscation hot path is already warm. Guarded by the same mutex as deobfuscation, so it
-     * can't race a real request; on failure the WebView is simply created lazily on first use.
+     * the deobfuscation hot path is already warm. Deliberately lock-free — it never holds
+     * deobfuscateMutex across the player-JS fetch, so it can't block a real deobfuscation request;
+     * it only warms when no WebView exists yet. On failure the WebView is created lazily on first use.
+     *
+     * NOTE: the n-transform path (transformNParamInUrl) is also not under deobfuscateMutex, so cipher
+     * WebView creation has a pre-existing race. Closing that (serialising all getOrCreateWebView
+     * calls) is a separate hot-path change that should go through manual cipher testing.
      */
     suspend fun prewarm() {
+        if (cipherWebView != null) return
         Timber.tag(TAG).d("Prewarming cipher WebView...")
-        deobfuscateMutex.withLock {
-            getOrCreateWebView(forceRefresh = false)
-        }
+        getOrCreateWebView(forceRefresh = false)
     }
 
     /**

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherDeobfuscator.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherDeobfuscator.kt
@@ -73,18 +73,15 @@ object CipherDeobfuscator {
 
     /**
      * Best-effort: create the cipher WebView (fetch player JS + load it) ahead of first playback so
-     * the deobfuscation hot path is already warm. Deliberately lock-free — it never holds
-     * deobfuscateMutex across the player-JS fetch, so it can't block a real deobfuscation request;
-     * it only warms when no WebView exists yet. On failure the WebView is created lazily on first use.
-     *
-     * NOTE: the n-transform path (transformNParamInUrl) is also not under deobfuscateMutex, so cipher
-     * WebView creation has a pre-existing race. Closing that (serialising all getOrCreateWebView
-     * calls) is a separate hot-path change that should go through manual cipher testing.
+     * the deobfuscation hot path is already warm. Holds the same mutex as deobfuscateStreamUrl /
+     * transformNParamInUrl so it can't race a real request for the shared single-WebView state. On
+     * failure the WebView is simply created lazily on first use.
      */
     suspend fun prewarm() {
-        if (cipherWebView != null) return
         Timber.tag(TAG).d("Prewarming cipher WebView...")
-        getOrCreateWebView(forceRefresh = false)
+        deobfuscateMutex.withLock {
+            getOrCreateWebView(forceRefresh = false)
+        }
     }
 
     /**
@@ -167,12 +164,15 @@ object CipherDeobfuscator {
      * IMPORTANT: This must be called for WEB_REMIX, WEB, WEB_CREATOR, TVHTML5 clients
      * and for privately owned tracks (uploaded songs).
      */
-    suspend fun transformNParamInUrl(url: String): String {
+    suspend fun transformNParamInUrl(url: String): String = deobfuscateMutex.withLock {
+        // Hold the same mutex as deobfuscateStreamUrl/prewarm: the shared CipherWebView has
+        // single-shot continuation slots, so sig deciphering, n-transform, and warm-up must never
+        // touch it concurrently (concurrent calls would clobber each other's WebView state).
         Timber.tag(TAG).d("=== N-TRANSFORM URL ===")
         Timber.tag(TAG).d("Input URL length: ${url.length}")
         Timber.tag(TAG).d("Input URL preview: ${url.take(100)}...")
 
-        return try {
+        try {
             transformNInternal(url)
         } catch (e: CancellationException) {
             throw e // request superseded/cancelled — propagate rather than masking as a no-op transform


### PR DESCRIPTION
## Summary

Improves time-to-first-audio on app open / relaunch and fixes a few now-playing UI lags. A previously-played track now starts close to instant on relaunch.

### Playback start / relaunch
- **Pre-warm** the cipher WebView and the PoToken/BotGuard generator at startup, off the first-play critical path. The cipher warm-up (no session needed) fires immediately; the PoToken warm-up waits for `visitorData`.
- **LoadControl**: start playback once ~750ms is buffered (media3's default is 1000ms); min/max and after-rebuffer stay at the media3 defaults (no rebuffer regression).
- **Serve player-cached audio from disk on relaunch** instead of deleting it and re-resolving over the network. On a cold relaunch the in-memory stream URL is gone, which previously hit a false "ghost cache entry" path that called `playerCache.removeResource` and forced a full re-download every relaunch.
- **Skip the `validateStatus` HEAD probe for the WEB_REMIX main client** — its authenticated CDN URLs can 403 on HEAD yet serve fine on the byte-range GET, so the HEAD was a wasted round-trip. Tracks `webRemixFailedIds` and falls through to the fallback clients if a video 403s on the actual GET.

### Cipher concurrency
- Run the n-parameter transform and the warm-up under the same mutex as signature deobfuscation, so the single shared `CipherWebView` is never accessed concurrently.

### Now-playing UI
- Collect player-status flows (`isPlaying`, `playbackState`, `mediaMetadata`, `error`) with `collectAsState` so the controls/metadata don't repaint stale player state for a moment on resume.
- `stateIn` the per-song DB flows (`currentSong`/`currentFormat`/`currentLyrics`) so details, format and like-state are cached across a resume instead of re-querying.
- Seed the progress position/duration from the player and the song metadata so the time label and trackbar show the real position immediately on relaunch instead of flashing `0:00`.

Built (`assembleFossDebug`) and tested on-device.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Pre-warm cipher and PoToken/BotGuard components during startup for faster first playback.
  * Tune playback buffering for smoother streaming.
  * Improve playback caching to serve cached audio directly from disk and avoid unnecessary resolution work.
  * Reduce repeated metadata database queries by caching player-derived state.
* **Bug Fixes**
  * Prevent repeated WEB_REMIX retries by marking failing videos and forcing fallback resolution.
  * Fix playback duration/progress handling to avoid zero or incorrect duration during transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->