### PR TITLE
fix(ui): prevent crash from duplicate lazy list keys

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/AlbumScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/AlbumScreen.kt
@@ -394,7 +394,7 @@ fun AlbumScreen(
             if (filteredSongs.isNotEmpty()) {
                 itemsIndexed(
                     items = filteredSongs,
-                    key = { _, song -> song.id },
+                    key = { index, song -> "${song.id}_$index" },
                 ) { index, song ->
                     val onCheckedChange: (Boolean) -> Unit = {
                         if (it) {

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/StatsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/StatsScreen.kt
@@ -454,7 +454,7 @@ fun StatsScreen(
                     ) {
                         itemsIndexed(
                             items = mostPlayedSongsStats,
-                            key = { _, song -> song.id },
+                            key = { index, song -> "${song.id}_$index" },
                         ) { index, song ->
                             LocalSongsGrid(
                                 title = "${index + 1}. ${song.title}",

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistSongsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistSongsScreen.kt
@@ -127,7 +127,7 @@ fun ArtistSongsScreen(
 
             itemsIndexed(
                 items = songs,
-                key = { _, item -> item.id },
+                key = { index, item -> "${item.id}_$index" },
             ) { index, song ->
                 SongListItem(
                     song = song,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryPodcastsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryPodcastsScreen.kt
@@ -386,7 +386,7 @@ fun LibraryPodcastsScreen(
 
                     itemsIndexed(
                         items = downloadedEpisodes,
-                        key = { _, item -> item.song.id },
+                        key = { index, item -> "${item.song.id}_$index" },
                         contentType = { _, _ -> CONTENT_TYPE_SONG },
                     ) { index, episode ->
                         // Always show channel name: use artists if available,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibrarySongsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibrarySongsScreen.kt
@@ -459,7 +459,7 @@ fun LibrarySongsScreen(
 
             itemsIndexed(
                 items = filteredSongs,
-                key = { _, item -> item.song.id },
+                key = { index, item -> "${item.song.id}_$index" },
                 contentType = { _, _ -> CONTENT_TYPE_SONG },
             ) { index, song ->
                 SongListItem(

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -588,7 +588,7 @@ fun AutoPlaylistScreen(
                 if (filteredSongs.isNotEmpty()) {
                     itemsIndexed(
                         items = filteredSongs,
-                        key = { _, song -> song.id },
+                        key = { index, song -> "${song.id}_$index" },
                     ) { index, song ->
                         val onCheckedChange: (Boolean) -> Unit = {
                             if (it) {

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/CachePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/CachePlaylistScreen.kt
@@ -253,7 +253,7 @@ fun CachePlaylistScreen(
                     }
                 }
 
-                itemsIndexed(filteredSongs, key = { _, song -> song.id }) { index, song ->
+                itemsIndexed(filteredSongs, key = { index, song -> "${song.id}_$index" }) { index, song ->
                     val onCheckedChange: (Boolean) -> Unit = {
                         if (it) {
                             selection.add(song.id)

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/TopPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/TopPlaylistScreen.kt
@@ -305,7 +305,7 @@ fun TopPlaylistScreen(
                 if (filteredSongs.isNotEmpty()) {
                     itemsIndexed(
                         items = filteredSongs,
-                        key = { _, song -> song.id },
+                        key = { index, song -> "${song.id}_$index" },
                     ) { index, song ->
                         val onCheckedChange: (Boolean) -> Unit = {
                             if (it) {

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/search/OnlineSearchResult.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/search/OnlineSearchResult.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
@@ -496,10 +497,10 @@ fun OnlineSearchResult(
                                 NavigationTitle(summary.title)
                             }
 
-                            items(
+                            itemsIndexed(
                                 items = summary.items,
-                                key = { "${summary.title}/${it.id}/${summary.items.indexOf(it)}" },
-                                itemContent = ytItemContent,
+                                key = { index, item -> "${summary.title}/${item.id}/$index" },
+                                itemContent = { index, item -> ytItemContent(item) },
                             )
                         }
 


### PR DESCRIPTION
## Problem
When a YouTube video ID appears more than once in a `LazyColumn`. This crashes the app entirely.

## Cause
Nine screens used a bare YouTube video ID (`.id` or `.song.id`) as the `LazyColumn`/`LazyRow` item key. When the same video appears twice in the list -possible via API quirks, sync races, or user data- Compose throws because keys must be unique. `OnlineSearchResult.kt` additionally used `indexOf(it)` which returns the first match for equal objects, also producing duplicate keys.

## Solution
- Changed `key` lambdas in 8 `itemsIndexed` calls from `{ _, item -> item.id }` to `{ index, item -> "${item.id}_$index" }`, making each key unique by including the item's positional index
- Changed `OnlineSearchResult.kt` line 501 from `items()` with `indexOf(it)`-based key to `itemsIndexed()` with an explicit index-based key

## Testing
App assembles, song plays, I couldn't reproduce though.

## Related Issues
idk someone mentioned on discord.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved list item handling in music library screens and search results for more reliable UI updates and state preservation during navigation and content changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->