### PR TITLE
fix(player): rebuild cipher WebView on config change; recover stale cipher without app restart

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -208,6 +208,7 @@ import com.metrolist.music.utils.SyncUtils
 import com.metrolist.music.utils.getArtistSeparator
 import com.metrolist.music.utils.joinToArtistString
 import com.metrolist.music.utils.YTPlayerUtils
+import com.metrolist.music.utils.cipher.CipherDeobfuscator
 import com.metrolist.music.utils.dataStore
 import com.metrolist.music.utils.get
 import com.metrolist.music.utils.reportException
@@ -3152,6 +3153,18 @@ class MusicService :
             YTPlayerUtils.forceRefreshForVideo(mediaId)
         } catch (e: Exception) {
             Timber.tag(TAG).e(e, "Failed to clear decryption caches")
+        }
+
+        // A 403 can also mean the cipher produced a wrong-but-non-throwing signature from a
+        // stale/wrong player config — invisible to the cipher's own exception-retry. Ask it to
+        // re-fetch its config (rate-limited); if that corrects the table, the cipher rebuilds its
+        // WebView on the next decipher, so we clear the WEB_REMIX failure set to let playback return
+        // to WEB_REMIX — no app restart. Affects every cipher client (WEB_REMIX/WEB_CREATOR/TVHTML5/WEB).
+        scope.launch {
+            if (CipherDeobfuscator.onStreamRejected()) {
+                Timber.tag(TAG).d("Player config changed after stream rejection — restoring WEB_REMIX")
+                YTPlayerUtils.clearWebRemixFailures()
+            }
         }
 
         retryJob?.cancel()

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -59,6 +59,15 @@ object YTPlayerUtils {
         webRemixFailedIds.add(videoId)
     }
 
+    /**
+     * Cleared when the cipher recovers (player config refreshed after a stream rejection): the
+     * prior WEB_REMIX failures were caused by the stale cipher, so let resolution try WEB_REMIX
+     * again instead of staying pinned to a lower fallback client for the rest of the process.
+     */
+    fun clearWebRemixFailures() {
+        webRemixFailedIds.clear()
+    }
+
     private val MAIN_CLIENT: YouTubeClient = WEB_REMIX
 
     // VISIONOS first (its CDN URL has no spc throttle gate, so it streams whole songs with no

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherDeobfuscator.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherDeobfuscator.kt
@@ -39,6 +39,12 @@ object CipherDeobfuscator {
 
     private var cipherWebView: CipherWebView? = null
 
+    // The PlayerConfigStore.configEpoch the cached WebView was built under. When the config table
+    // changes (epoch advances), the cached WebView may have been built from a missing or wrong
+    // config for the current player, so getOrCreateWebView() rebuilds it instead of trusting it for
+    // the life of the process — the staleness that previously required an app restart to recover.
+    private var builtConfigEpoch = -1
+
     // Written on the decipher coroutine (Dispatchers.IO) but read via lastUsedPlayerHash from the
     // Compose UI thread (song-details sheet), so @Volatile to publish the write across threads.
     @Volatile
@@ -113,6 +119,17 @@ object CipherDeobfuscator {
             }
         }
     }
+
+    /**
+     * Called when a deciphered stream URL was rejected by the CDN (e.g. a WEB_REMIX 403). A wrong
+     * signature that the player JS computes WITHOUT throwing — a stale/wrong player config or a
+     * legacy-regex false positive — is invisible to [deobfuscateStreamUrl]'s exception-retry, so
+     * the rejected stream is the only signal it was wrong. Re-fetch the player-config table
+     * (rate-limited); if it changes, [PlayerConfigStore.configEpoch] advances and the next decipher
+     * rebuilds the WebView from the corrected config, recovering playback without an app restart.
+     * Returns whether the config table changed.
+     */
+    suspend fun onStreamRejected(): Boolean = PlayerConfigStore.refreshAfterStreamRejection()
 
     private suspend fun deobfuscateInternal(signatureCipher: String, videoId: String, isRetry: Boolean): String? {
         Timber.tag(TAG).d("deobfuscateInternal: videoId=$videoId, isRetry=$isRetry")
@@ -231,10 +248,21 @@ object CipherDeobfuscator {
     private suspend fun getOrCreateWebView(forceRefresh: Boolean): CipherWebView? {
         Timber.tag(TAG).d("getOrCreateWebView: forceRefresh=$forceRefresh, existing=${cipherWebView != null}")
 
-        if (!forceRefresh && cipherWebView != null) {
+        // Snapshot the epoch BEFORE extracting/building. A refresh that lands on another thread
+        // during this (multi-second) build then leaves builtConfigEpoch behind the live epoch,
+        // forcing a rebuild on the next decipher instead of masking the change. Capturing the epoch
+        // AFTER the build would record a config this WebView never actually incorporated — the
+        // staleness this whole mechanism exists to prevent.
+        val epochAtStart = PlayerConfigStore.configEpoch
+        if (!forceRefresh && cipherWebView != null && builtConfigEpoch == epochAtStart) {
             Timber.tag(TAG).d("Reusing existing CipherWebView (hash=$currentPlayerHash)")
             return cipherWebView
         }
+
+        // The epoch whose config this build incorporates. Defaults to the pre-build snapshot; the
+        // heal path below advances it only after a same-thread forceRefresh whose new config we
+        // re-extract and therefore HAVE incorporated (avoids a needless next rebuild).
+        var builtEpoch = epochAtStart
 
         // Close existing WebView if any
         if (cipherWebView != null) {
@@ -273,6 +301,7 @@ object CipherDeobfuscator {
             Timber.tag(TAG).d("forceRefresh($hash) -> hashNowKnown=$healed")
             if (healed) {
                 analysis = FunctionNameExtractor.analyzePlayerJs(playerJs, knownHash = hash)
+                builtEpoch = PlayerConfigStore.configEpoch
                 Timber.tag(TAG).d("Re-extracted after refresh: sigConfig=${analysis.sigInfo?.isHardcoded == true}, nConfig=${analysis.nFuncInfo?.isHardcoded == true}")
             }
         }
@@ -305,6 +334,7 @@ object CipherDeobfuscator {
 
         cipherWebView = webView
         currentPlayerHash = hash
+        builtConfigEpoch = builtEpoch
         return webView
     }
 

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/PlayerConfigStore.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/PlayerConfigStore.kt
@@ -55,8 +55,35 @@ object PlayerConfigStore {
     @Volatile
     private var mergedConfigs: Map<String, FunctionNameExtractor.HardcodedPlayerConfig> = emptyMap()
 
+    // Advanced every time a remote refresh actually changes the table. The cipher records the epoch
+    // its WebView was built under and rebuilds when this advances, so a corrected config for the
+    // current player — arriving by any refresh path AFTER the WebView was built from a missing or
+    // wrong entry — takes effect on the next decipher instead of being ignored until the process is
+    // restarted. See CipherDeobfuscator.getOrCreateWebView().
+    @Volatile
+    var configEpoch: Int = 0
+        private set
+
     @Volatile
     private var lastForcedAttemptMs = 0L
+
+    // Separate from lastForcedAttemptMs so a stream-rejection refresh (which fires on any 403,
+    // including unrelated/expired-URL ones) can never arm a cooldown that blocks the unknown-hash
+    // forceRefresh self-heal, or vice versa. They still serialize on refreshMutex (single-flight).
+    @Volatile
+    private var lastRejectionAttemptMs = 0L
+
+    // The two cooldown gates read DIFFERENT stamps on purpose (see above). Routed through these
+    // functions — which forceRefresh / refreshAfterStreamRejection actually call — so a unit test
+    // can prove neither path is gated by the other's cooldown without touching the network.
+    internal fun forcedCooldownActive(now: Long) = now - lastForcedAttemptMs < FORCE_REFRESH_COOLDOWN_MS
+
+    internal fun rejectionCooldownActive(now: Long) = now - lastRejectionAttemptMs < FORCE_REFRESH_COOLDOWN_MS
+
+    // Test-only: arm a cooldown stamp without invoking the network refresh paths.
+    internal fun armForcedCooldownForTest(ms: Long) { lastForcedAttemptMs = ms }
+
+    internal fun armRejectionCooldownForTest(ms: Long) { lastRejectionAttemptMs = ms }
 
     // True when the most recent fetch got ANY HTTP response (200/304/404/...). The forced-refresh
     // cooldown only arms in that case — it exists to protect the config host from repeat hits,
@@ -158,15 +185,47 @@ object PlayerConfigStore {
             }
 
             val now = System.currentTimeMillis()
-            if (now - lastForcedAttemptMs < FORCE_REFRESH_COOLDOWN_MS) {
+            if (forcedCooldownActive(now)) {
                 Timber.tag(TAG).d("forceRefresh skipped (cooldown)")
                 return@withLock false
             }
             lastForcedAttemptMs = now
-            fetchAndApply()
-            if (!lastAttemptReachedServer) lastForcedAttemptMs = 0L
+            fetchAndApplyResetting { lastForcedAttemptMs = 0L }
             mergedConfigs.containsKey(missingHash)
         }
+    }
+
+    /**
+     * Stream-rejection refresh: a deciphered URL was rejected by the CDN (e.g. a WEB_REMIX 403),
+     * which can mean the cipher produced a wrong-but-non-throwing signature from a stale/wrong
+     * player config — a failure the [CipherDeobfuscator] exception-retry never sees. Unlike
+     * [forceRefresh], this does NOT short-circuit when the current hash is already present (the
+     * entry may be present but WRONG), so it always re-fetches; it has its OWN cooldown (so it can't
+     * starve the unknown-hash [forceRefresh] path) but shares the single-flight lock. Returns
+     * whether the table changed — when true, [configEpoch] has advanced and the cipher rebuilds.
+     */
+    suspend fun refreshAfterStreamRejection(): Boolean = withContext(Dispatchers.IO) {
+        refreshMutex.withLock {
+            val now = System.currentTimeMillis()
+            if (rejectionCooldownActive(now)) {
+                Timber.tag(TAG).d("refreshAfterStreamRejection skipped (cooldown)")
+                return@withLock false
+            }
+            lastRejectionAttemptMs = now
+            fetchAndApplyResetting { lastRejectionAttemptMs = 0L }
+        }
+    }
+
+    /**
+     * Shared fetch tail for the cooldown-gated refresh paths: fetch + apply, and on a pure network
+     * failure (the server was never reached) reset the caller's cooldown stamp so a rotation hit
+     * while briefly offline retries on the next trigger instead of waiting out the cooldown.
+     * Returns whether the table changed. Must be called with [refreshMutex] held.
+     */
+    private fun fetchAndApplyResetting(resetCooldown: () -> Unit): Boolean {
+        val changed = fetchAndApply()
+        if (!lastAttemptReachedServer) resetCooldown()
+        return changed
     }
 
     private suspend fun refreshIfStale() {
@@ -249,7 +308,8 @@ object PlayerConfigStore {
         val merged = PlayerConfigParser.merge(bundledConfigs, remote)
         val changed = merged != mergedConfigs
         mergedConfigs = merged
-        Timber.tag(TAG).d("Remote configs applied (${remote.size} hashes, merged=${merged.size}, changed=$changed)")
+        if (changed) configEpoch++
+        Timber.tag(TAG).d("Remote configs applied (${remote.size} hashes, merged=${merged.size}, changed=$changed, epoch=$configEpoch)")
 
         try {
             cacheFile()?.let { writeAtomic(it, body) }

--- a/app/src/test/kotlin/com/metrolist/music/utils/cipher/PlayerConfigStoreCooldownTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/utils/cipher/PlayerConfigStoreCooldownTest.kt
@@ -1,0 +1,49 @@
+package com.metrolist.music.utils.cipher
+
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The unknown-hash self-heal (forceRefresh) and the stream-rejection refresh
+ * (refreshAfterStreamRejection) MUST use independent cooldown stamps. A stream rejection fires on
+ * any 403 — including unrelated/expired-URL ones — so if it shared forceRefresh's cooldown it could
+ * delay a real player-rotation self-heal by up to 5 minutes (and vice versa). These are the exact
+ * gate functions the two refresh paths call, so this proves the separation without any network.
+ */
+class PlayerConfigStoreCooldownTest {
+
+    @After
+    fun tearDown() {
+        // Disarm both so we don't leak cooldown state into other tests in the same JVM.
+        PlayerConfigStore.armForcedCooldownForTest(0L)
+        PlayerConfigStore.armRejectionCooldownForTest(0L)
+    }
+
+    @Test
+    fun `arming the forced cooldown does not gate the stream-rejection refresh`() {
+        val now = 10_000_000L
+        PlayerConfigStore.armForcedCooldownForTest(now)
+        PlayerConfigStore.armRejectionCooldownForTest(0L)
+
+        assertTrue("forceRefresh must be on cooldown", PlayerConfigStore.forcedCooldownActive(now))
+        assertFalse(
+            "a stream rejection must NOT be blocked by the unknown-hash cooldown",
+            PlayerConfigStore.rejectionCooldownActive(now),
+        )
+    }
+
+    @Test
+    fun `arming the rejection cooldown does not gate the unknown-hash forceRefresh`() {
+        val now = 10_000_000L
+        PlayerConfigStore.armRejectionCooldownForTest(now)
+        PlayerConfigStore.armForcedCooldownForTest(0L)
+
+        assertTrue("rejection refresh must be on cooldown", PlayerConfigStore.rejectionCooldownActive(now))
+        assertFalse(
+            "the unknown-hash self-heal must NOT be blocked by a stream-rejection cooldown",
+            PlayerConfigStore.forcedCooldownActive(now),
+        )
+    }
+}

--- a/app/src/test/kotlin/com/metrolist/music/utils/cipher/PlayerConfigStoreEpochTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/utils/cipher/PlayerConfigStoreEpochTest.kt
@@ -1,0 +1,66 @@
+package com.metrolist.music.utils.cipher
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * [PlayerConfigStore.configEpoch] must advance exactly when [PlayerConfigStore.applyRemote] changes
+ * the table, and never when an identical table is re-applied. That epoch is the sole signal the
+ * cipher uses to decide a cached WebView was built from a now-superseded config and must be rebuilt
+ * — the fix for playback staying broken (a wrong-but-non-throwing signature) until an app restart.
+ * A spurious bump would force needless WebView rebuilds; a missed bump would reproduce the bug.
+ */
+class PlayerConfigStoreEpochTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private fun configs(json: String) =
+        (PlayerConfigParser.parse(json) as PlayerConfigParser.ParseResult.Success).configs
+
+    // Same hash, different (sig, nClass, sts) — a real player rotation / config correction.
+    private val tableA =
+        """{"schemaVersion":1,"players":{"abcd1234":{"sig":"mP(4,155,INPUT)","nClass":"Yx","sts":20613}}}"""
+    private val tableB =
+        """{"schemaVersion":1,"players":{"abcd1234":{"sig":"Tl(48,5831,INPUT)","nClass":"W_","sts":20620}}}"""
+
+    @Before
+    fun setUp() {
+        PlayerConfigStore.cacheDirForTest = tmp.newFolder("cipher_cache")
+        PlayerConfigStore.setTableForTest(emptyMap())
+    }
+
+    @After
+    fun tearDown() {
+        PlayerConfigStore.cacheDirForTest = null
+        PlayerConfigStore.setTableForTest(emptyMap())
+    }
+
+    @Test
+    fun `epoch advances on a real change and holds on a no-op re-apply`() {
+        // configEpoch is process-global (object), so assert relative to the starting value.
+        val start = PlayerConfigStore.configEpoch
+
+        PlayerConfigStore.applyRemote(configs(tableA), tableA, "\"e1\"")
+        val afterFirst = PlayerConfigStore.configEpoch
+        assertEquals("first apply changes the table", start + 1, afterFirst)
+
+        PlayerConfigStore.applyRemote(configs(tableA), tableA, "\"e1\"")
+        assertEquals(
+            "re-applying the identical table must NOT advance the epoch (no needless rebuild)",
+            afterFirst,
+            PlayerConfigStore.configEpoch,
+        )
+
+        PlayerConfigStore.applyRemote(configs(tableB), tableB, "\"e2\"")
+        assertEquals(
+            "a corrected entry for the same hash advances the epoch (triggers WebView rebuild)",
+            afterFirst + 1,
+            PlayerConfigStore.configEpoch,
+        )
+    }
+}


### PR DESCRIPTION
## Problem

The cipher's `CipherWebView` is built once and reused for the life of the process. If a corrected `player_configs.json` entry arrives **after** the WebView was built from a missing/wrong config — or if a stale/wrong config produces a signature that the player JS computes **without throwing** (so `deobfuscateStreamUrl`'s exception-retry never fires) — the bad WebView is never rebuilt. Playback stays stuck on a fallback client until the user force-stops and reopens the app. Because the cipher WebView is shared, this breaks **every** cipher (web) client at once: WEB_REMIX, WEB_CREATOR, TVHTML5, WEB.

## Fix

- **Config epoch → WebView rebuild.** `PlayerConfigStore.configEpoch` advances whenever a refresh actually changes the table. `CipherDeobfuscator` records the epoch its WebView was built under (snapshotted **before** the build, so a change landing mid-build can't be masked) and rebuilds when it advances — so a corrected config takes effect on the next decipher, no restart.
- **Stream-rejection refresh.** A 403 (`handleExpiredUrlError`) now asks the cipher to re-fetch its config (`refreshAfterStreamRejection`) — the only signal a wrong-but-non-throwing signature gives. It has its **own** cooldown so it can't starve the unknown-hash self-heal, and on a real change the WEB_REMIX failure set is cleared so playback returns to WEB_REMIX.

## Tests

- Unit: `PlayerConfigStoreEpochTest` (epoch advances only on a real change), `PlayerConfigStoreCooldownTest` (the forced and rejection cooldowns are independent).
- On-device (foss debug): normal playback reuses the WebView (no rebuild storm); an injected wrong-but-non-throwing config 403s then recovers to WEB_REMIX with no restart; a config change landing mid-build proactively rebuilds instead of masking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from stream rejection (403) errors by clearing failure tracking and attempting alternative playback paths without requiring an app restart.
  * Enhanced automatic detection of cipher configuration changes to allow dynamic playback adaptation during playback sessions.

* **Tests**
  * Added tests for independent cooldown handling mechanisms.
  * Added tests for configuration state tracking improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->