### PR TITLE
fix(album): show performing artist instead of label on art-track albums

### DIFF
--- a/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
@@ -501,17 +501,32 @@ object YouTube {
                                 ?.url!!,
                         explicit = false, // TODO: Extract explicit badge for albums from YouTube response
                     )
+                val albumSongsList =
+                    if (withSongs) {
+                        albumSongs(
+                            playlistId,
+                            albumItem,
+                        ).getOrThrow()
+                    } else {
+                        emptyList()
+                    }
+                // When YouTube credits the album to a label/distributor channel (the header
+                // strapline) but every track names the same performing artist, surface the
+                // performer as the album artist instead of the label.
+                val performer =
+                    albumSongsList.firstOrNull()?.artists?.firstOrNull()?.takeIf { first ->
+                        first.name.isNotBlank() &&
+                            albumSongsList.all { it.artists.firstOrNull()?.name == first.name }
+                    }
+                val resolvedAlbum =
+                    if (performer != null && albumItem.artists?.any { it.name == performer.name } != true) {
+                        albumItem.copy(artists = listOf(performer))
+                    } else {
+                        albumItem
+                    }
                 return@runCatching AlbumPage(
-                    album = albumItem,
-                    songs =
-                        if (withSongs) {
-                            albumSongs(
-                                playlistId,
-                                albumItem,
-                            ).getOrThrow()
-                        } else {
-                            emptyList()
-                        },
+                    album = resolvedAlbum,
+                    songs = albumSongsList,
                     otherVersions =
                         response.contents.twoColumnBrowseResultsRenderer.secondaryContents
                             ?.sectionListRenderer

--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/AlbumPage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/AlbumPage.kt
@@ -101,8 +101,18 @@ data class AlbumPage(
                         id = it.navigationEndpoint?.browseEndpoint?.browseId
                     )
                 }.ifEmpty {
-                    // Fallback to album artists if no artists found in song data
-                    album?.artists ?: emptyList()
+                    // Label-uploaded albums (e.g. "OLAK5uy_…" art tracks) name the performing
+                    // artist as a plain-text run with no artist link, while the album header
+                    // strapline is the record label / distributor channel. Prefer that
+                    // plain-text artist over inheriting the label as the track artist.
+                    renderer.flexColumns.getOrNull(1)
+                        ?.musicResponsiveListItemFlexColumnRenderer?.text?.runs
+                        ?.splitBySeparator()?.firstOrNull()?.oddElements()
+                        ?.map { Artist(name = it.text, id = it.navigationEndpoint?.browseEndpoint?.browseId) }
+                        ?.filter { it.name.isNotBlank() }
+                        ?.takeIf { it.isNotEmpty() }
+                    // Final fallback: inherit the album artist when the row has no artist at all.
+                        ?: album?.artists ?: emptyList()
                 },
                 album = album?.let {
                     Album(it.title, it.browseId)


### PR DESCRIPTION
## Problem

Auto-generated "art track" album releases (the albums that `OLAK5uy_…` playlist links resolve to) are credited by YouTube Music to the uploading **label / distributor channel** in the album header `straplineTextOne`, not to the performing artist. The performing artist appears only on the individual tracks, as a plain-text run with no artist navigation link.

`AlbumPage.getSong()` extracted track artists solely via `extractRuns(flexColumns, "MUSIC_PAGE_TYPE_ARTIST")`, which keeps only runs that carry an artist link. For these releases nothing matches, so it fell through to `album?.artists` — the label. As a result every track **and** the album header showed the label (e.g. "Music Trend") instead of the performer (e.g. "Amir Eid").

Example: `https://music.youtube.com/playlist?list=OLAK5uy_krW0VC_iST9CwjsHc0Cr6PJ_ffYH6Knqo` — album *Rivo*, credited to "Music Trend", performed by "Amir Eid".

## Fix

- **`AlbumPage.getSong()`** — before inheriting the album artist, fall back to the plain-text artist run in `flexColumns[1]` (`splitBySeparator().firstOrNull().oddElements()`, the same parse the playlist page already uses).
- **`YouTube.album()`** — when every track shares one performing artist, surface it as the album artist instead of the label strapline.

## Notes

- **No new network requests** — the performer is derived from the `albumSongs` result `album()` already fetches.
- **Normal albums are unaffected** — when the strapline already equals the track artist the override is skipped, so correctly-credited albums (and their linked artist ids) are left untouched.
- Verified against the live API that the header and all tracks resolve to the performer; builds pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced artist information accuracy on album pages through improved data resolution
  * Refined fallback logic for song artist attribution when primary data is unavailable, ensuring more complete artist information display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->