### PR TITLE
Fix ANR: ensure startForeground() is called promptly in MusicService

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -604,6 +604,15 @@ class MusicService :
 
         playerInitialized.value = false
 
+        // Call startForeground() as early as possible to satisfy the
+        // 5-second timeout imposed by Context.startForegroundService().
+        // On some OEMs (e.g. MIUI), even a DataStore read can be slow
+        // enough to miss the window, so we promote before any I/O.
+        ensureForegroundChannelExists()
+        if (!ensureStartedAsForegroundOrStop()) {
+            return
+        }
+
         // Read ALL startup preferences in one shot so that subsequent code
         // never calls dataStore.get() (which does runBlocking internally).
         // This consolidates ~15 main-thread-blocking DataStore reads into 1.
@@ -613,10 +622,6 @@ class MusicService :
         // handled in createExoPlayer
 
         seedLoudnessCacheFromPrefs()
-
-        if (!ensureStartedAsForegroundOrStop()) {
-            return
-        }
 
         val defaultMediaNotificationProvider =
             DefaultMediaNotificationProvider(
@@ -4126,11 +4131,14 @@ class MusicService :
         flags: Int,
         startId: Int,
     ): Int {
-        val requiresForegroundPromotion =
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
-                (intent?.action == ACTION_ALARM_TRIGGER || !::player.isInitialized)
-        if (requiresForegroundPromotion && !ensureForegroundWithLatestNotificationOrStop()) {
-            return START_NOT_STICKY
+        // On Android O+, every startForegroundService() call requires
+        // Service.startForeground() to be called within a short timeout.
+        // Some OEMs (e.g. MIUI) strictly enforce this even when the
+        // service is already in the foreground, so always promote here.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            if (!ensureForegroundWithLatestNotificationOrStop()) {
+                return START_NOT_STICKY
+            }
         }
 
         when (intent?.action) {


### PR DESCRIPTION
## Problem

ANR crash on MIUI and other strict Android OEMs:

```
Reason: Context.startForegroundService() did not then call Service.startForeground()
```

The ANR occurs because:
1. In `onCreate()`, `startForeground()` was called **after** a blocking DataStore read (`runBlocking(Dispatchers.IO) { dataStore.data.first() }`). On slow I/O, this can exceed the 5-second timeout window.
2. In `onStartCommand()`, foreground promotion was conditional — it only called `startForeground()` for alarm triggers or when the player wasn't initialized. Some OEMs strictly enforce `startForeground()` even when `startForegroundService()` is called on an already-running service.

## Fix

1. **Move `ensureStartedAsForegroundOrStop()` before the DataStore read** in `onCreate()` so `startForeground()` is called as early as possible, before any I/O-bound initialization.

2. **Always ensure foreground in `onStartCommand()` on Android O+** — removed the conditional guard so every `onStartCommand()` call triggers foreground promotion, preventing the ANR on all code paths.

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification handling and service reliability for background music playback on Android devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->