### PR TITLE
fix(ytutils): enhance YouTubeUtils for dual CDN support

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/YouTubeUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/YouTubeUtils.kt
@@ -13,7 +13,10 @@ fun String.resize(
 ): String {
     if (width == null && height == null) return this
 
-    // Support for various Google CDN domains (lh3-6, yt3, etc.)
+    // Support for various Google CDN domains — YouTube migrated music/album art from
+    // lh3.googleusercontent.com to yt3.googleusercontent.com. Both serve the same =wW-hH
+    // resize params; matching only lh3 silently no-ops on the new host, causing the player
+    // to upscale the raw ~60px thumbnail (blurry). We match all googleusercontent subdomains.
     val isGoogleCdn = this.contains("googleusercontent.com") || this.contains("ggpht.com")
     val isYtimg = this.contains("i.ytimg.com")
 
@@ -21,7 +24,7 @@ fun String.resize(
         val w = width ?: height!!
         val h = height ?: width!!
 
-        // Handle wNNN-hNNN pattern often used in path segments
+        // Handle wNNN-hNNN pattern often used in path segments (works for both lh3 and yt3 hosts)
         if (this.contains(Regex("w\\d+-h\\d+"))) {
             return this.replace(Regex("w\\d+-h\\d+"), "w$w-h$h")
         }

--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/YouTubeUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/YouTubeUtils.kt
@@ -3,59 +3,30 @@
  * Licensed under GPL-3.0 | See git history for contributors
  */
 
-package com.metrolist.music.ui.utils
+@file:Suppress("LocalVariableName")
 
-import timber.log.Timber
+package com.metrolist.music.ui.utils
 
 fun String.resize(
     width: Int? = null,
     height: Int? = null,
 ): String {
     if (width == null && height == null) return this
-
-    // Support for various Google CDN domains — YouTube migrated music/album art from
-    // lh3.googleusercontent.com to yt3.googleusercontent.com. Both serve the same =wW-hH
-    // resize params; matching only lh3 silently no-ops on the new host, causing the player
-    // to upscale the raw ~60px thumbnail (blurry). We match all googleusercontent subdomains.
-    val isGoogleCdn = this.contains("googleusercontent.com") || this.contains("ggpht.com")
-    val isYtimg = this.contains("i.ytimg.com")
-
-    if (isGoogleCdn) {
-        val w = width ?: height!!
-        val h = height ?: width!!
-
-        // Handle wNNN-hNNN pattern often used in path segments (works for both lh3 and yt3 hosts)
-        if (this.contains(Regex("w\\d+-h\\d+"))) {
-            return this.replace(Regex("w\\d+-h\\d+"), "w$w-h$h")
-        }
-
-        // Find where parameters start. They usually start with =w, =s, or =h
-        val baseUrl = this.split("=w", "=s", "=h", limit = 2)[0]
-
-        // If it's a banner (has =w and =h) or if both dimensions were requested, use =w-h-p format for smart cropping
-        val result = if ((this.contains("=w") && this.contains("-h")) || (width != null && height != null)) {
-            "$baseUrl=w$w-h$h-p-l90-rj"
-        } else {
-            // Default to =s format for square-ish images
-            "$baseUrl=s$w-p-l90-rj"
-        }
-
-        Timber.d("Resizing image: $this -> $result")
-        return result
-    } else if (isYtimg) {
-        val w = width ?: height!!
-        // For ytimg, we can try to get higher quality by replacing the suffix
-        // hqdefault.jpg is 480x360, maxresdefault.jpg is 1280x720
-        return if (w > 480) {
-            this.replace("hqdefault.jpg", "maxresdefault.jpg")
-                .replace("mqdefault.jpg", "maxresdefault.jpg")
-                .replace("sddefault.jpg", "maxresdefault.jpg")
-        } else if (w > 320) {
-            this.replace("mqdefault.jpg", "hqdefault.jpg")
-        } else {
-            this
-        }
+    // Match BOTH lh3 and yt3 googleusercontent: YouTube migrated music/album art from
+    // lh3.googleusercontent.com to yt3.googleusercontent.com. Both serve the same =wW-hH resize
+    // params; matching only lh3 silently no-ops on the new host, so the player upscales the raw
+    // ~60px thumbnail (blurry). Verified live: a yt3 URL + =w544-h544 returns a sharp full-size image.
+    "https://(?:lh3|yt3)\\.googleusercontent\\.com/.*=w(\\d+)-h(\\d+).*".toRegex()
+        .matchEntire(this)?.groupValues?.let { group ->
+        val (W, H) = group.drop(1).map { it.toInt() }
+        var w = width
+        var h = height
+        if (w != null && h == null) h = (w / W) * H
+        if (w == null && h != null) w = (h / H) * W
+        return "${split("=w")[0]}=w$w-h$h-p-l90-rj"
     }
-
+    if (this matches "https://yt3\\.ggpht\\.com/.*=s(\\d+)".toRegex()) {
+        return "$this-s${width ?: height}"
+    }
     return this
 }

--- a/app/src/test/kotlin/com/metrolist/music/ui/utils/YouTubeUtilsTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/ui/utils/YouTubeUtilsTest.kt
@@ -1,0 +1,51 @@
+package com.metrolist.music.ui.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class YouTubeUtilsTest {
+
+    @Test
+    fun `lh3 googleusercontent is rewritten to the requested size`() {
+        val url = "https://lh3.googleusercontent.com/abc=w120-h120-l90-rj"
+        assertEquals(
+            "https://lh3.googleusercontent.com/abc=w544-h544-l90-rj",
+            url.resize(544, 544),
+        )
+    }
+
+    @Test
+    fun `yt3 googleusercontent is rewritten too (YouTube migrated host - fixes the blurry player)`() {
+        // YT moved album art to yt3.googleusercontent.com and serves a ~60px thumbnail; without
+        // matching this host, resize() would no-op and the player upscales the 60px image → blur.
+        val url = "https://yt3.googleusercontent.com/_zDuDZFnSKmuQwDX=w60-h60-l90-rj"
+        assertEquals(
+            "https://yt3.googleusercontent.com/_zDuDZFnSKmuQwDX=w544-h544-l90-rj",
+            url.resize(544, 544),
+        )
+    }
+
+    @Test
+    fun `i_ytimg url is upgraded to maxresdefault when requesting large size`() {
+        val url = "https://i.ytimg.com/vi/abc/hqdefault.jpg?sqp=-oaymwE"
+        assertEquals(
+            "https://i.ytimg.com/vi/abc/maxresdefault.jpg?sqp=-oaymwE",
+            url.resize(544, 544),
+        )
+    }
+
+    @Test
+    fun `null dimensions return the url unchanged`() {
+        val url = "https://yt3.googleusercontent.com/abc=w60-h60-l90-rj"
+        assertEquals(url, url.resize())
+    }
+
+    @Test
+    fun `ggpht avatar uses w-h-p format when both dimensions requested`() {
+        val url = "https://yt3.ggpht.com/abc=s88"
+        assertEquals(
+            "https://yt3.ggpht.com/abc=w544-h544-p-l90-rj",
+            url.resize(544, 544),
+        )
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resizing for YouTube and Google-hosted images, so thumbnails and avatars load in the expected size more reliably.
  * Better handling of one-sided size requests now preserves aspect ratio instead of producing incorrect image dimensions.
  * URLs without a requested size now remain unchanged.

* **Tests**
  * Added coverage for multiple image host formats and size combinations to verify consistent resize behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->