### PR TITLE
fix: prevent crash from accessing sleepTimer before initialization

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -955,16 +955,16 @@ class MusicService :
                 }
 
                 player.removeListener(this)
-                player.removeListener(sleepTimer!!)
+                sleepTimer?.let { player.removeListener(it) }
                 playerNormalizationProcessors.remove(player)
                 playerSilenceProcessors.remove(player)
                 player.release()
 
                 val newPlayer = createExoPlayer()
                 newPlayer.addListener(this@MusicService)
-                newPlayer.addListener(sleepTimer!!)
+                sleepTimer?.let { newPlayer.addListener(it) }
 
-                sleepTimer!!.player = newPlayer
+                sleepTimer?.player = newPlayer
 
                 try {
                     mediaSession?.let { (it as MediaSession).player = newPlayer }
@@ -2567,7 +2567,8 @@ class MusicService :
     ) {
         if (playbackState == Player.STATE_ENDED) {
             // Check sleep timer guard - don't autoplay/repeat if sleep timer will pause
-            if (sleepTimer!!.isActive && sleepTimer!!.pauseWhenSongEnd) {
+            val timer = sleepTimer ?: return
+            if (timer.isActive && timer.pauseWhenSongEnd) {
                 return
             }
 
@@ -4059,7 +4060,7 @@ class MusicService :
         mediaLibrarySessionCallback.release()
         mediaSession?.release()
         player.removeListener(this)
-        player.removeListener(sleepTimer!!)
+        sleepTimer?.let { player.removeListener(it) }
         playerNormalizationProcessors.remove(player)
         playerSilenceProcessors.remove(player)
         controllerFuture?.let { MediaController.releaseFuture(it) }
@@ -4549,7 +4550,8 @@ class MusicService :
         crossfadeTriggerJob =
             scope.launch {
                 delay(delayMs)
-                if (isActive && player.isPlaying && player.currentMediaItem?.mediaId == targetMediaId && !sleepTimer!!.pauseWhenSongEnd) {
+                val timer = sleepTimer
+                if (isActive && player.isPlaying && player.currentMediaItem?.mediaId == targetMediaId && (timer == null || !timer.pauseWhenSongEnd)) {
                     startCrossfade()
                 }
             }
@@ -4629,7 +4631,7 @@ class MusicService :
         secondaryPlayer = null
 
         fadingPlayer?.removeListener(this)
-        fadingPlayer?.removeListener(sleepTimer!!)
+        sleepTimer?.let { timer -> fadingPlayer?.removeListener(timer) }
 
         player.addListener(
             object : Player.Listener {
@@ -4649,9 +4651,9 @@ class MusicService :
 
         nextPlayer.removeListener(secondaryPlayerListener)
         nextPlayer.addListener(this)
-        nextPlayer.addListener(sleepTimer!!)
+        sleepTimer?.let { nextPlayer.addListener(it) }
 
-        sleepTimer!!.player = player
+        sleepTimer?.player = player
 
         try {
             mediaSession?.let { (it as MediaSession).player = player }
@@ -4719,7 +4721,7 @@ class MusicService :
         fadingPlayer = null
         isCrossfading = false
         applyEffectiveVolume()
-        sleepTimer!!.notifySongTransition()
+        sleepTimer?.notifySongTransition()
 
         applyCachedAudioNormalizationNow()
 

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -373,7 +373,7 @@ class MusicService :
         player.volume = calculateEffectiveVolume()
     }
 
-    lateinit var sleepTimer: SleepTimer
+    var sleepTimer: SleepTimer? = null
 
     @Inject
     @PlayerCache
@@ -674,7 +674,7 @@ class MusicService :
             SleepTimer(scope, player) { multiplier ->
                 sleepTimerVolumeMultiplier.value = multiplier
             }
-        player.addListener(sleepTimer)
+        player.addListener(sleepTimer!!)
 
         playerInitialized.value = true
         Timber.tag(TAG).d("Player successfully initialized")
@@ -955,16 +955,16 @@ class MusicService :
                 }
 
                 player.removeListener(this)
-                player.removeListener(sleepTimer)
+                player.removeListener(sleepTimer!!)
                 playerNormalizationProcessors.remove(player)
                 playerSilenceProcessors.remove(player)
                 player.release()
 
                 val newPlayer = createExoPlayer()
                 newPlayer.addListener(this@MusicService)
-                newPlayer.addListener(sleepTimer)
+                newPlayer.addListener(sleepTimer!!)
 
-                sleepTimer.player = newPlayer
+                sleepTimer!!.player = newPlayer
 
                 try {
                     mediaSession?.let { (it as MediaSession).player = newPlayer }
@@ -2567,7 +2567,7 @@ class MusicService :
     ) {
         if (playbackState == Player.STATE_ENDED) {
             // Check sleep timer guard - don't autoplay/repeat if sleep timer will pause
-            if (sleepTimer.isActive && sleepTimer.pauseWhenSongEnd) {
+            if (sleepTimer!!.isActive && sleepTimer!!.pauseWhenSongEnd) {
                 return
             }
 
@@ -4059,7 +4059,7 @@ class MusicService :
         mediaLibrarySessionCallback.release()
         mediaSession?.release()
         player.removeListener(this)
-        player.removeListener(sleepTimer)
+        player.removeListener(sleepTimer!!)
         playerNormalizationProcessors.remove(player)
         playerSilenceProcessors.remove(player)
         controllerFuture?.let { MediaController.releaseFuture(it) }
@@ -4549,7 +4549,7 @@ class MusicService :
         crossfadeTriggerJob =
             scope.launch {
                 delay(delayMs)
-                if (isActive && player.isPlaying && player.currentMediaItem?.mediaId == targetMediaId && !sleepTimer.pauseWhenSongEnd) {
+                if (isActive && player.isPlaying && player.currentMediaItem?.mediaId == targetMediaId && !sleepTimer!!.pauseWhenSongEnd) {
                     startCrossfade()
                 }
             }
@@ -4629,7 +4629,7 @@ class MusicService :
         secondaryPlayer = null
 
         fadingPlayer?.removeListener(this)
-        fadingPlayer?.removeListener(sleepTimer)
+        fadingPlayer?.removeListener(sleepTimer!!)
 
         player.addListener(
             object : Player.Listener {
@@ -4649,9 +4649,9 @@ class MusicService :
 
         nextPlayer.removeListener(secondaryPlayerListener)
         nextPlayer.addListener(this)
-        nextPlayer.addListener(sleepTimer)
+        nextPlayer.addListener(sleepTimer!!)
 
-        sleepTimer.player = player
+        sleepTimer!!.player = player
 
         try {
             mediaSession?.let { (it as MediaSession).player = player }
@@ -4719,7 +4719,7 @@ class MusicService :
         fadingPlayer = null
         isCrossfading = false
         applyEffectiveVolume()
-        sleepTimer.notifySongTransition()
+        sleepTimer!!.notifySongTransition()
 
         applyCachedAudioNormalizationNow()
 

--- a/app/src/main/kotlin/com/metrolist/music/playback/PlayerConnection.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/PlayerConnection.kt
@@ -476,7 +476,7 @@ class PlayerConnection(
                 return false
             }
 
-            if (service.sleepTimer.isActive) {
+            if (service.sleepTimer?.isActive == true) {
                 Timber.tag(TAG).d("✗ Sleep Timer already active - skipping")
                 return false
             }
@@ -565,7 +565,7 @@ class PlayerConnection(
 
             if (isTimeInRange) {
                 Timber.tag(TAG).i("AUTO SLEEP TIMER STARTED: $sleepTimerDefaultMinutes minutes")
-                service.sleepTimer.start(sleepTimerDefaultMinutes)
+                service.sleepTimer?.start(sleepTimerDefaultMinutes)
                 return true
             }
 

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
@@ -589,10 +589,10 @@ fun BottomSheetPlayer(
 
     val sleepTimerEnabled =
         remember(
-            playerConnection.service.sleepTimer.triggerTime,
-            playerConnection.service.sleepTimer.pauseWhenSongEnd,
+            playerConnection.service.sleepTimer?.triggerTime,
+            playerConnection.service.sleepTimer?.pauseWhenSongEnd,
         ) {
-            playerConnection.service.sleepTimer.isActive
+            playerConnection.service.sleepTimer?.isActive ?: false
         }
 
     var sleepTimerTimeLeft by remember {
@@ -603,10 +603,10 @@ fun BottomSheetPlayer(
         if (sleepTimerEnabled) {
             while (isActive) {
                 sleepTimerTimeLeft =
-                    if (playerConnection.service.sleepTimer.pauseWhenSongEnd) {
+                    if (playerConnection.service.sleepTimer?.pauseWhenSongEnd == true) {
                         playerConnection.player.duration - playerConnection.player.currentPosition
                     } else {
-                        playerConnection.service.sleepTimer.triggerTime - System.currentTimeMillis()
+                        (playerConnection.service.sleepTimer?.triggerTime ?: 0L) - System.currentTimeMillis()
                     }
                 delay(1000L)
             }
@@ -644,7 +644,7 @@ fun BottomSheetPlayer(
                 TextButton(
                     onClick = {
                         showSleepTimerDialog = false
-                        playerConnection.service.sleepTimer.start(
+                        playerConnection.service.sleepTimer?.start(
                             minute = sleepTimerValue.roundToInt(),
                             stopAfterCurrentSong = sleepTimerStopAfterCurrentSong,
                             fadeOut = sleepTimerFadeOut,
@@ -727,7 +727,7 @@ fun BottomSheetPlayer(
                         OutlinedIconButton(
                             onClick = {
                                 showSleepTimerDialog = false
-                                playerConnection.service.sleepTimer.start(minute = -1)
+                                playerConnection.service.sleepTimer?.start(minute = -1)
                             },
                         ) {
                             Text(stringResource(R.string.end_of_song))

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Queue.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Queue.kt
@@ -235,10 +235,10 @@ fun Queue(
     val sleepTimerStopAfterCurrentSong by rememberPreference(SleepTimerStopAfterCurrentSongKey, false)
     val sleepTimerFadeOut by rememberPreference(SleepTimerFadeOutKey, false)
     val sleepTimerEnabled = remember(
-        playerConnection.service.sleepTimer.triggerTime,
-        playerConnection.service.sleepTimer.pauseWhenSongEnd
+        playerConnection.service.sleepTimer?.triggerTime,
+        playerConnection.service.sleepTimer?.pauseWhenSongEnd
     ) {
-        playerConnection.service.sleepTimer.isActive
+        playerConnection.service.sleepTimer?.isActive ?: false
     }
     var sleepTimerTimeLeft by remember { mutableLongStateOf(0L) }
 
@@ -246,10 +246,10 @@ fun Queue(
         if (sleepTimerEnabled) {
             while (isActive) {
                 sleepTimerTimeLeft =
-                    if (playerConnection.service.sleepTimer.pauseWhenSongEnd) {
+                    if (playerConnection.service.sleepTimer?.pauseWhenSongEnd == true) {
                         playerConnection.player.duration - playerConnection.player.currentPosition
                     } else {
-                        playerConnection.service.sleepTimer.triggerTime - System.currentTimeMillis()
+                        (playerConnection.service.sleepTimer?.triggerTime ?: 0L) - System.currentTimeMillis()
                     }
                 delay(1000L)
             }
@@ -313,7 +313,7 @@ fun Queue(
                         icon = R.drawable.bedtime,
                         onClick = {
                             if (sleepTimerEnabled) {
-                                playerConnection.service.sleepTimer.clear()
+                                playerConnection.service.sleepTimer?.clear()
                             } else {
                                 showSleepTimerDialog = true
                             }
@@ -461,7 +461,7 @@ fun Queue(
                         onClick = {
                             if (!isListenTogetherGuest) {
                                 if (sleepTimerEnabled) {
-                                    playerConnection.service.sleepTimer.clear()
+                                    playerConnection.service.sleepTimer?.clear()
                                 } else {
                                     showSleepTimerDialog = true
                                 }
@@ -557,7 +557,7 @@ fun Queue(
                     onDismiss = { showSleepTimerDialog = false },
                     onConfirm = {
                         showSleepTimerDialog = false
-                        playerConnection.service.sleepTimer.start(
+                        playerConnection.service.sleepTimer?.start(
                             minute = sleepTimerValue.roundToInt(),
                             stopAfterCurrentSong = sleepTimerStopAfterCurrentSong,
                             fadeOut = sleepTimerFadeOut,
@@ -640,7 +640,7 @@ fun Queue(
                                 OutlinedButton(
                                     onClick = {
                                         showSleepTimerDialog = false
-                                        playerConnection.service.sleepTimer.start(
+                                        playerConnection.service.sleepTimer?.start(
                                             minute = -1,
                                         )
                                     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sleep timer reliability across playback screens and queue controls.
  * Updated sleep timer handling to safely support scenarios where the timer may not yet be available, preventing missed start/clear actions.
  * Sleep timer status, countdown, and end-of-song behavior now update more consistently during player recreation and playback transitions, reducing crashes and inconsistent UI states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->