### PR TITLE
fix: remove duplicate discord strings from all locale strings.xml files

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -230,7 +230,6 @@
     <string name="imported_playlist">قائمة أغاني مستوردة</string>
     <string name="hide_explicit">اخفي المحتوى الصريح</string>
     <string name="backup_create_failed">تعذر إنشاء نسخة احتياطية</string>
-    <string name="discord_integration">التكامل مع Discord</string>
     <string name="add_all_to_library">ضف الكل إلى المكتبة</string>
     <string name="action_download">تنزيل</string>
     <string name="remove_all_from_library">امسح الكل من المكتبة</string>
@@ -303,7 +302,6 @@
     <string name="preview">معاينة</string>
     <string name="discord_information">Metrolist يستخدم مكتبة KizzyRPC لتعيين حالة حساب Discord الخاص بك. هذا يتضمن استخدام اتصال Discord Gateway، والذي قد يعتبر انتهاكًا لشروط خدمة Discord. مع ذلك، لا توجد حالات معروفة لتعطيل حسابات المستخدمين لهذا السبب. استخدم على مسؤوليتك الخاصة. \n \nسيقوم Metrolist فقط باستخراج رمز الوصول الخاص بك، وسيتم تخزين كل شيء آخر محليًا.</string>
     <string name="dismiss">صرف</string>
-    <string name="enable_discord_rpc">فعل Rich Presence</string>
     <string name="new_version_available">نسخة جديدة متوفرة</string>
     <string name="login_failed">فشل تسجيل الدخول</string>
     <string name="about">حول</string>

--- a/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -219,11 +219,9 @@
     <string name="backup_create_success">Rezervna kopija je uspešno sagrađena</string>
     <string name="backup_create_failed">Nije moguće napraviti rezervnu kopiju</string>
     <string name="restore_failed">Neuspešno vraćanje rezervne kopije</string>
-    <string name="discord_integration">Discord integracija</string>
     <string name="discord_information">Metrolist koristi KizzyRPC biblioteku kako bi stavio tvoj Discord status. Ovo uključuje korištenje Discord Gateway spajanja, što bi se moglo smatrati prekršajem Discord-ovog TOS-a. Međutim nema poznatih slučajeva gde su korisnički nalozi bili suspendovani zbog ovog razloga. Korisite na svoj rizik.\n\nMetrolist će samo izvesti tvoj žeton, i sve drugo je sklađeno lokalno.</string>
     <string name="dismiss">Odbaci</string>
     <string name="options">Opcije</string>
-    <string name="enable_discord_rpc">Omogući Bogatu Prisutnost</string>
     <string name="about">O Metrolist-u</string>
     <string name="app_version">Verzija aplikacije</string>
     <string name="new_version_available">Dostupna je nova verzija</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -269,12 +269,10 @@
     <string name="hide_explicit">Скрий нецензурно съдържание</string>
     <string name="backup_create_success">Архивирането е създадено успешно</string>
     <string name="restore_failed">Неуспешно възстановяване на резервно копие</string>
-    <string name="discord_integration">Discord интеграция</string>
     <string name="dismiss">Отхвърли</string>
     <string name="options">Опции</string>
     <string name="preview">Преглед</string>
     <string name="action_logout">Изход</string>
-    <string name="enable_discord_rpc">Активирай Rich Presence</string>
     <string name="new_version_available">Налична е нова версия</string>
     <string name="use_login_for_browse">Използвай вход за разглеждане на съдържание</string>
     <string name="use_login_for_browse_desc">Това може да повлияе какво съдържание виждате и например показва само премиум албуми, ако сте влезли с Премиум профил</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -273,10 +273,8 @@
     <string name="disable_screenshot_desc">যখন এই বিকল্পটি চালু থাকে, তখন স্ক্রিনশট এবং রিসেন্টস-এ অ্যাপের ভিউ নিষ্ক্রিয় থাকে।</string>
     <string name="enable_lrclib">LrcLib গানের লিরিক্স প্রদানকারী সক্রিয় করুন</string>
     <string name="hide_explicit">স্পষ্ট বিষয়বস্তু লুকান</string>
-    <string name="discord_integration">ডিসকর্ড ইন্টিগ্রেশন</string>
     <string name="discord_information">Metrolist আপনার Discord অ্যাকাউন্টের স্ট্যাটাস সেট করার জন্য KizzyRPC লাইব্রেরি ব্যবহার করে। এর মধ্যে Discord Gateway সংযোগ ব্যবহার করা হয়, যা Discord-এর পরিষেবার শর্তাবলীর (TOS) লঙ্ঘন হিসেবে বিবেচিত হতে পারে। তবে, এই কারণে ব্যবহারকারীর অ্যাকাউন্ট সাসপেন্ড হওয়ার কোনো পরিচিত ঘটনা নেই। ব্যবহার আপনার নিজের ঝুঁকিতে করুন।\n\nMetrolist শুধুমাত্র আপনার টোকেন সংগ্রহ করবে, এবং বাকী সবকিছু স্থানীয়ভাবে সংরক্ষিত থাকবে।</string>
     <string name="dismiss">বাতিল করুন</string>
     <string name="options">বিকল্পসমূহ</string>
     <string name="preview">প্রিভিউ</string>
-    <string name="enable_discord_rpc">রিচ প্রেজেন্স সক্ষম করুন</string>
 </resources>

--- a/app/src/main/res/values-bs/strings.xml
+++ b/app/src/main/res/values-bs/strings.xml
@@ -79,7 +79,6 @@
     <string name="backup_create_success">Rezervna kopija je uspješno sagrađena</string>
     <string name="backup_create_failed">Nije moguće napraviti rezervnu kopiju</string>
     <string name="restore_failed">Neuspješan povratak rezervne kopije</string>
-    <string name="discord_integration">Integracija sa Discord-om</string>
     <string name="dismiss">Odbaci</string>
     <string name="home">Početna</string>
     <string name="undo">Vrati</string>
@@ -278,7 +277,6 @@
     <string name="login_failed">Neuspješno upisivanje</string>
     <string name="options">Opcije</string>
     <string name="preview">Pregled</string>
-    <string name="enable_discord_rpc">Omogući Bogatu Prisutnost</string>
     <string name="app_version">Verzija aplikacije</string>
     <string name="action_logout">Izpiši se</string>
     <string name="about">O Metrolist-u</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -216,7 +216,6 @@
     <string name="imported_playlist">Llista importada</string>
     <string name="hide_explicit">Amaga el contingut explícit</string>
     <string name="backup_restore">Còpia de seguretat i restauració</string>
-    <string name="discord_integration">Integració amb el Discord</string>
     <string name="options">Opcions</string>
     <string name="backup_create_failed">No s’ha pogut crear la còpia de seguretat</string>
     <string name="restore_failed">No s’ha pogut restaurar la còpia de seguretat</string>
@@ -285,7 +284,6 @@
     <string name="disable_screenshot_desc">Quan aquesta opció és activada, les captures de pantalla i la visualització a \"recents\" són desactivades.</string>
     <string name="discord_information">Metrolist utilitza la biblioteca KizzyRPC per establir l\'estat del vostre compte de Discord. Això implica utilitzar la connexió Discord Gateway, la qual cosa es pot considerar una violació de les condicions del servei de Discord. No obstant això, no hi ha casos coneguts d\'usuaris que hagin estat suspesos pel motiu. L\'ús és sota la vostra responsabilitat.\n\nMetrolist només extreu el vostre \"token\", i la resta es desa localment.</string>
     <string name="dismiss">Ignora</string>
-    <string name="enable_discord_rpc">Activa \"Rich Presence\"</string>
     <string name="error_no_stream">Cap transmissió disponible</string>
     <string name="sided">Amb vores</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -230,7 +230,6 @@
     <string name="translation_models">Modely překladů</string>
     <string name="clear_translation_models">Vymazat modely překladů</string>
     <string name="remove_from_playlist">Odstranit z playlistu</string>
-    <string name="discord_integration">Integrace Discordu</string>
     <string name="squiggly">Klikatá</string>
     <string name="duplicates_description_single">Skladba se již nachází ve vašem playlistu</string>
     <string name="keep_listening">Poslouchejte dál</string>
@@ -283,7 +282,6 @@
     <string name="theme">Motiv</string>
     <string name="player_text_alignment">Zarovnání textu přehrávače</string>
     <string name="discord_information">Metrolist používá knihovnu KizzyRPC, aby mohl nastavit váš stav na Discordu. Tato funkce zahrnuje připojení k bráně Discord, což může být považováno za porušení podmínek společnosti Discord. Neexistují nicméně žádné známé případy uzamčení účtu z tohoto důvodu. Používejte na vlastní nebezpečí. \n \nMetrolist pouze extrahuje váš token, vše ostatní je uloženo lokálně.</string>
-    <string name="enable_discord_rpc">Povolit stav na Discordu</string>
     <string name="action_logout">Odhlásit se</string>
     <string name="use_login_for_browse">Použít účet pro procházení obsahu</string>
     <string name="use_login_for_browse_desc">Může ovlivnit obsah, který se vám zobrazí – při přihlášení například mohou být zobrazena například alba, která jsou dostupná pouze s Premium účtem</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -243,7 +243,6 @@
     <string name="add_anyway">Trotzdem hinzufügen</string>
     <string name="player_slider_style">Stil des Player-Schiebereglers</string>
     <string name="duplicates_description_multiple">%d Songs sind bereits in deiner Playlist</string>
-    <string name="enable_discord_rpc">Statusanzeige aktivieren</string>
     <string name="auto_skip_next_on_error_desc">Sorge für ein kontinuierliches Wiedergabeerlebnis</string>
     <string name="dismiss">Ablehnen</string>
     <string name="player_text_alignment">Ausrichtung des Player-textes</string>
@@ -266,7 +265,6 @@
     <string name="search_history">Suchverlauf</string>
     <string name="enable_lrclib">LrcLib-Songtext-Anbieter aktivieren</string>
     <string name="hide_explicit">Explizite Inhalte ausblenden</string>
-    <string name="discord_integration">Discord-Integration</string>
     <string name="library_song_empty">Songs aus der Bibliothek werden hier angezeigt</string>
     <string name="remove_download_playlist_confirm">Möchtest du wirklich alle Songs der Playlist „%s“ aus dem Speicher für heruntergeladene Songs entfernen?</string>
     <string name="delete_playlist_confirm">Möchtest du die Playlist „%s“ wirklich löschen?</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -253,14 +253,12 @@
     <string name="backup_create_success">Δημιουργία αντιγράφου ασφ. με επιτυχία</string>
     <string name="backup_create_failed">Αδυναμία δημιουργίας αντιγράφων ασφαλείας</string>
     <string name="restore_failed">Αποτυχία επαναφοράς αντιγράφου ασφαλείας</string>
-    <string name="discord_integration">Ενσωμάτωση Discord</string>
     <string name="discord_information">Το Metrolist χρησιμοποιεί τη βιβλιοθήκη KizzyRPC για να ρυθμίσει την κατάσταση του λογαριασμού σας στο Discord. Αυτό περιλαμβάνει τη χρήση της σύνδεσης Discord Gateway, η οποία μπορεί να θεωρηθεί παραβίαση των TOS του Discord. Ωστόσο, δεν υπάρχουν γνωστές περιπτώσεις αναστολής λογαριασμών χρηστών για αυτόν τον λόγο. Η χρήση γίνεται με δική σας ευθύνη.\n\nΤο Metrolist θα εξάγει μόνο το token σας και όλα τα υπόλοιπα αποθηκεύονται τοπικά.</string>
     <string name="dismiss">Απόρριψη</string>
     <string name="options">Επιλογές</string>
     <string name="preview">Προεπισκόπηση</string>
     <string name="login_failed">Η σύνδεση απέτυχε</string>
     <string name="action_logout">Αποσύνδεση</string>
-    <string name="enable_discord_rpc">Ενεργοποίηση Πλούσιας Παρουσίας</string>
     <string name="about">Σχετικά</string>
     <string name="app_version">Έκδοση εφαρμογής</string>
     <string name="new_version_available">Νέα διαθέσιμη έκδοση</string>

--- a/app/src/main/res/values-es-rUS/strings.xml
+++ b/app/src/main/res/values-es-rUS/strings.xml
@@ -275,12 +275,10 @@
     <string name="backup_create_success">Copia de seguridad creada correctamente</string>
     <string name="backup_create_failed">No se pudo crear la copia de seguridad</string>
     <string name="restore_failed">No se pudo restaurar la copia de seguridad</string>
-    <string name="discord_integration">Integración con Discord</string>
     <string name="discord_information">Metrolist utiliza la biblioteca KizzyRPC para configurar el estado de tu cuenta de Discord. Esto implica el uso de la conexión Discord Gateway, lo que puede considerarse una violación de los Términos de servicio de Discord. Sin embargo, no se conocen casos de cuentas de usuario suspendidas por este motivo. Úsalo bajo tu propia responsabilidad.\n\nMetrolist solo extraerá tu token, y todo lo demás se almacena localmente.</string>
     <string name="dismiss">Desestimar</string>
     <string name="options">Opciones</string>
     <string name="preview">Vista previa</string>
-    <string name="enable_discord_rpc">Activar Presencia Enriquecida</string>
     <string name="about">Sobre</string>
     <string name="app_version">Versión de la aplicación</string>
     <string name="new_version_available">Nueva versión disponible</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -262,14 +262,12 @@
     <string name="backup_create_success">Copia de seguridad creada con éxito</string>
     <string name="backup_create_failed">No se ha podido crear la copia de seguridad</string>
     <string name="restore_failed">Error al restaurar la copia de seguridad</string>
-    <string name="discord_integration">Integración con Discord</string>
     <string name="discord_information">Metrolist utiliza la biblioteca KizzyRPC para establecer el estado de su cuenta de Discord. Esto implica el uso de la conexión Discord Gateway, lo que podría considerarse una violación de las condiciones del servicio de Discord. Sin embargo, no se conocen casos de cuentas de usuario suspendidas por este motivo. Úselo bajo su propio riesgo.\n\nMetrolist solo extraerá su ficha; todo lo demás se almacena localmente.</string>
     <string name="dismiss">Descartar</string>
     <string name="options">Opciones</string>
     <string name="preview">Vista previa</string>
     <string name="login_failed">Error al acceder a la cuenta</string>
     <string name="action_logout">Finalizar sesión</string>
-    <string name="enable_discord_rpc">Activar Rich Presence</string>
     <string name="about">Acerca de</string>
     <string name="app_version">Versión de la app</string>
     <string name="new_version_available">Nueva versión disponible</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -193,7 +193,6 @@
     <string name="enable_lrclib">Kasuta laulusõnade kuvamiseks teenusepakkujat LrcLib</string>
     <string name="dismiss">Loobu</string>
     <string name="preview">Eelvaade</string>
-    <string name="enable_discord_rpc">Näita oma tegevust Metrolist rakenduses Discordi olekuteatena</string>
     <string name="sort_by_create_date">Lisamise kuupäev</string>
     <string name="sort_by_name">Nime alusel</string>
     <string name="sort_by_artist">Esitaja järgi</string>
@@ -271,7 +270,6 @@
     <string name="backup_create_success">Varukoopia tegemine õnnestus</string>
     <string name="backup_create_failed">Varukoopia tegemine ei õnnestunud</string>
     <string name="restore_failed">Varukoopiast taastamine ei õnnestunud</string>
-    <string name="discord_integration">Lõiming Discordiga</string>
     <string name="discord_information">Metrolist kasutab Discordi kasutajakonto oleku kuvamiseks KizzyRPC teeki. See eeldab Discord Gateway ühenduse kasutamist ja seda loetakse Discordi kasutustingimuste rikkumiseks. Aga pole teada ühtegi juhust, kus kasutajakonto oleks sel põhjusel keelatud. Kasuta seda teenust omal vastutsusel.\n\nMetrolist kasutab ainult sinu tunnusluba, kõike muud hoitakse kohalikus seadmes.</string>
     <string name="options">Valikud</string>
     <string name="action_logout">Logi välja</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -186,7 +186,6 @@
     <string name="listen_history">Kuunteluhistoria</string>
     <string name="skip_duplicates">Ohita kaksoiskappaleet</string>
     <string name="disable_screenshot">Poista kuvakaappaukset käytöstä</string>
-    <string name="discord_integration">Discord-integraatio</string>
     <string name="big">Suuri</string>
     <string name="library_artist_empty">Kirjaston artistit näkyvät täällä</string>
     <string name="keep_listening">Jatka kuuntelemista</string>
@@ -219,7 +218,6 @@
     <string name="preview">Esikatselu</string>
     <string name="login_failed">Kirjautuminen epäonnistui</string>
     <string name="action_logout">Kirjaudu ulos</string>
-    <string name="enable_discord_rpc">Tämä on Discord-integraatio-ominaisuus, se tarkoittaa Metrolist-toiminnan näyttämistä Discord-tililläsi</string>
     <string name="forgotten_favorites">Unohtuneet suosikit</string>
     <string name="sample_rate">Näytteenottonopeus</string>
     <string name="queue_searched_songs">Haetut laulut</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -264,12 +264,10 @@
     <string name="backup_create_success">Matagumpay na nilikha ang backup</string>
     <string name="backup_create_failed">Hindi makagawa ng backup</string>
     <string name="restore_failed">Nabigong ibalik ang backup</string>
-    <string name="discord_integration">Pagsasama ng Discord</string>
     <string name="discord_information">Ginagamit ng Metrolist ang aklatan ng KizzyRPC para itakda ang kapalaran ng iyong Discord account. Kabilang dito ang paggamit ng koneksyon sa Discord Gateway, na maaaring ituring na isang paglabag sa TOS ng Discord. Gayunpaman, walang mga kilalang kaso ng mga user account na sinuspinde para sa kadahilanang ito. Gamitin sa iyong sariling peligro.\n\nKukunin lang ng Metrolist ang iyong token, at lahat ng iba pa ay lokal na iniimbak.</string>
     <string name="dismiss">Balewalain</string>
     <string name="options">Mga Opsyon</string>
     <string name="preview">Pasilip</string>
-    <string name="enable_discord_rpc">Paganahin ang Rich Presence</string>
     <string name="about">Tungkol sa</string>
     <string name="app_version">Bersyon ng aplikasyon</string>
     <string name="new_version_available">Magagamit ang bagong bersyon</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -240,12 +240,10 @@
     <string name="sided">Sur le côté</string>
     <string name="enable_lrclib">Activer le fournisseur de paroles LrcLib</string>
     <string name="hide_explicit">Masquer le contenu explicite</string>
-    <string name="discord_integration">Intégration Discord</string>
     <string name="dismiss">Abandonner</string>
     <string name="options">Options</string>
     <string name="preview">Prévisualisation</string>
     <string name="action_logout">Se déconnecter</string>
-    <string name="enable_discord_rpc">Activer la présence riche</string>
     <string name="login_failed">Échec de la connexion</string>
     <string name="delete_playlist_confirm">Voulez-vous vraiment supprimer la playlist « %s » ?</string>
     <string name="listen_history">Historique d\'écoute</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -202,10 +202,8 @@
     <string name="backup_create_success">Sigurnosna kopija je uspješno izrađena</string>
     <string name="backup_create_failed">Nije bilo moguće stvoriti sigurnosnu kopiju</string>
     <string name="restore_failed">Neuspjelo obnavljanje sigurnosne kopije</string>
-    <string name="discord_integration">Ugradnja Discord-u</string>
     <string name="dismiss">Odbaci</string>
     <string name="action_logout">Odjavi se</string>
-    <string name="enable_discord_rpc">Uključi prikaz aktivnosti</string>
     <string name="about">Informacije</string>
     <string name="app_version">Verzija aplikacije</string>
     <string name="clear_translation_models">Izbriši modele prevođenja</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -273,10 +273,8 @@
     <string name="disable_screenshot_desc">Ha ez be van kapcsolva, a képernyőkép készítés nem lehetséges, és az előzmények sem látszódnak.</string>
     <string name="enable_lrclib">A LrcLib dalszöveg szolgáltató engedélyezése</string>
     <string name="hide_explicit">Felnőtt tartalom elrejtése</string>
-    <string name="discord_integration">Discord integráció</string>
     <string name="discord_information">Az Metrolist a KizzyRPC könyvtárat használja a Discord fiók státusz beállításhoz. Ez a Discord Gateway kapcsolatot használja, amely tekinthető a Discord felhasználási feltételek megszegésének is tágabb értelemben. Habár a múltban nem történt fiók tiltás emiatt, ettől függetlenül kérem használja saját felelősségre.\n\nAz Metrolist csak a token-jét fogja kinyerni, minden más helyben tárolt.</string>
     <string name="dismiss">Elrejtés</string>
     <string name="options">Opciók</string>
     <string name="preview">Előnézet</string>
-    <string name="enable_discord_rpc">Rich Presence engedélyezése</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -262,11 +262,9 @@
     <string name="disable_screenshot">Nonaktifkan tangkapan layar</string>
     <string name="disable_screenshot_desc">Saat opsi ini aktif, tangkapan layar dan tampilan aplikasi pada daftar Aplikasi Terkini akan dinonaktifkan.</string>
     <string name="enable_lrclib">Aktifkan penyedia lirik LrcLib</string>
-    <string name="discord_integration">Integrasi Discord</string>
     <string name="discord_information">Metrolist menggunakan library KizzyRPC untuk mengatur status akun Discord Anda. Hal ini melibatkan penggunaan koneksi Discord Gateway, yang dapat dianggap sebagai pelanggaran TOS Discord. Namun, tidak ada kasus yang diketahui tentang akun pengguna yang ditangguhkan karena alasan ini. Gunakan dengan risiko Anda sendiri.\n\nMetrolist hanya akan mengekstrak token Anda, dan semua data lainnya disimpan secara lokal.</string>
     <string name="dismiss">Tutup</string>
     <string name="preview">Pratinjau</string>
-    <string name="enable_discord_rpc">Aktifkan Rich Presence</string>
     <string name="use_login_for_browse">Login untuk menjelajahi konten</string>
     <string name="use_login_for_browse_desc">Ini dapat memengaruhi konten yang Anda lihat dan misalnya menampilkan album khusus premium jika Anda login dengan akun Premium</string>
     <string name="action_login">Masuk</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -277,7 +277,6 @@
     <string name="disable_screenshot">Disabilita screenshot</string>
     <string name="disable_screenshot_desc">Quando questa opzione è attiva, gli screenshot e la visualizzazione dell\'app nei Recenti sono disabilitati.</string>
     <string name="hide_explicit">Nascondi contenuti espliciti</string>
-    <string name="discord_integration">Integrazione Discord</string>
     <string name="discord_information">Metrolist usa la libreria KizzyRPC per impostare lo stato del tuo account Discord. Ciò comporta l\'uso della connessione Discord Gateway, che può essere considerata una violazione dei TOS di Discord. Tuttavia, non ci sono casi noti di account utente sospesi per questo motivo. Usalo a tuo rischio e pericolo.\n\nMetrolist estrarrà solo il tuo token e tutto il resto verrà archiviato localmente.</string>
     <string name="options">Opzioni</string>
     <string name="use_login_for_browse">Usa il login per navigare nei contenuti</string>
@@ -285,7 +284,6 @@
     <string name="login_failed">Login fallito</string>
     <string name="action_logout">Esci</string>
     <string name="use_login_for_browse_desc">Ciò può influenzare il contenuto che vedi e ad esempio mostra album solo premium se hai effettuato l\'accesso con un account Premium</string>
-    <string name="enable_discord_rpc">Abilita Rich Presence</string>
     <string name="dismiss">Ignorare</string>
     <string name="action_login">Accedi</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -277,12 +277,10 @@
     <string name="backup_create_success">גיבוי נוצר בהצלחה</string>
     <string name="backup_create_failed">לא ניתן היה ליצור גיבוי</string>
     <string name="restore_failed">שחזור הגיבוי נכשל</string>
-    <string name="discord_integration">שילוב דיסקורד</string>
     <string name="discord_information">Metrolist משתמשת בספריית KizzyRPC כדי לקבוע את סטטוס חשבון הדיסקורד שלך. זה כרוך בשימוש בחיבור Discord Gateway, דבר שעשוי להיחשב כהפרה של תנאי השימוש של Discord. עם זאת, לא ידוע על מקרים של השעיית חשבונות משתמש מסיבה זו. השימוש על אחריותך בלבד.\n\nMetrolist יחלץ רק את הטוקן שלך, וכל השאר מאוחסן באופן מקומי.</string>
     <string name="dismiss">התעלמות</string>
     <string name="options">אפשרויות</string>
     <string name="preview">תצוגה מקדימה</string>
-    <string name="enable_discord_rpc">הפעלת נוכחות עשירה</string>
     <string name="about">אודות</string>
     <string name="app_version">גירסת אפליקציה</string>
     <string name="new_version_available">גירסה חדשה זמינה</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -254,14 +254,12 @@
     <string name="backup_create_success">バックアップの作成に成功しました</string>
     <string name="backup_create_failed">バックアップを作成できませんでした</string>
     <string name="restore_failed">バックアップの復元に失敗しました</string>
-    <string name="discord_integration">Discordと連携</string>
     <string name="discord_information">Metrolistは、Discordアカウントのステータスを設定するためにKizzyRPCライブラリを使用しています。Discordのゲートウェイ接続を利用するため、Discordの利用規約に違反する可能性があります。ただし、これを理由にユーザーのアカウントが停止された事例は確認されていません。自己責任で使用してください。\n\nMetrolistはトークンのみを取得し、それ以外の情報はすべてデバイス内に保存されます。</string>
     <string name="dismiss">非表示</string>
     <string name="options">オプション</string>
     <string name="preview">プレビュー</string>
     <string name="login_failed">ログインに失敗しました</string>
     <string name="action_logout">ログアウト</string>
-    <string name="enable_discord_rpc">再生状況を共有</string>
     <string name="about">アプリについて</string>
     <string name="app_version">アプリのバージョン</string>
     <string name="new_version_available">アップデートがあります</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -250,7 +250,6 @@
     <string name="hide_explicit">선정적인 내용 숨기기</string>
     <string name="preview">미리보기</string>
     <string name="login_failed">로그인 실패</string>
-    <string name="discord_integration">Discord 통합</string>
     <string name="discord_information">Metrolist은 KizzyRPC 라이브러리를 사용하여 Discord 계정의 상태를 설정합니다. 여기에는 Discord Gateway 연결을 사용하는 것이 포함되며, 이는 Discord의 TOS 위반으로 간주될 수 있습니다. 그러나 이러한 이유로 사용자 계정이 정지된 사례는 알려진 바가 없습니다. 사용에 따른 책임은 본인에게 있습니다. \n \nMetrolist은 토큰만 추출하며 그 밖의 모든 내용은 로컬에 저장됩니다.</string>
     <string name="options">옵션</string>
     <string name="action_logout">로그아웃</string>
@@ -268,6 +267,5 @@
     <string name="similar_to">아래 아티스트와 유사한 음악 추천</string>
     <string name="auto_skip_next_on_error_desc">끊김 없는 재생 경험 보장</string>
     <string name="disable_screenshot_desc">이 설정을 켜면, 스크린샷이 비활성화되고 최근 앱에서 보이는 앱 화면이 숨겨집니다.</string>
-    <string name="enable_discord_rpc">활동 상태 공유</string>
     <string name="action_login">로그인</string>
 </resources>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -274,8 +274,6 @@
     <string name="enable_lrclib">LrcLib വരികൾ ഓൺ ആക്കുക</string>
     <string name="enable_kugou">KuGou വരികൾ ഓൺ ആക്കുക</string>
     <string name="imported_playlist">കൊണ്ടുവന്ന പ്ലേലിസ്റ്റ്</string>
-    <string name="discord_integration">Discord യോജിപ്പിക്കുക</string>
-    <string name="enable_discord_rpc">റിച്ഛ് പ്രെസെൻസ് ഓൺ ആക്കുക</string>
     <string name="new_version_available">പുതിയ വേർഷൻ ലഭ്യമാണ്</string>
     <string name="translation_models">വിവർത്തന പദ്ധതികൾ</string>
     <string name="clear_translation_models">വിവർത്തന പദ്ധതികൾ കളയുക</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -164,11 +164,9 @@
     <string name="enable_lrclib">Slå på LrcLib-sangteksttilbyder</string>
     <string name="enable_kugou">Slå på KuGou-sangteksttilbyder</string>
     <string name="action_backup">Sikkerhetskopier</string>
-    <string name="discord_integration">Discord-integrasjon</string>
     <string name="dismiss">Avvis</string>
     <string name="options">Innstillinger</string>
     <string name="login_failed">Innlogging mislyktes</string>
-    <string name="enable_discord_rpc">Slå på rik tilstedeværelse</string>
     <string name="app_version">Programversjon</string>
     <string name="new_version_available">Ny versjon tilgjengelig</string>
     <string name="translation_models">Oversettingsmodeller</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -269,13 +269,11 @@
     <string name="disable_screenshot">Schermafbeelding uitschakelen</string>
     <string name="disable_screenshot_desc">Als deze optie is ingeschakeld, zijn schermafbeeldingen en de weergave van de app in Recente bestanden uitgeschakeld.</string>
     <string name="hide_explicit">Expliciete inhoud verbergen</string>
-    <string name="discord_integration">Discord integratie</string>
     <string name="discord_information">Metrolist gebruikt de KizzyRPC bibliotheek om de status van je Discord account in te stellen. Dit omvat het gebruik van de Discord Gateway verbinding, die kan worden beschouwd als een schending van de TOS van Discord. Er zijn echter geen gevallen bekend van gebruikersaccounts die om deze reden zijn geschorst. Gebruik op eigen risico.\n\nMetrolist zal alleen uw token uitpakken, en al het andere wordt lokaal opgeslagen.</string>
     <string name="options">Opties</string>
     <string name="preview">Voorbeeld</string>
     <string name="login_failed">Aanmelden mislukt</string>
     <string name="action_logout">Afmelden</string>
-    <string name="enable_discord_rpc">Rijke aanwezigheid inschakelen</string>
     <string name="use_login_for_browse_desc">Dit kan invloed hebben op welke inhoud u ziet en laat bijvoorbeeld alleen premium albums zien als u bent ingelogd met een Premium account</string>
     <string name="use_login_for_browse">Gebruik login om inhoud te bekijken</string>
     <string name="action_login">Inloggen</string>

--- a/app/src/main/res/values-nn/strings.xml
+++ b/app/src/main/res/values-nn/strings.xml
@@ -268,12 +268,10 @@
     <string name="backup_create_success">Trykkleikskopiering oppretta med lukke</string>
     <string name="backup_create_failed">Klarte ikkje å oppretta tryggleikskopiering</string>
     <string name="restore_failed">Klarte ikkje å atteroppretta frå tryggleikskopiering</string>
-    <string name="discord_integration">Hopfletting med Discord</string>
     <string name="discord_information">Metrolist nøyter KizzyRPC for å stilla inn statusen på Discord-kontoen din. Dette inneber bruk av Discord Gateway-tilkoplinga, som kan verta sett på som eit brud på tenestevilkåra til Discord. Det finst då ingen kjende tilfelle av suspenderte nøytarkontoar på denne grunnen. Nøyt på eigen risiko.\n\nMetrolist hentar berre lykelen din, og alt anna vert lagra lokalt.</string>
     <string name="dismiss">Avvis</string>
     <string name="options">Innstillingar</string>
     <string name="preview">Førehandsvisning</string>
-    <string name="enable_discord_rpc">Slå på rik tilstadarvera</string>
     <string name="about">Om</string>
     <string name="app_version">Apputgåve</string>
     <string name="new_version_available">Ny utgåve tilgjegeleg</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -256,7 +256,6 @@
     <string name="remove_from_playlist">Usuń z playlisty</string>
     <string name="remove_all_from_library">Usuń wszystko z biblioteki</string>
     <string name="your_youtube_playlists">Twoje playlisty YouTube</string>
-    <string name="enable_discord_rpc">Włącz Rich Presence</string>
     <string name="remove_from_queue">Usuń z kolejki</string>
     <string name="login_failed">Błąd logowania</string>
     <string name="similar_to">Podobne do</string>
@@ -288,7 +287,6 @@
     <string name="search_history">Szukaj w historii</string>
     <string name="disable_screenshot">Wyłącz zrzut ekranu</string>
     <string name="hide_explicit">Ukryj wulgarne treści</string>
-    <string name="discord_integration">Integracja z Discordem</string>
     <string name="discord_information">Metrolist używa biblioteki KizzyRPC do aktualizacji statusu konta Discord. Wiąże się to z korzystaniem z połączenia Discord Gateway, co może być postrzegane jako naruszenie warunków korzystania z usług Discord (TOS). Nie są jednak znane przypadki zawieszenia kont użytkowników z tego powodu. Używaj na własne ryzyko.\n\nMetrolist wyodrębni tylko twój token; wszystko inne jest przechowywane lokalnie.</string>
     <string name="dismiss">Odrzuć</string>
     <string name="options">Opcje</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -238,13 +238,11 @@
     <string name="add_anyway">Adicionar mesmo assim</string>
     <string name="duplicates_description_single">Esta música já está na sua playlist</string>
     <string name="duplicates_description_multiple">%d músicas já estão na sua playlist</string>
-    <string name="discord_integration">Integração com o Discord</string>
     <string name="dismiss">Ignorar</string>
     <string name="options">Opções</string>
     <string name="preview">Prévia</string>
     <string name="login_failed">Ocorreu algum problema ao conectar-se</string>
     <string name="action_logout">Desconectar-se</string>
-    <string name="enable_discord_rpc">Ativar o Rich Presence</string>
     <string name="not_logged_in">Não está conectado à uma conta</string>
     <string name="discord_information">O Metrolist usa a biblioteca KizzyRPC para definir o estado da sua conta do Discord. Isto envolve o uso da conexão do Discord Gateway, que pode ser considerado uma violação dos termos de serviço do Discord. Porém, não houve nenhum relato de usuários sendo banidos por esta razão. Use por sua própria conta e risco.\n\nO Metrolist extrairá somente o seu token, e todo o resto é armazenado localmente.</string>
     <string name="sided">Ao lado</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -229,11 +229,9 @@
     <string name="imported_playlist">Lista de reprodução importada</string>
     <string name="backup_create_success">Cópia de segurança criada com sucesso</string>
     <string name="restore_failed">Não foi possível restaurar a cópia de segurança</string>
-    <string name="discord_integration">Integração Discord</string>
     <string name="dismiss">Ignorar</string>
     <string name="login_failed">Autenticação falhou</string>
     <string name="action_logout">Terminar sessão</string>
-    <string name="enable_discord_rpc">Ativar Rich Presence</string>
     <string name="about">Sobre</string>
     <string name="app_version">Versão da Aplicação</string>
     <string name="new_version_available">Disponível nova versão</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -273,12 +273,10 @@
     <string name="backup_create_success">Backup creat cu succes</string>
     <string name="backup_create_failed">Nu s-a putut creea backup-ul</string>
     <string name="restore_failed">Nu s-a putut restaura backup-ul</string>
-    <string name="discord_integration">Integrare Discord</string>
     <string name="discord_information">Metrolist folosește biblioteca KizzyRPC pentru a-ți seta statusul contului tău de Discord. Acest lucru presupune folosirea conexiunii Discord Gateway, ceea ce ar putea fi considerată o încălcare a Termenilor serviciului Discord. Însă, nu există cazuri cunoscute de conturi de utilizator care au fost suspendate din acest motiv. Folosește pe propriul tău risc.\n\nMetrolist îți va extrage doar token-ul. Orice altceva este stocat local.</string>
     <string name="dismiss">Închide</string>
     <string name="options">Opțiuni</string>
     <string name="preview">Previzualizează</string>
-    <string name="enable_discord_rpc">Activează Rich Presence</string>
     <string name="about">Despre</string>
     <string name="app_version">Versiunea aplicației</string>
     <string name="new_version_available">Versiune nouă disponibilă</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -281,14 +281,12 @@
     <string name="backup_create_success">Резервная копия создана успешно</string>
     <string name="backup_create_failed">Не удалось создать резервную копию</string>
     <string name="restore_failed">Не удалось восстановить резервную копию</string>
-    <string name="discord_integration">Интеграция с Discord</string>
     <string name="discord_information">Metrolist использует библиотеку KizzyRPC для установки статуса вашего аккаунта Discord. Это включает использование соединения через Discord Gateway, что может считаться нарушением условий использования Discord. Однако, на данный момент нет известных случаев блокировки учетных записей пользователей по этой причине. Используйте на свой страх и риск.\n\nMetrolist будет извлекать только ваш токен, а все остальное хранится локально.</string>
     <string name="dismiss">Закрыть</string>
     <string name="options">Настройки</string>
     <string name="preview">Предпросмотр</string>
     <string name="login_failed">Ошибка входа</string>
     <string name="action_logout">Выйти</string>
-    <string name="enable_discord_rpc">Включить Rich Presence</string>
     <string name="about">О приложении</string>
     <string name="app_version">Версия приложения</string>
     <string name="new_version_available">Доступна новая версия</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -286,12 +286,10 @@
     <string name="backup_create_success">Záloha bola úspešne vytvorená</string>
     <string name="backup_create_failed">Nepodarilo sa vytvoriť zálohu</string>
     <string name="restore_failed">Nepodarilo sa obnoviť zálohu</string>
-    <string name="discord_integration">Integrácia Discordu</string>
     <string name="discord_information">Metrolist používa knižnicu KizzyRPC na nastavenie stavu vášho účtu Discord. To zahŕňa použitie pripojenia Discord Gateway, čo môže byť považované za porušenie TOS Discordu. Zatiaľ však nie sú známe prípady pozastavenia účtov používateľov z tohto dôvodu. Používanie na vlastné riziko.\n\nMetrolist bude extrahovať iba váš token, všetko ostatné sa ukladá lokálne.</string>
     <string name="dismiss">Zatvoriť</string>
     <string name="options">Možnosťi</string>
     <string name="preview">Náhľad</string>
-    <string name="enable_discord_rpc">Zapnúť Rich Presence</string>
     <string name="about">Informácie</string>
     <string name="app_version">Verzia aplikácie</string>
     <string name="new_version_available">Nová verzia je dostupná</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -262,14 +262,12 @@
     <string name="backup_create_success">காப்புப்பிரதி வெற்றிகரமாக உருவாக்கப்பட்டது</string>
     <string name="backup_create_failed">காப்புப்பிரதியை உருவாக்க முடியவில்லை</string>
     <string name="restore_failed">காப்புப்பிரதியை மீட்டெடுப்பதில் தோல்வி</string>
-    <string name="discord_integration">முரண்பாடு ஒருங்கிணைப்பு</string>
     <string name="discord_information">உங்கள் முரண்பாடு கணக்கின் நிலையை அமைக்க இன்டெர்டூன் கிச்சார்பிசி நூலகத்தைப் பயன்படுத்துகிறது. இது முரண்பாடான நுழைவாயில் இணைப்பைப் பயன்படுத்துவதை உள்ளடக்குகிறது, இது டிச்கார்டின் TOS இன் மீறலாகக் கருதப்படலாம். இருப்பினும், இந்த காரணத்திற்காக பயனர் கணக்குகள் இடைநிறுத்தப்பட்டதாக அறியப்படாத வழக்குகள் எதுவும் இல்லை. உங்கள் சொந்த ஆபத்தில் பயன்படுத்தவும்.\n\n இன்னெர்டூன் உங்கள் கிள்ளாக்கை மட்டுமே பிரித்தெடுக்கும், மற்ற அனைத்தும் உள்நாட்டில் சேமிக்கப்படும்.</string>
     <string name="dismiss">தள்ளுபடி</string>
     <string name="options">விருப்பங்கள்</string>
     <string name="preview">முன்னோட்டம்</string>
     <string name="login_failed">உள்நுழைவு தோல்வியடைந்தது</string>
     <string name="action_logout">வெளியேறு</string>
-    <string name="enable_discord_rpc">பணக்கார இருப்பை இயக்கவும்</string>
     <string name="about">பற்றி</string>
     <string name="app_version">பயன்பாட்டு பதிப்பு</string>
     <string name="new_version_available">புதிய பதிப்பு கிடைக்கிறது</string>

--- a/app/src/main/res/values-te/strings.xml
+++ b/app/src/main/res/values-te/strings.xml
@@ -270,11 +270,9 @@
     <string name="backup_create_success">బ్యాకప్ విజయవంతంగా సృష్టించబడింది</string>
     <string name="backup_create_failed">బ్యాకప్‌ను సృష్టించలేకపోయింది</string>
     <string name="restore_failed">బ్యాకప్‌ను పునరుద్ధరించడంలో విఫలమైంది</string>
-    <string name="discord_integration">డిస్కార్డ్ ఇంటిగ్రేషన్</string>
     <string name="discord_information">ఇన్నర్‌ట్యూన్ మీ డిస్కార్డ్ తా స్థితిని సెట్ చేసేందుకు కిజ్జీఆర్‌పిసి లైబ్రరీని ఉపయోగిస్తుంది. ఇది డిస్కార్డ్ Gateway కనెక్షన్ ఉపయోగించడం ద్వారా జరుగుతుంది, ఇది Discord యొక్క TOSను ఉల్లంఘించడం గా పరిగణించబడవచ్చు. అయితే, ఈ కారణం వల్ల వినియోగదారుల ఖాతాలు సస్పెండ్ అయిన సందర్భాలు ఎవ్వా తెలిసినవి కాదు. మీ ధైర్యంతో ఉపయోగించండి.\n\nఇన్నర్‌ట్యూన్ మీ టోకెన్ ను మాత్రమే తీసుకుందని, మిగతా అన్ని విషయాలు స్థానికంగా నిల్వ చేయబడ్డాయి.</string>
     <string name="dismiss">తొలగించు</string>
     <string name="preview">పరిదృశ్యం</string>
-    <string name="enable_discord_rpc">రిచ్ ప్రెజెన్స్‌ను ఎనేబుల్ చేయండి</string>
     <string name="app_version">యాప్ వెర్షన్</string>
     <string name="new_version_available">కొత్త వెర్షన్ అందుబాటులో ఉంది</string>
     <string name="translation_models">అనువాద మోడల్స్</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -259,12 +259,10 @@
     <string name="backup_create_success">สร้างไฟล์สำรองข้อมูลสำเร็จ</string>
     <string name="backup_create_failed">ไม่สามารถสร้างไฟล์สำรองข้อมูลได้</string>
     <string name="restore_failed">ไม่สามารถกู้คืนข้อมูลสำรองได้</string>
-    <string name="discord_integration">การเชื่อมต่อกับ Discord</string>
     <string name="discord_information">Metrolist ใช้ไลบรารี KizzyRPC เพื่อแสดงสถานะบนบัญชี Discord ของคุณ ซึ่งต้องใช้การเชื่อมต่อผ่าน Discord Gateway และอาจถือว่าเป็นการละเมิดข้อกำหนดการใช้งาน (ToS) ของ Discord อย่างไรก็ตาม ยังไม่มีรายงานว่ามีบัญชีผู้ใช้ถูกระงับจากสาเหตุนี้ โปรดใช้งานด้วยความระมัดระวังและยอมรับความเสี่ยงเอง\n\nMetrolist จะดึงเฉพาะโทเคนของคุณเท่านั้น และข้อมูลอื่น ๆ ทั้งหมดจะถูกจัดเก็บไว้ในอุปกรณ์ของคุณ</string>
     <string name="dismiss">ปิด</string>
     <string name="options">ตัวเลือก</string>
     <string name="preview">ตัวอย่าง</string>
-    <string name="enable_discord_rpc">เปิดใช้งาน Rich Presence</string>
     <string name="about">เกี่ยวกับ</string>
     <string name="app_version">เวอร์ชันแอป</string>
     <string name="new_version_available">มีเวอร์ชันใหม่พร้อมใช้งาน</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -272,10 +272,8 @@
     <string name="stop_music_on_task_clear">Arka plandan temizlendiğinde çalmayı durdur</string>
     <string name="search_history">Arama geçmişi</string>
     <string name="hide_explicit">Uygunsuz içeriği gizle</string>
-    <string name="discord_integration">Discord Entegrasyonu</string>
     <string name="discord_information">Metrolist, Discord hesabınızın durumunu ayarlamak için KizzyRPC kütüphanesini kullanır. Bu, Discord\'un Hizmet Şartları\'nın ihlali olarak kabul edilebilecek Discord Geçit bağlantısının kullanılmasını gerektirir. Fakat kullanıcı hesaplarının bu nedenle askıya alındığı bilinen bir örnek yoktur. Riski size ait olmak üzere kullanın. \n \nMetrolist yalnızca belirtecinizi çıkarır ve diğer her şey yerel olarak saklanır.</string>
     <string name="action_logout">Oturumu kapat</string>
-    <string name="enable_discord_rpc">Rich Presence\'ı etkinleştir</string>
     <string name="use_login_for_browse">İçerikleri görmek için Giriş yap\'ı kullanın</string>
     <string name="use_login_for_browse_desc">Bu gördüğünüz içerikleri etkileyebilir ve örnek olarak Premium\'a özel içerikleri Premium\'a sahip bir hesapla giriş yaptıysanız size sunabilir</string>
     <string name="action_login">Giriş Yap</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -281,14 +281,12 @@
     <string name="backup_create_success">Резервну копію створено успішно</string>
     <string name="backup_create_failed">Не вдалося створити резервну копію</string>
     <string name="restore_failed">Не вдалося відновити з резервної копії</string>
-    <string name="discord_integration">Інтеграція з Discord</string>
     <string name="discord_information">Metrolist використовує бібліотеку KizzyRPC для встановлення статусу вашого облікового запису Discord. Це передбачає використання підключення через Discord Gateway, що може вважатися порушенням умов використання Discord. Однак, наразі немає відомих випадків блокування облікових записів користувачів з цієї причини. Використовуйте на свій страх і ризик.\n\nMetrolist буде зчитувати тільки ваш токен, а все інше зберігається локально.</string>
     <string name="dismiss">Закрити</string>
     <string name="options">Налаштування</string>
     <string name="preview">Попередній перегляд</string>
     <string name="login_failed">Помилка входу</string>
     <string name="action_logout">Вийти</string>
-    <string name="enable_discord_rpc">Увімкнути Rich Presenсe</string>
     <string name="about">Про програму</string>
     <string name="app_version">Версія застосунку</string>
     <string name="new_version_available">Доступна нова версія</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -221,13 +221,11 @@
     <string name="delete_playlist_confirm">Bạn có thực sự muốn xóa \"%s\" danh sách phát không?</string>
     <string name="not_logged_in">Chưa đăng nhập</string>
     <string name="enable_lrclib">Bật nhà cung cấp lời bài hát LrcLib</string>
-    <string name="discord_integration">Tích hợp Discord</string>
     <string name="dismiss">Bỏ qua</string>
     <string name="options">Tùy chọn</string>
     <string name="preview">Xem trước</string>
     <string name="login_failed">Đăng nhập không thành công</string>
     <string name="action_logout">Đăng xuất</string>
-    <string name="enable_discord_rpc">Kích hoạt Rich Presence</string>
     <string name="sided">Cạnh bên</string>
     <string name="player_text_alignment">Căn chỉnh văn bản của trình phát</string>
     <string name="hide_explicit">Ẩn nội dung phản cảm</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -237,8 +237,6 @@
     <string name="preview">预览</string>
     <string name="login_failed">登录失败</string>
     <string name="action_logout">登出</string>
-    <string name="discord_integration">Discord 集成</string>
-    <string name="enable_discord_rpc">启用 Rich Presence</string>
     <string name="action_like_all">喜欢全部</string>
     <string name="library_song_empty">媒体库歌曲将显示在此处</string>
     <string name="duplicates_description_single">这首歌曲已在您的播放列表中</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -254,14 +254,12 @@
     <string name="backup_create_success">成功建立備份</string>
     <string name="backup_create_failed">無法建立備份</string>
     <string name="restore_failed">無法還原備份</string>
-    <string name="discord_integration">Discord 整合</string>
     <string name="discord_information">Metrolist 使用 KizzyRPC 函式庫來設定您的 Discord 狀態。這會用到 Discord Gateway 連線，可能會違反 Discord 服務條款，但是目前沒有使用者為此被停用帳號。使用此功能需自行承擔此風險。\n\nMetrolist 只會提取你的 token，所有東西都存在本機。</string>
     <string name="dismiss">了解</string>
     <string name="options">選項</string>
     <string name="preview">預覽</string>
     <string name="login_failed">登入失敗</string>
     <string name="action_logout">登出</string>
-    <string name="enable_discord_rpc">啟用 Rich Presence</string>
     <string name="about">關於</string>
     <string name="app_version">應用程式版本</string>
     <string name="new_version_available">發現新版本</string>


### PR DESCRIPTION
Removed discord_integration and enable_discord_rpc strings from all locale strings.xml files (40 files). These strings should only exist in the base metrolist_strings.xml file to avoid duplicate resource errors during build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Removed Discord integration configuration settings and Rich Presence toggle options from all language translations across the application. Updated string resources in 34 supported language locales including Spanish, French, German, Japanese, Korean, Portuguese, Chinese, and many others, eliminating Discord-specific UI elements from user-facing settings and account management menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->