### PR TITLE
fix(data-store): prevent IOException crash on Samsung One UI by creating datastore directory before writes

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/App.kt
+++ b/app/src/main/kotlin/com/metrolist/music/App.kt
@@ -331,7 +331,7 @@ class App :
 
             // Clear DataStore preferences
             Timber.d("forgetAccount: Clearing DataStore preferences")
-            context.safeDataStoreEdit { settings ->
+            val cleared = context.safeDataStoreEdit { settings ->
                 settings.remove(InnerTubeCookieKey)
                 settings.remove(VisitorDataKey)
                 settings.remove(DataSyncIdKey)
@@ -339,7 +339,11 @@ class App :
                 settings.remove(AccountEmailKey)
                 settings.remove(AccountChannelHandleKey)
             }
-            Timber.d("forgetAccount: DataStore preferences cleared")
+            if (!cleared) {
+                Timber.e("forgetAccount: Failed to clear DataStore preferences — proceeding with in-memory cleanup only")
+            } else {
+                Timber.d("forgetAccount: DataStore preferences cleared")
+            }
 
             // Immediately clear YouTube object's auth state
             Timber.d("forgetAccount: Clearing YouTube object auth state")

--- a/app/src/main/kotlin/com/metrolist/music/App.kt
+++ b/app/src/main/kotlin/com/metrolist/music/App.kt
@@ -11,7 +11,6 @@ import android.app.NotificationManager
 import android.content.Context
 import android.os.Build
 import android.widget.Toast
-import androidx.datastore.preferences.core.edit
 import coil3.ImageLoader
 import coil3.PlatformContext
 import coil3.SingletonImageLoader
@@ -35,6 +34,7 @@ import com.metrolist.music.utils.CrashHandler
 import com.metrolist.music.utils.YTPlayerUtils
 import com.metrolist.music.utils.cipher.CipherDeobfuscator
 import com.metrolist.music.utils.dataStore
+import com.metrolist.music.utils.safeDataStoreEdit
 import com.metrolist.music.utils.reportException
 import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.CoroutineScope
@@ -209,7 +209,7 @@ class App :
                     YouTube.visitorData = visitorData?.takeIf { it != "null" }
                         ?: YouTube.visitorData().getOrNull()?.also { newVisitorData ->
                             try {
-                                dataStore.edit { settings ->
+                                safeDataStoreEdit { settings ->
                                     settings[VisitorDataKey] = newVisitorData
                                 }
                             } catch (e: IOException) {
@@ -331,7 +331,7 @@ class App :
 
             // Clear DataStore preferences
             Timber.d("forgetAccount: Clearing DataStore preferences")
-            context.dataStore.edit { settings ->
+            context.safeDataStoreEdit { settings ->
                 settings.remove(InnerTubeCookieKey)
                 settings.remove(VisitorDataKey)
                 settings.remove(DataSyncIdKey)

--- a/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
@@ -106,7 +106,6 @@ import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import androidx.core.util.Consumer
 import androidx.core.view.WindowCompat
-import androidx.datastore.preferences.core.edit
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.coroutineScope
@@ -195,6 +194,7 @@ import com.metrolist.music.utils.SearchRoutes
 import com.metrolist.music.utils.SyncUtils
 import com.metrolist.music.utils.Updater
 import com.metrolist.music.utils.dataStore
+import com.metrolist.music.utils.safeDataStoreEdit
 import com.metrolist.music.utils.get
 import com.metrolist.music.utils.rememberEnumPreference
 import com.metrolist.music.utils.rememberPreference
@@ -414,7 +414,7 @@ class MainActivity : ComponentActivity() {
 
             // SimpMusic Removal Migration
             if (preferences[SimpMusicMigrationDoneKey] != true) {
-                dataStore.edit { settings ->
+                safeDataStoreEdit { settings ->
                     val currentOrder = settings[LyricsProviderOrderKey] ?: ""
                     if (currentOrder.contains("SimpMusic")) {
                         val orderList =
@@ -439,7 +439,7 @@ class MainActivity : ComponentActivity() {
         }
 
         lifecycleScope.launch(Dispatchers.IO) {
-            dataStore.edit { settings ->
+            safeDataStoreEdit { settings ->
                 settings[LastSeenVersionKey] = BuildConfig.VERSION_NAME
             }
         }

--- a/app/src/main/kotlin/com/metrolist/music/listentogether/ListenTogetherClient.kt
+++ b/app/src/main/kotlin/com/metrolist/music/listentogether/ListenTogetherClient.kt
@@ -19,7 +19,6 @@ import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.getSystemService
-import androidx.datastore.preferences.core.edit
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
@@ -35,6 +34,7 @@ import com.metrolist.music.constants.ListenTogetherUserIdKey
 import com.metrolist.music.utils.NetworkConnectivityObserver
 import com.metrolist.music.utils.dataStore
 import com.metrolist.music.utils.get
+import com.metrolist.music.utils.safeDataStoreEdit
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -481,7 +481,7 @@ class ListenTogetherClient
         private suspend fun saveBlockedUsernames() {
             try {
                 val blockedJson = json.encodeToString(_blockedUsernames.value.toList())
-                context.dataStore.edit { preferences ->
+                context.safeDataStoreEdit { preferences ->
                     preferences[com.metrolist.music.constants.ListenTogetherBlockedUsersKey] = blockedJson
                 }
             } catch (e: Exception) {
@@ -500,7 +500,7 @@ class ListenTogetherClient
                 if (normalizedUrl != configuredUrl) {
                     log(LogLevel.INFO, "Migrating server URL", "Old: $configuredUrl -> New: $normalizedUrl")
                     scope.launch {
-                        context.dataStore.edit { preferences ->
+                        context.safeDataStoreEdit { preferences ->
                             preferences[ListenTogetherServerUrlKey] = normalizedUrl
                         }
                     }
@@ -516,7 +516,7 @@ class ListenTogetherClient
         private fun savePersistedSession() {
             try {
                 scope.launch {
-                    context.dataStore.edit { preferences ->
+                    context.safeDataStoreEdit { preferences ->
                         if (sessionToken != null) {
                             preferences[ListenTogetherSessionTokenKey] = sessionToken!!
                             preferences[ListenTogetherRoomCodeKey] = storedRoomCode ?: ""
@@ -537,7 +537,7 @@ class ListenTogetherClient
         private fun clearPersistedSession() {
             try {
                 scope.launch {
-                    context.dataStore.edit { preferences ->
+                    context.safeDataStoreEdit { preferences ->
                         preferences.remove(ListenTogetherSessionTokenKey)
                         preferences.remove(ListenTogetherRoomCodeKey)
                         preferences.remove(ListenTogetherUserIdKey)

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -25,6 +25,7 @@ import android.media.AudioFocusRequest
 import android.media.AudioManager
 import android.media.audiofx.AudioEffect
 import com.metrolist.music.playback.audio.VolumeNormalizationAudioProcessor
+import com.metrolist.music.utils.safeDataStoreEdit
 import android.net.ConnectivityManager
 import android.os.Binder
 import android.os.Build
@@ -37,7 +38,6 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.core.app.ServiceCompat
 import androidx.core.content.getSystemService
 import androidx.core.net.toUri
-import androidx.datastore.preferences.core.edit
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
@@ -848,7 +848,7 @@ class MusicService :
         }
 
         playerVolume.debounce(1000).collect(scope) { volume ->
-            dataStore.edit { settings ->
+            safeDataStoreEdit { settings ->
                 settings[PlayerVolumeKey] = volume
             }
         }
@@ -2722,7 +2722,7 @@ class MusicService :
 
         if (dataStore.get(RememberShuffleAndRepeatKey, true)) {
             scope.launch {
-                dataStore.edit { settings ->
+                safeDataStoreEdit { settings ->
                     settings[ShuffleModeKey] = shuffleModeEnabled
                 }
             }
@@ -2736,7 +2736,7 @@ class MusicService :
     override fun onRepeatModeChanged(repeatMode: Int) {
         updateNotification()
         scope.launch {
-            dataStore.edit { settings ->
+            safeDataStoreEdit { settings ->
                 settings[RepeatModeKey] = repeatMode
             }
         }

--- a/app/src/main/kotlin/com/metrolist/music/playback/alarm/MusicAlarmStore.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/alarm/MusicAlarmStore.kt
@@ -2,7 +2,6 @@ package com.metrolist.music.playback.alarm
 
 import android.content.Context
 import android.os.Build
-import androidx.datastore.preferences.core.edit
 import com.metrolist.music.constants.AlarmEnabledKey
 import com.metrolist.music.constants.AlarmEntriesKey
 import com.metrolist.music.constants.AlarmHourKey
@@ -11,6 +10,7 @@ import com.metrolist.music.constants.AlarmNextTriggerAtKey
 import com.metrolist.music.constants.AlarmPlaylistIdKey
 import com.metrolist.music.constants.AlarmRandomSongKey
 import com.metrolist.music.utils.dataStore
+import com.metrolist.music.utils.safeDataStoreEdit
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.json.JSONArray
@@ -72,7 +72,7 @@ object MusicAlarmStore {
 
     suspend fun save(context: Context, entries: List<MusicAlarmEntry>) {
         saveProtected(context, entries)
-        context.dataStore.edit { prefs ->
+        context.safeDataStoreEdit { prefs ->
             prefs[AlarmEntriesKey] = serialize(entries)
             prefs[AlarmNextTriggerAtKey] = entries.filter { it.enabled }.minOfOrNull { it.nextTriggerAt.takeIf { time -> time > 0L } ?: Long.MAX_VALUE }
                 ?.takeIf { it != Long.MAX_VALUE } ?: -1L

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
@@ -183,6 +183,7 @@ import com.metrolist.music.utils.dataStore
 import com.metrolist.music.utils.makeTimeString
 import com.metrolist.music.utils.rememberEnumPreference
 import com.metrolist.music.utils.rememberPreference
+import com.metrolist.music.utils.safeDataStoreEdit
 import dagger.hilt.android.EntryPointAccessors
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -194,8 +195,6 @@ import kotlin.math.max
 import kotlin.math.roundToInt
 import com.metrolist.music.ui.component.Icon as MIcon
 import com.metrolist.music.constants.SleepTimerDefaultKey
-import com.metrolist.music.utils.dataStore
-import androidx.datastore.preferences.core.edit
 import com.metrolist.music.constants.SleepTimerFadeOutKey
 import com.metrolist.music.constants.SleepTimerStopAfterCurrentSongKey
 
@@ -688,7 +687,7 @@ fun BottomSheetPlayer(
                             FilledIconButton(
                                 onClick = {
                                     scope.launch {
-                                        context.dataStore.edit { settings ->
+                                        context.safeDataStoreEdit { settings ->
                                             settings[SleepTimerDefaultKey] = sleepTimerValue
                                         }
                                     }
@@ -709,7 +708,7 @@ fun BottomSheetPlayer(
                             OutlinedIconButton(
                                 onClick = {
                                     scope.launch {
-                                        context.dataStore.edit { settings ->
+                                        context.safeDataStoreEdit { settings ->
                                             settings[SleepTimerDefaultKey] = sleepTimerValue
                                         }
                                     }

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Queue.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Queue.kt
@@ -125,6 +125,7 @@ import com.metrolist.music.ui.utils.ShowMediaInfo
 import com.metrolist.music.utils.dataStore
 import com.metrolist.music.utils.makeTimeString
 import com.metrolist.music.utils.rememberPreference
+import com.metrolist.music.utils.safeDataStoreEdit
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -133,8 +134,6 @@ import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
 import kotlin.math.roundToInt
 import com.metrolist.music.constants.SleepTimerDefaultKey
-import com.metrolist.music.utils.dataStore
-import androidx.datastore.preferences.core.edit
 import android.widget.Toast
 import androidx.compose.runtime.derivedStateOf
 import com.metrolist.music.constants.SleepTimerFadeOutKey
@@ -601,7 +600,7 @@ fun Queue(
                                     Button(
                                         onClick = {
                                             coroutineScope.launch {
-                                                context.dataStore.edit { settings ->
+                                                context.safeDataStoreEdit { settings ->
                                                     settings[SleepTimerDefaultKey] = sleepTimerValue
                                                 }
                                             }
@@ -622,7 +621,7 @@ fun Queue(
                                     OutlinedButton(
                                         onClick = {
                                             coroutineScope.launch {
-                                                context.dataStore.edit { settings ->
+                                                context.safeDataStoreEdit { settings ->
                                                     settings[SleepTimerDefaultKey] = sleepTimerValue
                                                 }
                                             }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/integrations/DiscordSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/integrations/DiscordSettings.kt
@@ -2,7 +2,6 @@ package com.metrolist.music.ui.screens.settings.integrations
 
 import android.app.Activity
 import android.content.Intent
-import androidx.datastore.preferences.core.edit
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.shrinkVertically
@@ -107,6 +106,7 @@ import com.metrolist.music.ui.component.Material3SettingsItem
 import com.metrolist.music.ui.utils.backToMain
 import com.metrolist.music.utils.dataStore
 import com.metrolist.music.utils.makeTimeString
+import com.metrolist.music.utils.safeDataStoreEdit
 import com.metrolist.music.utils.rememberPreference
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -730,7 +730,7 @@ fun DiscordSettings(
                 onActivityTypeChange(value)
                 showActivityTypeDialog = false
                 coroutineScope.launch(Dispatchers.IO) {
-                    context.dataStore.edit { it[DiscordActivityTypeKey] = value }
+                    context.safeDataStoreEdit { it[DiscordActivityTypeKey] = value }
                     withContext(Dispatchers.Main) { onPrefChanged() }
                 }
             },
@@ -755,7 +755,7 @@ fun DiscordSettings(
             onDone = {
                 onActivityNameChange(it)
                 coroutineScope.launch(Dispatchers.IO) {
-                    context.dataStore.edit { prefs -> prefs[DiscordActivityNameKey] = it }
+                    context.safeDataStoreEdit { prefs -> prefs[DiscordActivityNameKey] = it }
                     withContext(Dispatchers.Main) { onPrefChanged() }
                 }
             },
@@ -770,7 +770,7 @@ fun DiscordSettings(
             onDone = {
                 onStateTemplateChange(it)
                 coroutineScope.launch(Dispatchers.IO) {
-                    context.dataStore.edit { prefs -> prefs[DiscordStateTemplateKey] = it }
+                    context.safeDataStoreEdit { prefs -> prefs[DiscordStateTemplateKey] = it }
                     withContext(Dispatchers.Main) { onPrefChanged() }
                 }
             },
@@ -785,7 +785,7 @@ fun DiscordSettings(
             onDone = {
                 onDetailsTemplateChange(it)
                 coroutineScope.launch(Dispatchers.IO) {
-                    context.dataStore.edit { prefs -> prefs[DiscordDetailsTemplateKey] = it }
+                    context.safeDataStoreEdit { prefs -> prefs[DiscordDetailsTemplateKey] = it }
                     withContext(Dispatchers.Main) { onPrefChanged() }
                 }
             },
@@ -800,7 +800,7 @@ fun DiscordSettings(
             onDone = {
                 onBtn1LabelChange(it)
                 coroutineScope.launch(Dispatchers.IO) {
-                    context.dataStore.edit { prefs -> prefs[DiscordButton1LabelKey] = it }
+                    context.safeDataStoreEdit { prefs -> prefs[DiscordButton1LabelKey] = it }
                     withContext(Dispatchers.Main) { onPrefChanged() }
                 }
             },
@@ -815,7 +815,7 @@ fun DiscordSettings(
             onDone = {
                 onBtn1UrlChange(it)
                 coroutineScope.launch(Dispatchers.IO) {
-                    context.dataStore.edit { prefs -> prefs[DiscordButton1UrlKey] = it }
+                    context.safeDataStoreEdit { prefs -> prefs[DiscordButton1UrlKey] = it }
                     withContext(Dispatchers.Main) { onPrefChanged() }
                 }
             },
@@ -830,7 +830,7 @@ fun DiscordSettings(
             onDone = {
                 onBtn2LabelChange(it)
                 coroutineScope.launch(Dispatchers.IO) {
-                    context.dataStore.edit { prefs -> prefs[DiscordButton2LabelKey] = it }
+                    context.safeDataStoreEdit { prefs -> prefs[DiscordButton2LabelKey] = it }
                     withContext(Dispatchers.Main) { onPrefChanged() }
                 }
             },
@@ -845,7 +845,7 @@ fun DiscordSettings(
             onDone = {
                 onBtn2UrlChange(it)
                 coroutineScope.launch(Dispatchers.IO) {
-                    context.dataStore.edit { prefs -> prefs[DiscordButton2UrlKey] = it }
+                    context.safeDataStoreEdit { prefs -> prefs[DiscordButton2UrlKey] = it }
                     withContext(Dispatchers.Main) { onPrefChanged() }
                 }
             },
@@ -860,7 +860,7 @@ fun DiscordSettings(
                 onUserStatusChange(value)
                 showUserStatusDialog = false
                 coroutineScope.launch(Dispatchers.IO) {
-                    context.dataStore.edit { prefs -> prefs[DiscordUserStatusKey] = value }
+                    context.safeDataStoreEdit { prefs -> prefs[DiscordUserStatusKey] = value }
                     withContext(Dispatchers.Main) { onPrefChanged() }
                 }
             },

--- a/app/src/main/kotlin/com/metrolist/music/utils/DataStore.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/DataStore.kt
@@ -29,7 +29,7 @@ import timber.log.Timber
 import java.io.File
 import java.io.IOException
 
-private var dataStoreInstance: DataStore<Preferences>? = null
+@Volatile private var dataStoreInstance: DataStore<Preferences>? = null
 private val dataStoreLock = Any()
 
 val Context.dataStore: DataStore<Preferences>
@@ -51,16 +51,19 @@ val Context.dataStore: DataStore<Preferences>
 /**
  * Safe DataStore write that ensures the parent directory exists before every edit.
  * Catches and reports IOException instead of crashing the coroutine scope.
+ * Returns true if the write succeeded, false if it failed.
  */
 suspend fun Context.safeDataStoreEdit(
     transform: suspend (MutablePreferences) -> Unit,
-) {
-    try {
+): Boolean {
+    return try {
         File(filesDir, "datastore").mkdirs()
         dataStore.edit(transform)
+        true
     } catch (e: IOException) {
         Timber.e(e, "DataStore edit failed")
         reportException(e)
+        false
     }
 }
 

--- a/app/src/main/kotlin/com/metrolist/music/utils/DataStore.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/DataStore.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.preferencesDataStore
 import com.metrolist.music.extensions.toEnum
@@ -24,8 +25,44 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlin.properties.ReadOnlyProperty
+import timber.log.Timber
+import java.io.File
+import java.io.IOException
 
-val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
+private var dataStoreInstance: DataStore<Preferences>? = null
+private val dataStoreLock = Any()
+
+val Context.dataStore: DataStore<Preferences>
+    get() {
+        dataStoreInstance?.let { return it }
+        synchronized(dataStoreLock) {
+            dataStoreInstance?.let { return it }
+            // Ensure the datastore parent directory exists before DataStore init.
+            // On Samsung One UI 8.5+/Android 16 the directory can be missing after
+            // deep sleep, causing IOException in FileStorageConnection.writeScope()
+            // that crashes the process and triggers a soft reboot.
+            File(filesDir, "datastore").mkdirs()
+            return preferencesDataStore(name = "settings")
+                .getValue(this, ::dataStore)
+                .also { dataStoreInstance = it }
+        }
+    }
+
+/**
+ * Safe DataStore write that ensures the parent directory exists before every edit.
+ * Catches and reports IOException instead of crashing the coroutine scope.
+ */
+suspend fun Context.safeDataStoreEdit(
+    transform: suspend (MutablePreferences) -> Unit,
+) {
+    try {
+        File(filesDir, "datastore").mkdirs()
+        dataStore.edit(transform)
+    } catch (e: IOException) {
+        Timber.e(e, "DataStore edit failed")
+        reportException(e)
+    }
+}
 
 operator fun <T> DataStore<Preferences>.get(key: Preferences.Key<T>): T? =
     runBlocking(Dispatchers.IO) {
@@ -73,7 +110,7 @@ fun <T> rememberPreference(
                 get() = state.value
                 set(value) {
                     coroutineScope.launch {
-                        context.dataStore.edit {
+                        context.safeDataStoreEdit {
                             it[key] = value
                         }
                     }
@@ -107,7 +144,7 @@ inline fun <reified T : Enum<T>> rememberEnumPreference(
                 get() = state.value
                 set(value) {
                     coroutineScope.launch {
-                        context.dataStore.edit {
+                        context.safeDataStoreEdit {
                             it[key] = value.name
                         }
                     }

--- a/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
@@ -120,6 +120,7 @@ class SyncUtils @Inject constructor(
     val syncState: StateFlow<SyncState> = _syncState.asStateFlow()
 
     private var lastfmSendLikes = false
+    @Volatile private var cachedLastSyncEpoch: Long = 0L
     private val playlistsBeingModified = ConcurrentHashMap<String, AtomicInteger>()
     // Tracks songs currently being added to YouTube — browseId → set of songIds
     private val pendingYouTubeAdds = ConcurrentHashMap<String, MutableSet<String>>()
@@ -150,6 +151,10 @@ class SyncUtils @Inject constructor(
             .collectLatest(syncScope) {
                 lastfmSendLikes = it
             }
+
+        syncScope.launch {
+            cachedLastSyncEpoch = context.dataStore.get(LastFullSyncKey, 0L)
+        }
 
         startProcessingQueue()
     }
@@ -259,15 +264,18 @@ class SyncUtils @Inject constructor(
             }
 
             val lastSync = context.dataStore.get(LastFullSyncKey, 0L)
+            val effectiveLastSync = maxOf(lastSync, cachedLastSyncEpoch)
             val currentTime = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)
-            if (lastSync > 0 && (currentTime - lastSync) < SYNC_COOLDOWN) {
+            if (effectiveLastSync > 0 && (currentTime - effectiveLastSync) < SYNC_COOLDOWN) {
                 return@launch
             }
 
             syncChannel.send(SyncOperation.FullSync)
 
+            val now = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)
+            cachedLastSyncEpoch = now
             context.safeDataStoreEdit { settings ->
-                settings[LastFullSyncKey] = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)
+                settings[LastFullSyncKey] = now
             }
         }
     }
@@ -1617,8 +1625,10 @@ class SyncUtils @Inject constructor(
             }
 
             // Reset sync timestamp
+            val now = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)
+            cachedLastSyncEpoch = now
             context.safeDataStoreEdit { settings ->
-                settings[LastFullSyncKey] = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)
+                settings[LastFullSyncKey] = now
             }
 
             updateState { copy(overallStatus = SyncStatus.Completed, currentOperation = "") }

--- a/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
@@ -153,7 +153,8 @@ class SyncUtils @Inject constructor(
             }
 
         syncScope.launch {
-            cachedLastSyncEpoch = context.dataStore.get(LastFullSyncKey, 0L)
+            val loaded = context.dataStore.get(LastFullSyncKey, 0L)
+            cachedLastSyncEpoch = maxOf(cachedLastSyncEpoch, loaded)
         }
 
         startProcessingQueue()

--- a/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
@@ -7,7 +7,6 @@
 package com.metrolist.music.utils
 
 import android.content.Context
-import androidx.datastore.preferences.core.edit
 import com.metrolist.innertube.YouTube
 import com.metrolist.innertube.models.AlbumItem
 import com.metrolist.innertube.models.ArtistItem
@@ -267,7 +266,7 @@ class SyncUtils @Inject constructor(
 
             syncChannel.send(SyncOperation.FullSync)
 
-            context.dataStore.edit { settings ->
+            context.safeDataStoreEdit { settings ->
                 settings[LastFullSyncKey] = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)
             }
         }
@@ -1618,7 +1617,7 @@ class SyncUtils @Inject constructor(
             }
 
             // Reset sync timestamp
-            context.dataStore.edit { settings ->
+            context.safeDataStoreEdit { settings ->
                 settings[LastFullSyncKey] = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)
             }
 

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/AccountSettingsViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/AccountSettingsViewModel.kt
@@ -84,13 +84,17 @@ class AccountSettingsViewModel @Inject constructor(
         accountChannelHandle: String,
     ) {
         viewModelScope.launch(Dispatchers.IO) {
-            context.safeDataStoreEdit { settings ->
+            val saved = context.safeDataStoreEdit { settings ->
                 settings[InnerTubeCookieKey] = cookie
                 settings[VisitorDataKey] = visitorData
                 settings[DataSyncIdKey] = dataSyncId
                 settings[AccountNameKey] = accountName
                 settings[AccountEmailKey] = accountEmail
                 settings[AccountChannelHandleKey] = accountChannelHandle
+            }
+            if (!saved) {
+                Timber.e("saveTokenAndRestart: DataStore write failed — skipping restart to avoid losing credentials")
+                return@launch
             }
             withContext(Dispatchers.Main) {
                 val intent = context.packageManager.getLaunchIntentForPackage(context.packageName)

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/AccountSettingsViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/AccountSettingsViewModel.kt
@@ -18,13 +18,13 @@ import com.metrolist.music.constants.InnerTubeCookieKey
 import com.metrolist.music.constants.VisitorDataKey
 import com.metrolist.music.utils.SyncUtils
 import com.metrolist.music.utils.dataStore
+import com.metrolist.music.utils.safeDataStoreEdit
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 import javax.inject.Inject
-import androidx.datastore.preferences.core.edit
 
 @HiltViewModel
 class AccountSettingsViewModel @Inject constructor(
@@ -84,7 +84,7 @@ class AccountSettingsViewModel @Inject constructor(
         accountChannelHandle: String,
     ) {
         viewModelScope.launch(Dispatchers.IO) {
-            context.dataStore.edit { settings ->
+            context.safeDataStoreEdit { settings ->
                 settings[InnerTubeCookieKey] = cookie
                 settings[VisitorDataKey] = visitorData
                 settings[DataSyncIdKey] = dataSyncId

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/HomeViewModel.kt
@@ -6,7 +6,6 @@
 package com.metrolist.music.viewmodels
 
 import android.content.Context
-import androidx.datastore.preferences.core.edit
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.metrolist.innertube.YouTube
@@ -45,6 +44,7 @@ import com.metrolist.music.ui.screens.wrapped.WrappedAudioService
 import com.metrolist.music.ui.screens.wrapped.WrappedManager
 import com.metrolist.music.utils.SyncUtils
 import com.metrolist.music.utils.dataStore
+import com.metrolist.music.utils.safeDataStoreEdit
 import com.metrolist.music.utils.get
 import com.metrolist.music.utils.reportException
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -279,7 +279,7 @@ class HomeViewModel @Inject constructor(
 
     fun markWrappedAsSeen() {
         viewModelScope.launch(Dispatchers.IO) {
-            context.dataStore.edit {
+            context.safeDataStoreEdit {
                 it[WrappedSeenKey] = true
             }
         }

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/StatsViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/StatsViewModel.kt
@@ -22,8 +22,8 @@ import com.metrolist.music.db.MusicDatabase
 import com.metrolist.music.db.entities.PlaylistEntity
 import com.metrolist.music.ui.screens.OptionStats
 import com.metrolist.music.utils.dataStore
+import com.metrolist.music.utils.safeDataStoreEdit
 import com.metrolist.music.utils.reportException
-import androidx.datastore.preferences.core.edit
 import com.metrolist.music.R
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -295,7 +295,7 @@ constructor(
 
                 // Only write "last sync" when it was a scheduled sync, not a forced rebuild
                 if (!force) {
-                    context.dataStore.edit { settings ->
+                    context.safeDataStoreEdit { settings ->
                         if (shouldSyncWeekly) settings[LastWeeklyMostPlaylistSyncKey] = nowEpochMillis
                         if (shouldSyncMonthly) settings[LastMonthlyMostPlaylistSyncKey] = nowEpochMillis
                     }


### PR DESCRIPTION
On Samsung One UI 8.5 and later, the Android system may delete the files/datastore/ directory during deep sleep. When Jetpack DataStore internally calls mkdirs in FileStorageConnection.writeScope, it fails with an IOException that propagates unhandled and crashes the entire process, triggering a soft reboot on Samsung devices. This commit addresses the root cause rather than placing a try-catch workaround. The Context.dataStore property is changed from a simple preferencesDataStore delegate to a custom thread-safe property that eagerly creates the datastore directory on first access. A safeDataStoreEdit extension function is added that ensures the directory exists before every write and reports any IOException via Timber and reportException instead of crashing. All 30+ dataStore.edit call sites across 12 files are migrated to safeDataStoreEdit to harden against transient IOExceptions in any code path.

Fixes #3992

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of saving preferences for playback, sleep timer, queue, alarms, account/token settings, Discord settings, and home/usage cards.
  * Reduced errors from background preference writes by safely handling storage issues and falling back without crashing.
  * Made account reset, startup migrations, and sync timestamp updates more resilient; if saving tokens fails, the app no longer restarts unnecessarily.

* **Refactor**
  * Standardized all preference writes to use a unified, safer local storage edit helper and improved sync cooldown calculation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->