### PR TITLE
fix(playback): eliminate PlayerConnection NPE race with MusicService player init

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
@@ -204,7 +204,6 @@ import com.metrolist.music.widget.PlaylistWidgetReceiver
 import com.valentinilk.shimmer.LocalShimmerTheme
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
@@ -260,26 +259,9 @@ class MainActivity : ComponentActivity() {
                 service: IBinder?,
             ) {
                 if (service is MusicBinder) {
-                    try {
-                        playerConnection = PlayerConnection(this@MainActivity, service, database, lifecycleScope)
-                        playerConnectionSnapshot = playerConnection
-                        Timber.tag("MainActivity").d("PlayerConnection created successfully")
-                        // Connect Listen Together manager to player
-                        listenTogetherManager.setPlayerConnection(playerConnection)
-                    } catch (e: Exception) {
-                        Timber.tag("MainActivity").e(e, "Failed to create PlayerConnection")
-                        // Retry after a delay of 500ms
-                        lifecycleScope.launch {
-                            delay(500)
-                            try {
-                                playerConnection = PlayerConnection(this@MainActivity, service, database, lifecycleScope)
-                                playerConnectionSnapshot = playerConnection
-                                listenTogetherManager.setPlayerConnection(playerConnection)
-                            } catch (e2: Exception) {
-                                Timber.tag("MainActivity").e(e2, "Failed to create PlayerConnection on retry")
-                            }
-                        }
-                    }
+                    playerConnection = PlayerConnection(this@MainActivity, service, database, lifecycleScope)
+                    playerConnectionSnapshot = playerConnection
+                    listenTogetherManager.setPlayerConnection(playerConnection)
                 }
             }
 

--- a/app/src/main/kotlin/com/metrolist/music/playback/PlayerConnection.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/PlayerConnection.kt
@@ -62,25 +62,32 @@ class PlayerConnection(
     val service = binder.service
     private val playerReadinessFlow = service.isPlayerReady
 
-    /**
-     * Safe player accessor checks readiness & handles errors.
-     * Should be used by all player access within this class.
-     */
-    private fun getPlayerSafe(): ExoPlayer =
-        try {
-            if (!playerReadinessFlow.value) {
-                Timber.tag(TAG).w("Player accessed before service initialization complete; returning best-effort reference")
-            }
+    private fun getPlayerSafe(): ExoPlayer {
+        check(playerReadinessFlow.value) {
+            "Player not yet initialized in MusicService; " +
+                "service.isPlayerReady=${playerReadinessFlow.value}"
+        }
+        return try {
             service.player
         } catch (e: UninitializedPropertyAccessException) {
-            Timber.tag(TAG).e(e, "Fatal: player property accessed but not initialized")
-            throw IllegalStateException("MusicService.player not initialized; possible race condition in service startup", e)
+            throw IllegalStateException(
+                "MusicService.player field not initialized despite isPlayerReady=true; " +
+                    "possible race condition in service startup",
+                e,
+            )
+        }
+    }
+
+    private fun getPlayerOrNull(): ExoPlayer? =
+        try {
+            if (!playerReadinessFlow.value) return null
+            service.player
+        } catch (_: UninitializedPropertyAccessException) {
+            null
+        } catch (_: NullPointerException) {
+            null
         }
 
-    /**
-     * Public accessor for player. Throws if player not ready.
-     * Callers should check [isPlayerInitialized] before calling, or handle exceptions.
-     */
     val player: ExoPlayer
         get() = getPlayerSafe()
 
@@ -91,22 +98,26 @@ class PlayerConnection(
     private val playWhenReady: MutableStateFlow<Boolean>
     val isPlaying: kotlinx.coroutines.flow.StateFlow<Boolean>
 
-    init {
-        Timber.tag(TAG).d("PlayerConnection init: playerReady=${playerReadinessFlow.value}")
-
-        // Initialize with player state or safe defaults if player not ready
-        val initialState =
-            try {
-                val initialPlayer = getPlayerSafe()
+    private val initialState: Triple<Int, Boolean, Boolean> =
+        try {
+            val initialPlayer = getPlayerOrNull()
+            if (initialPlayer != null) {
                 Triple(
                     initialPlayer.playbackState,
                     initialPlayer.playWhenReady,
                     initialPlayer.playWhenReady && initialPlayer.playbackState != STATE_ENDED,
                 )
-            } catch (e: Exception) {
-                Timber.tag(TAG).e(e, "Error during PlayerConnection initialization, using defaults")
+            } else {
+                Timber.tag(TAG).w("Player not ready during construction; using safe defaults")
                 Triple(Player.STATE_IDLE, false, false)
             }
+        } catch (e: Exception) {
+            Timber.tag(TAG).e(e, "Error during PlayerConnection initialization, using defaults")
+            Triple(Player.STATE_IDLE, false, false)
+        }
+
+    init {
+        Timber.tag(TAG).d("PlayerConnection init: playerReady=${playerReadinessFlow.value}")
 
         playbackState = MutableStateFlow(initialState.first)
         playWhenReady = MutableStateFlow(initialState.second)
@@ -132,7 +143,6 @@ class PlayerConnection(
         Timber.tag(TAG).d("PlayerConnection state flows initialized successfully")
     }
 
-    // Effective playing state, considers Cast when active
     val isEffectivelyPlaying =
         combine(
             isPlaying,
@@ -143,10 +153,10 @@ class PlayerConnection(
         }.stateIn(
             scope,
             SharingStarted.Lazily,
-            player.playbackState != STATE_ENDED && player.playWhenReady,
+            initialState.third,
         )
 
-    val mediaMetadata = MutableStateFlow(player.currentMetadata)
+    val mediaMetadata = MutableStateFlow(getPlayerOrNull()?.currentMetadata)
     // stateIn so the latest DB result is cached and shared: on resume / re-subscription the value
     // is available immediately instead of re-running the Room query (which delayed now-playing
     // details, format and like-state on every foreground). Lazily keeps it hot across lifecycle
@@ -194,26 +204,19 @@ class PlayerConnection(
     private var attachedPlayer: Player? = null
 
     init {
-        try {
-            // Observe player changes (e.g. crossfade swap)
-            scope.launch {
-                service.playerFlow.collect { newPlayer ->
-                    if (newPlayer != null && newPlayer != attachedPlayer) {
-                        updateAttachedPlayer(newPlayer)
-                    }
+        scope.launch {
+            service.playerFlow.collect { newPlayer ->
+                if (newPlayer != null && newPlayer != attachedPlayer) {
+                    updateAttachedPlayer(newPlayer)
                 }
             }
-            // Initial setup if flow hasn't emitted yet but service is ready
-            if (attachedPlayer == null && service.isPlayerReady.value) {
-                updateAttachedPlayer(player)
-            }
-
-            Timber.tag(TAG).d("PlayerConnection flow observer registered")
-        } catch (e: Exception) {
-            Timber.tag(TAG).e(e, "Failed to initialize PlayerConnection listener or state")
-            // Propagate the error so MainActivity can retry
-            throw e
         }
+        val readyPlayer = getPlayerOrNull()
+        if (attachedPlayer == null && readyPlayer != null) {
+            updateAttachedPlayer(readyPlayer)
+        }
+
+        Timber.tag(TAG).d("PlayerConnection flow observer registered; playerReady=${playerReadinessFlow.value}")
     }
 
     private fun updateAttachedPlayer(newPlayer: Player) {


### PR DESCRIPTION
## Summary
- Fix NPE crash in `PlayerConnection` construction caused by a race condition between `onServiceConnected` and `MusicService.player` (lateinit var) initialization
- `PlayerConnection` now always constructs successfully with safe defaults; state syncs automatically via `playerFlow` when the player becomes ready

## Root cause
When `MusicService.onCreate()` is still running and `onServiceConnected` fires, `PlayerConnection` was accessing `service.player` before it was initialized. With R8, the `lateinit` check is stripped, so `service.player` returns null silently — any subsequent method call (e.g. `.playbackState`) throws NPE.

Three unprotected `player` accesses during `PlayerConnection` construction (lines 146, 149, 208 in the old code) bypassed the try/catch in the first `init` block, crashing the entire construction. The retry in `MainActivity.onServiceConnected` also failed because the player was still not ready after 500ms.

## Fix (structural)
1. **`getPlayerSafe()`** — Now calls `check(playerReadinessFlow.value)` before touching `service.player`, preventing the NPE at the source
2. **`getPlayerOrNull()`** — New safe accessor used during construction; returns `null` when player isn't ready, catching both `UninitializedPropertyAccessException` and `NullPointerException`
3. **`initialState`** — Computed via `getPlayerOrNull()` before any property init, providing safe defaults for `isEffectivelyPlaying` and `mediaMetadata`
4. **`isEffectivelyPlaying`** — Uses `initialState.third` instead of `player.playbackState` (was the primary NPE source)
5. **`mediaMetadata`** — Uses `getPlayerOrNull()?.currentMetadata` instead of `player.currentMetadata`
6. **Second `init` block** — Removed try/catch-rethrow; uses `getPlayerOrNull()` for immediate attachment
7. **`MainActivity.onServiceConnected`** — Removed retry logic since construction can no longer throw

## Testing
Verified that all state flows initialize with safe defaults and that `playerFlow` collector registers correctly to sync real state when MusicService finishes player initialization.

Fixes #3943

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified player connection initialization and state management.
  * Updated player access patterns to use safer, readiness-aware accessors.
  * Streamlined connection setup logic by removing retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->