### PR TITLE
fix(ui): inline duration with artist name instead of right-aligning with weight(1f)

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
@@ -285,7 +285,6 @@ fun ClickableArtistText(
     )
 }
 
-// Basic list item - optimized with inline to reduce recomposition
 @Composable
 inline fun ListItem(
     modifier: Modifier = Modifier,
@@ -403,7 +402,6 @@ fun ListItem(
     isActive = isActive
 )
 
-// merge badges and subtitle text and pass to basic list item
 @Composable
 fun ListItem(
     modifier: Modifier = Modifier,
@@ -555,28 +553,19 @@ fun SongListItem(
          ListItem(
              title = song.song.title,
              subtitle = {
-                 badges()
-                 if (subtitleOverride == null) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Text(
-                            text = song.orderedArtists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name },
-                            style = MaterialTheme.typography.bodySmall.copy(color = MaterialTheme.colorScheme.secondary),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            modifier = Modifier.weight(1f)
-                        )
-                        val durationText = makeTimeString(song.song.duration * 1000L)
-                        if (durationText.isNotEmpty()) {
-                            Text(
-                                text = " • $durationText",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.secondary,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                            )
-                        }
-                    }
-                 } else {
+                  badges()
+                  if (subtitleOverride == null) {
+                      Text(
+                          text = joinByBullet(
+                              song.orderedArtists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name },
+                              makeTimeString(song.song.duration * 1000L)
+                          ),
+                          style = MaterialTheme.typography.bodySmall,
+                          color = MaterialTheme.colorScheme.secondary,
+                          maxLines = 1,
+                          overflow = TextOverflow.Ellipsis,
+                      )
+                  } else {
                      Text(
                          text = subtitleOverride,
                          style = MaterialTheme.typography.bodySmall,
@@ -650,28 +639,16 @@ fun SongGridItem(
         )
     },
     subtitle = {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            Text(
-                text = song.orderedArtists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name },
-                style = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.secondary),
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.weight(1f)
-            )
-            val durationText = makeTimeString(song.song.duration * 1000L)
-            if (durationText.isNotEmpty()) {
-                Text(
-                    text = durationText,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.secondary,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
-        }
+        Text(
+            text = joinByBullet(
+                song.orderedArtists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name },
+                makeTimeString(song.song.duration * 1000L)
+            ),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.secondary,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
     },
     badges = badges,
     thumbnailContent = {
@@ -811,22 +788,17 @@ fun AlbumListItem(
     title = album.album.title,
     subtitle = {
         badges()
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Text(
-                text = album.artists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name },
-                style = MaterialTheme.typography.bodySmall.copy(color = MaterialTheme.colorScheme.secondary),
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.weight(1f)
-            )
-            Text(
-                text = " • ${pluralStringResource(R.plurals.n_song, album.album.songCount, album.album.songCount)}${album.album.year?.let { " • $it" } ?: ""}",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.secondary,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        }
+        Text(
+            text = joinByBullet(
+                album.artists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name },
+                pluralStringResource(R.plurals.n_song, album.album.songCount, album.album.songCount),
+                album.album.year?.toString()
+            ),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.secondary,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
     },
     thumbnailContent = {
         ItemThumbnail(
@@ -1133,41 +1105,25 @@ fun MediaMetadataListItem(
         title = mediaMetadata.title,
         subtitle = {
             if (mediaMetadata.explicit) Icon.Explicit()
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(
-                    text = mediaMetadata.artists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name },
-                    style = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.secondary),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f)
-                )
-                val durationText = makeTimeString(mediaMetadata.duration * 1000L)
-                if (durationText.isNotEmpty()) {
-                    Text(
-                        text = " • $durationText",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.secondary,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
+            Text(
+                text = buildAnnotatedString {
+                    append(
+                        joinByBullet(
+                            mediaMetadata.artists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name },
+                            makeTimeString(mediaMetadata.duration * 1000L)
+                        )
                     )
-                }
-                if (mediaMetadata.suggestedBy != null) {
-                    Text(
-                        text = " • ",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.secondary,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                    Text(
-                        text = mediaMetadata.suggestedBy,
-                        style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold),
-                        color = MaterialTheme.colorScheme.secondary,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
-            }
+                    if (mediaMetadata.suggestedBy != null) {
+                        append(" • ")
+                        withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
+                            append(mediaMetadata.suggestedBy)
+                        }
+                    }
+                },
+                style = MaterialTheme.typography.bodyMedium.copy(color = MaterialTheme.colorScheme.secondary),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
         },
         thumbnailContent = {
             ItemThumbnail(

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
@@ -1107,13 +1107,12 @@ fun MediaMetadataListItem(
             if (mediaMetadata.explicit) Icon.Explicit()
             Text(
                 text = buildAnnotatedString {
-                    append(
-                        joinByBullet(
-                            mediaMetadata.artists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name },
-                            makeTimeString(mediaMetadata.duration * 1000L)
-                        )
+                    val base = joinByBullet(
+                        mediaMetadata.artists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name },
+                        makeTimeString(mediaMetadata.duration * 1000L)
                     )
-                    if (mediaMetadata.suggestedBy != null) {
+                    append(base)
+                    if (mediaMetadata.suggestedBy != null && base.isNotEmpty()) {
                         append(" • ")
                         withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
                             append(mediaMetadata.suggestedBy)


### PR DESCRIPTION
## Problem
In SongListItem, SongGridItem, AlbumListItem and MediaMetadataListItem, the duration text is pushed to the right edge of the row because the artist name uses weight(1f). This creates visual gaps like "maneskin                • 3:20" instead of inline "maneskin • 3:20".

## Cause
The subtitle Row used weight(1f) on the artist text to make room for clickable artist links. When clickable artists were removed, the weight stayed, keeping the layout broken.

## Solution
Replaced the Row+weight(1f) layout with joinByBullet which combines artist name, duration and metadata into a single inline string that truncates naturally.

## Testing
Built and verified on emulator: subtitle now shows "artist • 3:20" without right-aligned gaps.

## Related Issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified subtitle composition and display logic across music list and grid items.
  * Song grid item subtitles now display up to 2 lines instead of 1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->