### PR TITLE
Fix: Song duration not showing in artist top songs section

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/db/entities/ArtistPageCache.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/ArtistPageCache.kt
@@ -202,7 +202,7 @@ private fun CachedItem.toYTItem(): YTItem {
             explicit = explicit,
             artists = artists.map { com.metrolist.innertube.models.Artist(it.name, it.id) },
             album = album?.let { com.metrolist.innertube.models.Album(it.name, it.id) },
-            duration = duration ?: 0,
+            duration = duration,
             setVideoId = videoId,
         )
         is CachedItem.Album -> AlbumItem(

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/ArtistViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/ArtistViewModel.kt
@@ -157,6 +157,7 @@ class ArtistViewModel @Inject constructor(
                     fun com.metrolist.innertube.models.Artist.resolve() =
                         if (id == null) resolvedIdMap[name]?.let { copy(id = it) } ?: this else this
 
+                    // Resolve artist IDs and fetch durations from more endpoint
                     val resolvedSections = page.sections.map { section ->
                         section.copy(items = section.items.map { item ->
                             when (item) {
@@ -169,7 +170,40 @@ class ArtistViewModel @Inject constructor(
                             }
                         })
                     }
-                    val resolvedPage = page.copy(sections = resolvedSections)
+
+                    // Fetch song durations from the more endpoint if the first section has songs without duration
+                    val sectionsWithDurations = if (resolvedSections.isNotEmpty()) {
+                        val needDurations = resolvedSections.first().items.any {
+                            it is SongItem && it.duration == null
+                        }
+                        if (needDurations) {
+                            val moreEndpoint = resolvedSections.first().moreEndpoint
+                            if (moreEndpoint != null) {
+                                try {
+                                    val moreItems = withContext(Dispatchers.IO) {
+                                        YouTube.artistItems(moreEndpoint).getOrNull()
+                                    }
+                                    if (moreItems != null) {
+                                        val durationById = moreItems.items.filterIsInstance<SongItem>()
+                                            .associate { it.id to it.duration }
+                                        if (durationById.isNotEmpty()) {
+                                            listOf(resolvedSections.first().copy(
+                                                items = resolvedSections.first().items.map { item ->
+                                                    if (item is SongItem && item.duration == null) {
+                                                        item.copy(duration = durationById[item.id] ?: item.duration)
+                                                    } else item
+                                                }
+                                            )) + resolvedSections.drop(1)
+                                        } else resolvedSections
+                                    } else resolvedSections
+                                } catch (e: Exception) {
+                                    resolvedSections
+                                }
+                            } else resolvedSections
+                        } else resolvedSections
+                    } else resolvedSections
+
+                    val resolvedPage = page.copy(sections = sectionsWithDurations)
                     val filteredSections = resolvedPage.sections
                         .map { section ->
                             section.copy(items = section.items.filterExplicit(hideExplicit).filterVideoSongs(hideVideoSongs).filterYoutubeShorts(hideYoutubeShorts))

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/ArtistViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/ArtistViewModel.kt
@@ -172,7 +172,8 @@ class ArtistViewModel @Inject constructor(
                     }
 
                     // Fetch song durations from the more endpoint if the first section has songs without duration
-                    val sectionsWithDurations = if (resolvedSections.isNotEmpty()) {
+                    var sectionsWithDurations = resolvedSections
+                    if (resolvedSections.isNotEmpty()) {
                         val needDurations = resolvedSections.first().items.any {
                             it is SongItem && it.duration == null
                         }
@@ -180,28 +181,30 @@ class ArtistViewModel @Inject constructor(
                             val moreEndpoint = resolvedSections.first().moreEndpoint
                             if (moreEndpoint != null) {
                                 try {
-                                    val moreItems = withContext(Dispatchers.IO) {
-                                        YouTube.artistItems(moreEndpoint).getOrNull()
+                                    val moreResult = withContext(Dispatchers.IO) {
+                                        YouTube.artistItems(moreEndpoint)
                                     }
-                                    if (moreItems != null) {
-                                        val durationById = moreItems.items.filterIsInstance<SongItem>()
-                                            .associate { it.id to it.duration }
-                                        if (durationById.isNotEmpty()) {
-                                            listOf(resolvedSections.first().copy(
-                                                items = resolvedSections.first().items.map { item ->
-                                                    if (item is SongItem && item.duration == null) {
-                                                        item.copy(duration = durationById[item.id] ?: item.duration)
-                                                    } else item
-                                                }
-                                            )) + resolvedSections.drop(1)
-                                        } else resolvedSections
-                                    } else resolvedSections
+                                    moreResult
+                                        .onSuccess { moreItems ->
+                                            val durationById = moreItems.items.filterIsInstance<SongItem>()
+                                                .associate { it.id to it.duration }
+                                            if (durationById.isNotEmpty()) {
+                                                sectionsWithDurations = listOf(resolvedSections.first().copy(
+                                                    items = resolvedSections.first().items.map { item ->
+                                                        if (item is SongItem && item.duration == null) {
+                                                            item.copy(duration = durationById[item.id] ?: item.duration)
+                                                        } else item
+                                                    }
+                                                )) + resolvedSections.drop(1)
+                                            }
+                                        }
+                                        .onFailure { e -> reportException(e) }
                                 } catch (e: Exception) {
-                                    resolvedSections
+                                    reportException(e)
                                 }
-                            } else resolvedSections
-                        } else resolvedSections
-                    } else resolvedSections
+                            }
+                        }
+                    }
 
                     val resolvedPage = page.copy(sections = sectionsWithDurations)
                     val filteredSections = resolvedPage.sections

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/ArtistPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/ArtistPage.kt
@@ -141,6 +141,7 @@ data class ArtistPage(
                     val artistRuns = expandedRuns.filter { 
                         it.text.isNotBlank() && it.text != "&" && it.text != "," 
                     }
+                    val subtitleGroups = subtitleRuns.splitBySeparator()
                     SongItem(
                         id = renderer.navigationEndpoint.watchEndpoint?.videoId ?: return null,
                         title = renderer.title.runs?.firstOrNull()?.text ?: return null,
@@ -151,7 +152,10 @@ data class ArtistPage(
                             )
                         }.ifEmpty { null } ?: return null,
                         album = null,
-                        duration = null,
+                        duration = subtitleGroups.lastOrNull()
+                            ?.firstOrNull()
+                            ?.takeIf { it.navigationEndpoint == null }
+                            ?.text?.parseTime(),
                         musicVideoType = renderer.musicVideoType,
                         thumbnail = renderer.thumbnailRenderer.musicThumbnailRenderer?.getThumbnailUrl() ?: return null,
                         explicit = renderer.subtitleBadges?.find {

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/ArtistPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/ArtistPage.kt
@@ -72,12 +72,15 @@ data class ArtistPage(
         }
 
         private fun fromMusicResponsiveListItemRenderer(renderer: MusicResponsiveListItemRenderer): SongItem? {
-            val artistRuns = renderer.flexColumns
+            val subtitleLine = renderer.flexColumns
                 .getOrNull(1)
                 ?.musicResponsiveListItemFlexColumnRenderer
                 ?.text
                 ?.runs
-                ?.splitBySeparator()
+
+            val subtitleGroups = subtitleLine?.splitBySeparator()
+
+            val artistRuns = subtitleGroups
                 ?.getOrNull(0)
                 ?.splitArtistsByConjunction()
                 ?.filter { it.text.isNotBlank() && it.text != "&" && it.text != "," }
@@ -99,6 +102,16 @@ data class ArtistPage(
                     } else null
                 }
 
+            // Duration is in the last group after "•" separator in the subtitle line
+            val durationFromSubtitle = subtitleGroups
+                ?.drop(1)
+                ?.firstOrNull { group ->
+                    group.firstOrNull()?.text?.parseTime() != null
+                }
+                ?.firstOrNull()
+                ?.text
+                ?.parseTime()
+
             val libraryTokens = PageHelper.extractLibraryTokensFromMenuItems(renderer.menu?.menuRenderer?.items)
 
             return SongItem(
@@ -117,10 +130,11 @@ data class ArtistPage(
                     ?.text ?: return null,
                 artists = artistRuns ?: return null,
                 album = album,
-                duration = renderer.fixedColumns?.firstOrNull()
-                    ?.musicResponsiveListItemFlexColumnRenderer?.text
-                    ?.runs?.firstOrNull()
-                    ?.text?.parseTime(),
+                duration = durationFromSubtitle
+                    ?: renderer.fixedColumns?.firstOrNull()
+                        ?.musicResponsiveListItemFlexColumnRenderer?.text
+                        ?.runs?.firstOrNull()
+                        ?.text?.parseTime(),
                 musicVideoType = renderer.musicVideoType,
                 thumbnail = renderer.thumbnail?.musicThumbnailRenderer?.getThumbnailUrl() ?: return null,
                 explicit = renderer.badges?.find {

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/ArtistPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/ArtistPage.kt
@@ -16,6 +16,7 @@ import com.metrolist.innertube.models.Run
 import com.metrolist.innertube.models.SectionListRenderer
 import com.metrolist.innertube.models.SongItem
 import com.metrolist.innertube.models.WatchEndpoint
+import com.metrolist.innertube.utils.parseTime
 import com.metrolist.innertube.models.YTItem
 import com.metrolist.innertube.models.filterExplicit
 import com.metrolist.innertube.models.getItems
@@ -116,7 +117,10 @@ data class ArtistPage(
                     ?.text ?: return null,
                 artists = artistRuns ?: return null,
                 album = album,
-                duration = null,
+                duration = renderer.fixedColumns?.firstOrNull()
+                    ?.musicResponsiveListItemFlexColumnRenderer?.text
+                    ?.runs?.firstOrNull()
+                    ?.text?.parseTime(),
                 musicVideoType = renderer.musicVideoType,
                 thumbnail = renderer.thumbnail?.musicThumbnailRenderer?.getThumbnailUrl() ?: return null,
                 explicit = renderer.badges?.find {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved song duration accuracy on artist pages by parsing durations from list subtitle text and filling in missing durations using an additional artist data source when available.
  * Cached items now preserve “unknown” durations instead of defaulting them, preventing incorrect duration values from appearing in the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->