### PR TITLE
Fix song caching during crossfade playback

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -1619,10 +1619,15 @@ class MusicService :
         val mediaMetadata =
             withContext(Dispatchers.Main) {
                 player.findNextMediaItemById(mediaId)?.metadata
-            } ?: return
+                    ?: secondaryPlayer?.findNextMediaItemById(mediaId)?.metadata
+                    ?: fadingPlayer?.findNextMediaItemById(mediaId)?.metadata
+            }
+
+        if (mediaMetadata == null && song == null) return
+
         val duration =
             song?.song?.duration?.takeIf { it != -1 }
-                ?: mediaMetadata.duration.takeIf { it != -1 }
+                ?: mediaMetadata?.duration?.takeIf { it != -1 }
                 ?: (
                     playbackData?.videoDetails ?: YTPlayerUtils
                         .playerResponseForMetadata(mediaId)
@@ -1631,15 +1636,15 @@ class MusicService :
                 )?.lengthSeconds?.toInt()
                 ?: -1
         database.query {
-            if (song == null) {
+            if (song == null && mediaMetadata != null) {
                 insert(mediaMetadata.copy(duration = duration))
-            } else {
+            } else if (song != null) {
                 var updatedSong = song.song
                 if (song.song.duration == -1) {
                     updatedSong = updatedSong.copy(duration = duration)
                 }
                 // Update isVideo flag if it's different from the current value
-                if (song.song.isVideo != mediaMetadata.isVideoSong) {
+                if (mediaMetadata != null && song.song.isVideo != mediaMetadata.isVideoSong) {
                     updatedSong = updatedSong.copy(isVideo = mediaMetadata.isVideoSong)
                 }
                 // Set dateDownload when song is cached during playback
@@ -2438,6 +2443,12 @@ class MusicService :
         lastPlaybackSpeed = -1.0f // force update song
 
         setupAudioNormalization()
+
+        mediaItem?.mediaId?.let { mediaId ->
+            scope.launch(Dispatchers.IO) {
+                recoverSong(mediaId)
+            }
+        }
 
         scrobbleManager?.onSongStop()
         if (player.playWhenReady && player.playbackState == Player.STATE_READY) {
@@ -4623,6 +4634,8 @@ class MusicService :
         } catch (e: Exception) {
             timber.log.Timber.e(e, "Failed to swap player in MediaSession")
         }
+
+        onMediaItemTransition(player.currentMediaItem, Player.MEDIA_ITEM_TRANSITION_REASON_AUTO)
 
         val previousAudioSessionId = fadingPlayer?.audioSessionId ?: C.AUDIO_SESSION_ID_UNSET
 


### PR DESCRIPTION
I have addressed the issue where songs were inconsistently cached when the "crossfade" feature was enabled. 

Key changes include:
1.  **Metadata Recovery:** Updated `recoverSong()` to search for media metadata across all active player instances (`player`, `secondaryPlayer`, and `fadingPlayer`). This ensures that caching and database updates can proceed correctly regardless of which player instance is currently handling the song.
2.  **Transition Synchronization:** Manually triggered `onMediaItemTransition()` during the player swap in `performCrossfadeSwap()`. This ensures that essential initialization logic, such as caching status checks and audio normalization, is executed for every track change during a crossfade.
3.  **Explicit Verification:** Added an explicit call to `recoverSong()` within `onMediaItemTransition()` to perform a final caching status check whenever a new song starts playing.

I verified that the changes compile successfully using `./gradlew :app:assembleFossDebug`.

---
*PR created automatically by Jules for task [5756055750592807592](https://jules.google.com/task/5756055750592807592) started by @mostafaalagamy*