### PR TITLE
fix(playback): handle ERROR_CODE_REMOTE_ERROR with stream URL refresh instead of generic retry

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -2970,6 +2970,9 @@ class MusicService :
         error.errorCode == PlaybackException.ERROR_CODE_IO_FILE_NOT_FOUND ||
             (error.cause as? PlaybackException)?.errorCode == PlaybackException.ERROR_CODE_IO_FILE_NOT_FOUND
 
+    private fun isRemotePlaybackError(error: PlaybackException): Boolean =
+        error.errorCode == PlaybackException.ERROR_CODE_REMOTE_ERROR
+
     override fun onPlayerError(error: PlaybackException) {
         super.onPlayerError(error)
 
@@ -3027,6 +3030,12 @@ class MusicService :
             isFileNotFoundError(error) -> {
                 Timber.tag(TAG).d("Cache file missing (ENOENT) detected, refreshing stream")
                 handleFileNotFoundError(mediaId)
+                return
+            }
+
+            isRemotePlaybackError(error) -> {
+                Timber.tag(TAG).d("Remote playback error detected (${error.errorCode}), refreshing stream URL")
+                handleExpiredUrlError(mediaId)
                 return
             }
 

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/PlaybackError.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/PlaybackError.kt
@@ -52,9 +52,18 @@ fun PlaybackError(
             rawErrorMessage.contains("403", ignoreCase = true) ||
             rawErrorMessage.contains("Response code: 403", ignoreCase = true) ||
             error.errorCode == PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS
+
+    // Check if this is a "job cancelled" error from YouTube
+    // YouTube returns this when the playback job cannot be started (often transient)
+    val isJobCancelled = rawErrorMessage.contains("job", ignoreCase = true) &&
+            (rawErrorMessage.contains("cancelled", ignoreCase = true) ||
+                    rawErrorMessage.contains("canceled", ignoreCase = true) ||
+                    rawErrorMessage.contains("cancellat", ignoreCase = true))
     
     val errorMessage = if (isAgeRestricted) {
         "This app does not support playing age-restricted songs. We are working on fixing this issue."
+    } else if (isJobCancelled) {
+        "The video is not available for playback. Try again or skip to the next song."
     } else {
         rawErrorMessage
     }

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/PlaybackError.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/PlaybackError.kt
@@ -63,7 +63,7 @@ fun PlaybackError(
     val errorMessage = if (isAgeRestricted) {
         "This app does not support playing age-restricted songs. We are working on fixing this issue."
     } else if (isJobCancelled) {
-        "The video is not available for playback. Try again or skip to the next song."
+        stringResource(R.string.error_job_cancelled)
     } else {
         rawErrorMessage
     }

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -548,6 +548,7 @@
 
     <!-- Playback errors -->
     <string name="error_playback_failed">Playback failed</string>
+    <string name="error_job_cancelled">The video is not available for playback. Try again or skip to the next song.</string>
     <string name="error_episode_save">Failed to save episode</string>
     <string name="error_episode_remove">Failed to remove episode</string>
     <string name="error_podcast_subscribe">Failed to subscribe to podcast</string>


### PR DESCRIPTION
## Problem
ExoPlayer ERROR_CODE_REMOTE_ERROR silently stops playback without retry, leaving the user on a stuck track.

## Cause
The onPlayerError handler did not recognize REMOTE_ERROR codes and fell through to stopOnError. Additionally, the generic retry handleGenericIOError does not invalidate the cached stream URL, so retrying with an expired URL fails again.

## Solution
Added isRemotePlaybackError check in onPlayerError that calls handleExpiredUrlError, which clears the cached stream URL, marks WEB_REMIX as failed, refreshes cipher config, and retries playback. This gives a structural recovery instead of a blind retry.

## Testing
Tested on emulator with network interruptions triggering remote errors, verified retry fires with fresh URL resolution.

## Related Issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Improved error handling and recovery mechanisms for remote playback connection failures, allowing the app to gracefully manage interrupted streams
* Enhanced detection and user-facing error messaging when videos become unavailable for playback, with clear guidance to retry or skip to the next song
<!-- end of auto-generated comment: release notes by coderabbit.ai -->