### PR TITLE
fix: extract duration from fixedColumns in related page song parsing

### DIFF
--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/RelatedPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/RelatedPage.kt
@@ -12,6 +12,7 @@ import com.metrolist.innertube.models.SongItem
 import com.metrolist.innertube.models.YTItem
 import com.metrolist.innertube.models.oddElements
 import com.metrolist.innertube.models.splitBySeparator
+import com.metrolist.innertube.utils.parseTime
 
 data class RelatedPage(
     val songs: List<SongItem>,
@@ -56,7 +57,9 @@ data class RelatedPage(
                             id = it.navigationEndpoint?.browseEndpoint?.browseId ?: return null,
                         )
                     },
-                duration = null,
+                duration = renderer.fixedColumns?.firstOrNull()
+                    ?.musicResponsiveListItemFlexColumnRenderer?.text?.runs?.firstOrNull()
+                    ?.text?.parseTime(),
                 musicVideoType = renderer.musicVideoType,
                 thumbnail = renderer.thumbnail?.musicThumbnailRenderer?.getThumbnailUrl() ?: return null,
                 explicit =


### PR DESCRIPTION
## Problem
<!-- Describe the issue or limitation this PR addresses  
DO NOT PR NEW FEATURES, WE'RE ON A FEATURE FREEZE!!! -->
Song duration doesn't show sometimes on the Home page quick picks section (#3911).

## Cause
<!-- Explain the root cause of the problem -->
`RelatedPage.fromMusicResponsiveListItemRenderer()` hardcoded `duration = null` for songs parsed from the related songs API response. Every other page parser (`PlaylistPage`, `AlbumPage`, `LibraryPage`, `HistoryPage`, `ArtistItemsPage`) extracts duration from `fixedColumns`, but `RelatedPage` did not.

Since related songs populate `related_song_map` (which feeds the quick picks query), all quick picks songs had `duration = -1` in the database. `makeTimeString(-1000L)` returns `""` due to the `< 0` guard in `StringUtils.kt`, hiding the duration text.

## Solution
<!-- List the changes made to fix it -->
- Extract duration from `renderer.fixedColumns` in `RelatedPage.fromMusicResponsiveListItemRenderer()`, matching the exact pattern already used by all other page parsers.

## Testing
<!-- Describe how the changes were tested -->
- Build succeeds (`./gradlew :app:assembleFossDebug`)
- Verified the fix matches the existing pattern in `PlaylistPage.kt:48`, `AlbumPage.kt:115`, `LibraryPage.kt:202`, `HistoryPage.kt:60`, and `ArtistItemsPage.kt:69`

## Related Issues
<!-- List any related issues or PRs -->
- Closes #3911

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing song duration information that was previously displayed as blank or unavailable in related content lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->