### PR TITLE
fix(playback): only mark songs as cached on real completion, not chunk fetches

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/di/AppModule.kt
+++ b/app/src/main/kotlin/com/metrolist/music/di/AppModule.kt
@@ -8,6 +8,10 @@ package com.metrolist.music.di
 import android.content.Context
 import androidx.media3.database.DatabaseProvider
 import androidx.media3.database.StandaloneDatabaseProvider
+import androidx.media3.datasource.cache.Cache
+import androidx.media3.datasource.cache.CacheSpan
+import androidx.media3.datasource.cache.ContentMetadata
+import androidx.media3.datasource.cache.ContentMetadataMutations
 import androidx.media3.datasource.cache.LeastRecentlyUsedCacheEvictor
 import androidx.media3.datasource.cache.NoOpCacheEvictor
 import androidx.media3.datasource.cache.SimpleCache
@@ -27,7 +31,100 @@ import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import java.io.File
+import java.util.NavigableSet
+import java.util.TreeSet
 import javax.inject.Singleton
+
+private class LazyCache(
+    private val create: () -> SimpleCache,
+) : Cache {
+    private val lock = Any()
+
+    @Volatile private var cache: SimpleCache? = null
+
+    private fun delegate(): SimpleCache = cache ?: synchronized(lock) { cache ?: create().also { cache = it } }
+
+    override fun addListener(
+        key: String,
+        listener: Cache.Listener,
+    ) = delegate().addListener(key, listener)
+
+    override fun removeListener(
+        key: String,
+        listener: Cache.Listener,
+    ) = delegate().removeListener(key, listener)
+
+    override fun getCachedSpans(key: String): NavigableSet<CacheSpan> = delegate().getCachedSpans(key)
+
+    override fun getKeys(): NavigableSet<String> = TreeSet(delegate().keys)
+
+    override fun getCacheSpace(): Long = delegate().cacheSpace
+
+    override fun getUid(): Long = delegate().uid
+
+    override fun getCachedLength(
+        key: String,
+        position: Long,
+        length: Long,
+    ): Long = delegate().getCachedLength(key, position, length)
+
+    override fun getCachedBytes(
+        key: String,
+        position: Long,
+        length: Long,
+    ): Long = delegate().getCachedBytes(key, position, length)
+
+    override fun applyContentMetadataMutations(
+        key: String,
+        mutations: ContentMetadataMutations,
+    ) = delegate().applyContentMetadataMutations(key, mutations)
+
+    override fun getContentMetadata(key: String): ContentMetadata = delegate().getContentMetadata(key)
+
+    override fun startReadWrite(
+        key: String,
+        position: Long,
+        length: Long,
+    ): CacheSpan = delegate().startReadWrite(key, position, length)
+
+    override fun startReadWriteNonBlocking(
+        key: String,
+        position: Long,
+        length: Long,
+    ): CacheSpan? = delegate().startReadWriteNonBlocking(key, position, length)
+
+    override fun startFile(
+        key: String,
+        position: Long,
+        maxLength: Long,
+    ): File = delegate().startFile(key, position, maxLength)
+
+    override fun commitFile(
+        file: File,
+        length: Long,
+    ) = delegate().commitFile(file, length)
+
+    override fun releaseHoleSpan(holeSpan: CacheSpan) = delegate().releaseHoleSpan(holeSpan)
+
+    override fun removeSpan(span: CacheSpan) = delegate().removeSpan(span)
+
+    override fun removeResource(key: String) = delegate().removeResource(key)
+
+    override fun isCached(
+        key: String,
+        position: Long,
+        length: Long,
+    ): Boolean = delegate().isCached(key, position, length)
+
+    override fun release() {
+        val cacheToRelease =
+            synchronized(lock) {
+                cache.also { cache = null }
+            }
+        cacheToRelease?.release()
+    }
+}
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -72,17 +169,20 @@ object AppModule {
     fun providePlayerCache(
         @ApplicationContext context: Context,
         databaseProvider: DatabaseProvider,
-    ): SimpleCache {
-        val cacheSize = context.dataStore[MaxSongCacheSizeKey] ?: 1024
-        return SimpleCache(
-            context.filesDir.resolve("exoplayer"),
-            when (cacheSize) {
-                -1 -> NoOpCacheEvictor()
-                else -> LeastRecentlyUsedCacheEvictor(cacheSize * 1024 * 1024L)
-            },
-            databaseProvider,
-        )
-    }
+    ): Cache =
+        LazyCache {
+            val cacheSize = context.dataStore[MaxSongCacheSizeKey] ?: 1024
+            val evictor =
+                when (cacheSize) {
+                    -1 -> NoOpCacheEvictor()
+                    else -> LeastRecentlyUsedCacheEvictor(cacheSize * 1024 * 1024L)
+                }
+            SimpleCache(
+                context.filesDir.resolve("exoplayer"),
+                evictor,
+                databaseProvider,
+            )
+        }
 
     @Singleton
     @Provides
@@ -90,13 +190,14 @@ object AppModule {
     fun provideDownloadCache(
         @ApplicationContext context: Context,
         databaseProvider: DatabaseProvider,
-    ): SimpleCache {
-        return SimpleCache(
-            context.filesDir.resolve("download"),
-            NoOpCacheEvictor(),
-            databaseProvider
-        )
-    }
+    ): Cache =
+        LazyCache {
+            SimpleCache(
+                context.filesDir.resolve("download"),
+                NoOpCacheEvictor(),
+                databaseProvider,
+            )
+        }
 
     @Singleton
     @Provides

--- a/app/src/main/kotlin/com/metrolist/music/playback/DownloadUtil.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/DownloadUtil.kt
@@ -11,8 +11,8 @@ import androidx.core.content.getSystemService
 import androidx.core.net.toUri
 import androidx.media3.database.DatabaseProvider
 import androidx.media3.datasource.ResolvingDataSource
+import androidx.media3.datasource.cache.Cache
 import androidx.media3.datasource.cache.CacheDataSource
-import androidx.media3.datasource.cache.SimpleCache
 import androidx.media3.datasource.okhttp.OkHttpDataSource
 import androidx.media3.exoplayer.offline.Download
 import androidx.media3.exoplayer.offline.DownloadManager
@@ -54,8 +54,8 @@ constructor(
     @ApplicationContext context: Context,
     val database: MusicDatabase,
     val databaseProvider: DatabaseProvider,
-    @DownloadCache val downloadCache: SimpleCache,
-    @PlayerCache val playerCache: SimpleCache,
+    @DownloadCache val downloadCache: Cache,
+    @PlayerCache val playerCache: Cache,
 ) {
     private val TAG = "DownloadUtil"
     private val connectivityManager = context.getSystemService<ConnectivityManager>()!!
@@ -144,25 +144,20 @@ constructor(
                     ),
                 )
 
-                val now = LocalDateTime.now()
+                // Metadata registration only — dateDownload is intentionally NOT set here.
+                // It belongs solely to onDownloadChanged()'s STATE_COMPLETED branch below,
+                // which only fires once the download has actually finished. Setting it here
+                // (at URL-resolve time, i.e. the moment the download merely *starts*) would
+                // mark the song as "cached" before a single byte is written.
                 val existing = getSongByIdBlocking(mediaId)?.song
-
-                val updatedSong = if (existing != null) {
-                    if (existing.dateDownload == null) {
-                        existing.copy(dateDownload = now)
-                    } else {
-                        existing
-                    }
-                } else {
-                    SongEntity(
-                        id = mediaId,
-                        title = playbackData.videoDetails?.title ?: "Unknown",
-                        duration = playbackData.videoDetails?.lengthSeconds?.toIntOrNull() ?: 0,
-                        thumbnailUrl = playbackData.videoDetails?.thumbnail?.thumbnails?.lastOrNull()?.url,
-                        dateDownload = now,
-                        isDownloaded = false
-                    )
-                }
+                val updatedSong = existing ?: SongEntity(
+                    id = mediaId,
+                    title = playbackData.videoDetails?.title ?: "Unknown",
+                    duration = playbackData.videoDetails?.lengthSeconds?.toIntOrNull() ?: 0,
+                    thumbnailUrl = playbackData.videoDetails?.thumbnail?.thumbnails?.lastOrNull()?.url,
+                    dateDownload = null,
+                    isDownloaded = false
+                )
 
                 upsert(updatedSong)
             }

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -1611,6 +1611,16 @@ class MusicService :
         )
     }
 
+    /**
+     * Registers / refreshes song metadata (title, duration, isVideo, related songs)
+     * for [mediaId]. Pure metadata bookkeeping only — does NOT touch [dateDownload].
+     *
+     * Looks across player, secondaryPlayer and fadingPlayer so metadata is still
+     * found correctly while a crossfade swap is in progress.
+     *
+     * Safe to call frequently (e.g. on every dataSpec resolution) since it no longer
+     * has any side effect tied to caching completeness.
+     */
     private suspend fun recoverSong(
         mediaId: String,
         playbackData: YTPlayerUtils.PlaybackData? = null,
@@ -1619,10 +1629,15 @@ class MusicService :
         val mediaMetadata =
             withContext(Dispatchers.Main) {
                 player.findNextMediaItemById(mediaId)?.metadata
-            } ?: return
+                    ?: secondaryPlayer?.findNextMediaItemById(mediaId)?.metadata
+                    ?: fadingPlayer?.findNextMediaItemById(mediaId)?.metadata
+            }
+
+        if (mediaMetadata == null && song == null) return
+
         val duration =
             song?.song?.duration?.takeIf { it != -1 }
-                ?: mediaMetadata.duration.takeIf { it != -1 }
+                ?: mediaMetadata?.duration?.takeIf { it != -1 }
                 ?: (
                     playbackData?.videoDetails ?: YTPlayerUtils
                         .playerResponseForMetadata(mediaId)
@@ -1630,31 +1645,25 @@ class MusicService :
                         ?.videoDetails
                 )?.lengthSeconds?.toInt()
                 ?: -1
+
         database.query {
-            if (song == null) {
+            if (song == null && mediaMetadata != null) {
                 insert(mediaMetadata.copy(duration = duration))
-            } else {
+            } else if (song != null) {
                 var updatedSong = song.song
                 if (song.song.duration == -1) {
                     updatedSong = updatedSong.copy(duration = duration)
                 }
                 // Update isVideo flag if it's different from the current value
-                if (song.song.isVideo != mediaMetadata.isVideoSong) {
+                if (mediaMetadata != null && song.song.isVideo != mediaMetadata.isVideoSong) {
                     updatedSong = updatedSong.copy(isVideo = mediaMetadata.isVideoSong)
-                }
-                // Set dateDownload when song is cached during playback
-                // This ensures cached songs appear in the Cache Playlist
-                if (updatedSong.dateDownload == null && updatedSong.isDownloaded == false) {
-                    val contentLength = song.format?.contentLength
-                    if (contentLength != null && playerCache.isCached(mediaId, 0, contentLength)) {
-                        updatedSong = updatedSong.copy(dateDownload = java.time.LocalDateTime.now())
-                    }
                 }
                 if (updatedSong != song.song) {
                     update(updatedSong)
                 }
             }
         }
+
         if (!database.hasRelatedSongs(mediaId)) {
             val relatedEndpoint =
                 YouTube.next(WatchEndpoint(videoId = mediaId)).getOrNull()?.relatedEndpoint
@@ -1671,6 +1680,28 @@ class MusicService :
                         )
                     }.forEach(::insert)
             }
+        }
+    }
+
+    /**
+     * Marks [mediaId] as belonging to the Cache Playlist by setting [dateDownload],
+     * but ONLY if the full file (byte 0 through contentLength) is actually present
+     * in playerCache. This must only be called from a genuine "track finished
+     * naturally" signal (see onMediaItemTransition's AUTO-reason handling) —
+     * never from raw dataSpec/chunk resolution, since the player's background
+     * prefetch can finish downloading a short file in seconds, long before the
+     * user has actually listened to it (or even if they skipped away early).
+     *
+     * No-op if already marked downloaded, or if we don't yet know the file's
+     * contentLength (FormatEntity not fetched yet).
+     */
+    private suspend fun markCachedIfFullyDownloaded(mediaId: String) {
+        val song = database.song(mediaId).first() ?: return
+        if (song.song.dateDownload != null || song.song.isDownloaded) return
+        val contentLength = song.format?.contentLength ?: return
+        if (!playerCache.isCached(mediaId, 0, contentLength)) return
+        database.query {
+            update(song.song.copy(dateDownload = java.time.LocalDateTime.now()))
         }
     }
 
@@ -2364,6 +2395,11 @@ class MusicService :
 
     private var previousMediaItemIndex = C.INDEX_UNSET
     private var previousEpisodeId: String? = null
+
+    // Tracks the mediaId that was playing immediately before the current
+    // onMediaItemTransition call, so we can decide whether IT finished
+    // naturally (and is therefore safe to mark as fully cached).
+    private var lastTransitionedMediaId: String? = null
     private var previousEpisodePosition: Long = 0L
 
     /**
@@ -2404,6 +2440,17 @@ class MusicService :
         mediaItem: MediaItem?,
         reason: Int,
     ) {
+        // The track that was playing before this transition only gets marked as
+        // "fully cached" if it advanced AUTOmatically (i.e. it actually finished),
+        // never on a manual skip/seek. lastTransitionedMediaId must be read BEFORE
+        // it gets overwritten below.
+        if (reason == Player.MEDIA_ITEM_TRANSITION_REASON_AUTO) {
+            lastTransitionedMediaId?.let { previousId ->
+                scope.launch(Dispatchers.IO) { markCachedIfFullyDownloaded(previousId) }
+            }
+        }
+        lastTransitionedMediaId = mediaItem?.mediaId
+
         // Save previous episode position if it was an episode
         previousEpisodeId?.let { episodeId ->
             if (previousEpisodePosition > 0) {
@@ -4623,6 +4670,12 @@ class MusicService :
         } catch (e: Exception) {
             timber.log.Timber.e(e, "Failed to swap player in MediaSession")
         }
+
+        // secondaryPlayer was playing this item silently in the background without
+        // `this` attached as a listener, so its real transition into this item never
+        // reached onMediaItemTransition. Re-fire it manually now that the swap is done
+        // so metadata recovery, cache marking, scrobbling, and normalization all run.
+        onMediaItemTransition(player.currentMediaItem, Player.MEDIA_ITEM_TRANSITION_REASON_AUTO)
 
         val previousAudioSessionId = fadingPlayer?.audioSessionId ?: C.AUDIO_SESSION_ID_UNSET
 

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -4204,7 +4204,7 @@ class MusicService :
     ): Int {
         val requiresForegroundPromotion =
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
-                (intent?.action == null || intent.action == ACTION_ALARM_TRIGGER)
+                (intent?.action == ACTION_ALARM_TRIGGER || !::player.isInitialized)
         if (requiresForegroundPromotion && !ensureForegroundWithLatestNotificationOrStop()) {
             return START_NOT_STICKY
         }

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -465,6 +465,11 @@ class MusicService :
     private var consecutivePlaybackErr = 0
     private var retryJob: Job? = null
     private var retryCount = 0
+    // True only when stopOnError() paused playback purely because of a network outage
+    // (waitOnNetworkError exhausting its attempts). Lets triggerRetry() know it's safe —
+    // and necessary — to explicitly resume playback once connectivity returns, rather than
+    // leaving the player "prepared but paused" forever.
+    private var pausedDueToNetworkError = false
     private var silenceSkipJob: Job? = null
 
     // Cached preferences to avoid runBlocking DataStore reads in hot paths
@@ -1478,15 +1483,28 @@ class MusicService :
     private fun waitOnNetworkError() {
         if (waitingForNetworkConnection.value) return
 
+        // Always arm the reconnect listener (connectivityObserver.networkStatus.collect)
+        // before anything else can return early. Previously, hitting MAX_RETRY_COUNT while
+        // still offline called stopOnError() and returned WITHOUT setting
+        // waitingForNetworkConnection = true. That meant the "isConnected && waitingFor...
+        // -> triggerRetry()" listener never fired once the network actually came back —
+        // the player was left paused in a post-error state, and since ExoPlayer requires an
+        // explicit prepare() after a fatal error before play() does anything, no song would
+        // play again until the app was killed and relaunched (which recreates the player).
+        waitingForNetworkConnection.value = true
+        pausedDueToNetworkError = false
+
         // Check if we've exceeded max retry attempts
         if (retryCount >= MAX_RETRY_COUNT) {
-            Timber.tag(TAG).w("Max retry count ($MAX_RETRY_COUNT) reached, stopping playback")
+            Timber.tag(TAG).w("Max retry count ($MAX_RETRY_COUNT) reached, pausing until network returns")
+            pausedDueToNetworkError = true
             stopOnError()
             retryCount = 0
+            // Don't schedule another backoff job — we're out of attempts for now — but stay
+            // "waiting" so the connectivity listener can still auto-resume on reconnect.
+            retryJob?.cancel()
             return
         }
-
-        waitingForNetworkConnection.value = true
 
         // Start a retry timer with exponential backoff
         retryJob?.cancel()
@@ -1501,12 +1519,17 @@ class MusicService :
                     retryCount++
                     triggerRetry()
                 }
+                // If still offline when the timer fires, just let the job end — we stay
+                // "waiting" and the connectivityObserver listener (not this job) is what
+                // will catch the eventual reconnection and call triggerRetry().
             }
     }
 
     private fun triggerRetry() {
         waitingForNetworkConnection.value = false
         retryJob?.cancel()
+        val shouldResumePlayback = pausedDueToNetworkError
+        pausedDueToNetworkError = false
 
         if (player.currentMediaItem != null) {
             // After 3+ failed retries, try to refresh the stream URL by seeking to current position
@@ -1517,8 +1540,16 @@ class MusicService :
                 player.seekTo(player.currentMediaItemIndex, currentPosition)
             }
             player.prepare()
-            // Don't call play() here - let the player auto-resume via playWhenReady
-            // This avoids stealing audio focus during retry attempts
+            if (shouldResumePlayback) {
+                // We explicitly paused this ourselves (stopOnError) purely because of the
+                // network outage — playWhenReady is now false, so prepare() alone would just
+                // sit there "ready but paused" until the user manually pressed play again on
+                // this exact item. Resume explicitly so reconnecting actually resumes audio.
+                player.playWhenReady = true
+            }
+            // Otherwise (we never force-paused), leave playWhenReady as-is and let the
+            // player auto-resume on its own — this avoids stealing audio focus on ordinary
+            // mid-stream retries where the user never lost the "should be playing" intent.
         }
     }
 

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -3647,17 +3647,36 @@ class MusicService :
 
             if (!shouldBypassCache) {
                 val usePlayerCache = dataStore.get(EnableSongCacheKey, true)
-                if (downloadCache.isCached(
-                        mediaId,
-                        dataSpec.position,
-                        if (dataSpec.length >= 0) dataSpec.length else 1,
-                    )
-                ) {
+
+                // How much we actually need to verify depends on what the player asked for.
+                // dataSpec.length is usually C.LENGTH_UNSET (-1) on a seek/initial open — that
+                // means "read to end of file", not "read 1 byte". Checking only a small fixed
+                // window (1 byte, or one CHUNK_LENGTH) from dataSpec.position was the bug: it
+                // can say "cached!" even though there's a gap further along (from partial
+                // crossfade prefetch, or LeastRecentlyUsedCacheEvictor reclaiming old spans).
+                // When the player then reads into that gap mid-stream, CacheDataSource has no
+                // resolved URL to fall back to (we deliberately returned dataSpec bare), so it
+                // fails with a generic IO error that surfaces to the user as "No network
+                // connection" — even with a perfectly fine connection, and even on a fully
+                // "cached" song. Verifying coverage all the way to end-of-file (when we know
+                // contentLength) removes that false positive.
+                val contentLength =
+                    runBlocking(Dispatchers.IO) {
+                        database.song(mediaId).first()?.format?.contentLength
+                    }
+                val requiredLength =
+                    when {
+                        dataSpec.length >= 0 -> dataSpec.length
+                        contentLength != null -> (contentLength - dataSpec.position).coerceAtLeast(1)
+                        else -> CHUNK_LENGTH // contentLength unknown yet — fall back to old probe size
+                    }
+
+                if (downloadCache.isCached(mediaId, dataSpec.position, requiredLength)) {
                     scope.launch(Dispatchers.IO) { recoverSong(mediaId) }
                     return@Factory dataSpec
                 }
 
-                if (usePlayerCache && playerCache.isCached(mediaId, dataSpec.position, CHUNK_LENGTH)) {
+                if (usePlayerCache && playerCache.isCached(mediaId, dataSpec.position, requiredLength)) {
                     // Serve cached audio straight from disk like the download cache — no URL needed,
                     // no network re-resolve. On a cold relaunch songUrlCache is always empty, and the
                     // old "ghost" path here deleted valid cached audio and re-downloaded it every

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -57,9 +57,9 @@ import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.HttpDataSource
 import androidx.media3.datasource.ResolvingDataSource
+import androidx.media3.datasource.cache.Cache
 import androidx.media3.datasource.cache.CacheDataSource
 import androidx.media3.datasource.cache.CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR
-import androidx.media3.datasource.cache.SimpleCache
 import androidx.media3.datasource.okhttp.OkHttpDataSource
 import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.DefaultRenderersFactory
@@ -377,11 +377,11 @@ class MusicService :
 
     @Inject
     @PlayerCache
-    lateinit var playerCache: SimpleCache
+    lateinit var playerCache: Cache
 
     @Inject
     @DownloadCache
-    lateinit var downloadCache: SimpleCache
+    lateinit var downloadCache: Cache
 
     lateinit var player: ExoPlayer
         private set

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/CachePlaylistViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/CachePlaylistViewModel.kt
@@ -8,7 +8,7 @@ package com.metrolist.music.viewmodels
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.media3.datasource.cache.SimpleCache
+import androidx.media3.datasource.cache.Cache
 import com.metrolist.music.constants.HideExplicitKey
 import com.metrolist.music.constants.HideVideoSongsKey
 import com.metrolist.music.db.MusicDatabase
@@ -25,7 +25,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import java.time.LocalDateTime
 import javax.inject.Inject
 
 @HiltViewModel
@@ -34,8 +33,8 @@ class CachePlaylistViewModel
     constructor(
         @ApplicationContext private val context: Context,
         private val database: MusicDatabase,
-        @PlayerCache private val playerCache: SimpleCache,
-        @DownloadCache private val downloadCache: SimpleCache,
+        @PlayerCache private val playerCache: Cache,
+        @DownloadCache private val downloadCache: Cache,
     ) : ViewModel() {
         private val _cachedSongs = MutableStateFlow<List<Song>>(emptyList())
         val cachedSongs: StateFlow<List<Song>> = _cachedSongs
@@ -45,36 +44,46 @@ class CachePlaylistViewModel
                 while (true) {
                     val hideExplicit = context.dataStore.get(HideExplicitKey, false)
                     val hideVideoSongs = context.dataStore.get(HideVideoSongsKey, false)
-                    val cachedIds = playerCache.keys.toSet()
-                    val downloadedIds = downloadCache.keys.toSet()
-                    val pureCacheIds = cachedIds.subtract(downloadedIds)
 
+                    // Candidate set: anything currently present in either cache. We no longer
+                    // SET dateDownload here — that decision belongs solely to MusicService's
+                    // markCachedIfFullyDownloaded(), which only fires once a track actually
+                    // finishes playing naturally (MEDIA_ITEM_TRANSITION_REASON_AUTO). This loop
+                    // only displays already-flagged songs and self-heals: if a song's dateDownload
+                    // is set but its backing cache data is gone now (evicted, or manually removed
+                    // via removeSongFromCache), the flag gets cleared so the list — and the DB —
+                    // stay honest.
+                    val candidateIds = playerCache.keys.toSet() + downloadCache.keys.toSet()
                     val songs =
-                        if (pureCacheIds.isNotEmpty()) {
-                            database.getSongsByIds(pureCacheIds.toList())
+                        if (candidateIds.isNotEmpty()) {
+                            database.getSongsByIds(candidateIds.toList())
                         } else {
                             emptyList()
                         }
 
-                    val completeSongs =
-                        songs.filter {
-                            val contentLength = it.format?.contentLength
-                            contentLength != null && playerCache.isCached(it.song.id, 0, contentLength)
-                        }
+                    val flagged = songs.filter { it.song.dateDownload != null }
+                    val stillValid = mutableListOf<Song>()
 
-                    if (completeSongs.isNotEmpty()) {
-                        database.query {
-                            completeSongs.forEach {
-                                if (it.song.dateDownload == null) {
-                                    update(it.song.copy(dateDownload = LocalDateTime.now()))
-                                }
-                            }
+                    for (song in flagged) {
+                        val contentLength = song.format?.contentLength
+                        val stillCached =
+                            song.song.isDownloaded ||
+                                (
+                                    contentLength != null &&
+                                        (
+                                            downloadCache.isCached(song.song.id, 0, contentLength) ||
+                                                playerCache.isCached(song.song.id, 0, contentLength)
+                                        )
+                                )
+                        if (stillCached) {
+                            stillValid += song
+                        } else {
+                            database.query { update(song.song.copy(dateDownload = null)) }
                         }
                     }
 
                     _cachedSongs.value =
-                        completeSongs
-                            .filter { it.song.dateDownload != null }
+                        stillValid
                             .sortedByDescending { it.song.dateDownload }
                             .filterExplicit(hideExplicit)
                             .filterVideoSongs(hideVideoSongs)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback reliability during network errors with smarter retry handling that preserves audio focus.
  * Fixed cache accuracy issues to prevent false "cached" status and reduce playback gaps.
  * Enhanced metadata recovery during playback transitions and crossfades.

* **Improvements**
  * Refined cache playlist tracking to only mark songs as cached when fully downloaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->