### PR TITLE
fix(player): self-heal cipher for non-WEB_REMIX clients (WEB_CREATOR/TVHTML5)

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -34,7 +34,10 @@ import com.metrolist.music.utils.cipher.FunctionNameExtractor
 import com.metrolist.music.utils.cipher.PlayerJsFetcher
 import com.metrolist.music.utils.potoken.PoTokenGenerator
 import com.metrolist.music.utils.potoken.PoTokenResult
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import timber.log.Timber
@@ -67,6 +70,14 @@ object YTPlayerUtils {
     fun clearWebRemixFailures() {
         webRemixFailedIds.clear()
     }
+
+    // Fire-and-forget scope for the cipher config self-heal triggered when a cipher client fails
+    // stream validation during resolution. Only WEB_REMIX skips HEAD validation (so its bad URL
+    // 403s on ExoPlayer and hits MusicService's handler); WEB_CREATOR / TVHTML5 / WEB are validated
+    // here and never reach ExoPlayer, so without this trigger a WEB_REMIX-disabled user would never
+    // self-heal a stale/wrong cipher config. Kept off the resolution coroutine so the (network)
+    // refresh never blocks falling through to the next client.
+    private val cipherRefreshScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     private val MAIN_CLIENT: YouTubeClient = WEB_REMIX
 
@@ -457,6 +468,17 @@ object YTPlayerUtils {
                     break
                 } else {
                     Timber.tag(logTag).d("Stream validation failed for client: ${currentClient.clientName}")
+                    // A cipher client failing validation can mean a wrong-but-non-throwing signature
+                    // from a stale/wrong player config — caught here at resolution, so it never
+                    // reaches ExoPlayer and MusicService's 403 handler never fires. Ask the cipher to
+                    // re-fetch its config (rate-limited, off this coroutine); if it changes, the
+                    // cipher rebuilds its WebView and the next resolution returns to this client — no
+                    // app restart. This is what covers WEB_CREATOR/TVHTML5/WEB-only users.
+                    if (needsNTransform) {
+                        cipherRefreshScope.launch {
+                            if (CipherDeobfuscator.onStreamRejected()) clearWebRemixFailures()
+                        }
+                    }
                 }
             } else {
                 Timber.tag(logTag).d("Player response status not OK: ${streamPlayerResponse?.playabilityStatus?.status}, reason: ${streamPlayerResponse?.playabilityStatus?.reason}")


### PR DESCRIPTION
## Problem

The cipher self-heal added in #3995 fires `onStreamRejected()` only from `MusicService`'s ExoPlayer-403 handler. But only **WEB_REMIX** skips HEAD validation, so only its bad URL reaches ExoPlayer and 403s. Every other cipher client — **WEB_CREATOR, TVHTML5** — is HEAD-validated during resolution: a wrong-but-non-throwing signature fails `validateStatus` and falls through **without ever reaching ExoPlayer**, so the refetch is never triggered.

Net effect: a user who has **WEB_REMIX disabled** in Stream sources (e.g. WEB_CREATOR-only or TVHTML5-only) never gets the mid-session self-heal — a stale/wrong config keeps them broken until a 6 h startup refresh or an app restart.

## Fix

In `YTPlayerUtils`, when a `needsNTransform` (cipher) client fails `validateStatus`, also fire `CipherDeobfuscator.onStreamRejected()` — rate-limited and off the resolution coroutine so it never blocks falling through. On a real config change the cipher rebuilds its WebView (#3995's epoch mechanism) and the WEB_REMIX failure set is cleared, so the next resolution returns to the proper client. No new state; reuses the existing self-heal.

## Tests

On-device (foss debug, logged in), with only one cipher client enabled at a time and a wrong-but-non-throwing config injected for the live player:
- **WEB_CREATOR-only:** `BK(8)→false → "Stream validation failed for client: WEB_CREATOR" → Remote configs applied (changed=true) → BK(15) rebuild → Playback: client=WEB_CREATOR`, recovered, no restart.
- **TVHTML5-only:** same sequence ending in `Playback: client=TVHTML5`, recovered, no restart.
- Baseline: with a correct config, WEB_CREATOR/TVHTML5 validate and play normally (no spurious refetch).
- Existing `PlayerConfigStoreEpochTest` / `PlayerConfigStoreCooldownTest` still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stream playback reliability with automatic error recovery that eliminates the need for app restart when stream validation fails
  * Enhanced robustness of stream resolution handling for edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->