### PR TITLE
fix(android-auto): resolve playlist freeze and playback delay

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
@@ -27,7 +27,6 @@ import coil3.imageLoader
 import com.google.common.collect.ImmutableList
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
-import com.google.common.util.concurrent.SettableFuture
 import com.metrolist.innertube.YouTube
 import com.metrolist.innertube.models.PlaylistItem
 import com.metrolist.innertube.models.SongItem
@@ -123,13 +122,14 @@ constructor(
         return Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
     }
 
-    @Deprecated("Deprecated in MediaLibrarySession.Callback")
+    @Suppress("OVERRIDE_DEPRECATION")
     override fun onPlaybackResumption(
         mediaSession: MediaSession,
         controller: MediaSession.ControllerInfo
-    ): ListenableFuture<MediaItemsWithStartPosition> {
-        return SettableFuture.create<MediaItemsWithStartPosition>()
-    }
+    ): ListenableFuture<MediaItemsWithStartPosition> =
+        Futures.immediateFuture(
+            MediaItemsWithStartPosition(emptyList(), 0, C.TIME_UNSET),
+        )
 
     override fun onGetLibraryRoot(
         session: MediaLibrarySession,
@@ -584,7 +584,7 @@ constructor(
         startIndex: Int,
         startPositionMs: Long,
     ): ListenableFuture<MediaItemsWithStartPosition> =
-        scope.future {
+        scope.future(Dispatchers.IO) {
             val defaultResult = MediaItemsWithStartPosition(emptyList(), startIndex, startPositionMs)
             val voiceQuery = mediaItems.firstOrNull()?.requestMetadata?.searchQuery
 


### PR DESCRIPTION
## Problem
Android Auto playlist view freezes with infinite loading spinner and song playback is significantly delayed with incomplete metadata.

## Cause
`onPlaybackResumption` in `MediaLibrarySessionCallback` returned a `SettableFuture` that was never resolved. When Android Auto connected and called this callback, the future blocked the entire media session pipeline indefinitely. All subsequent browsing and playback commands from the car UI were queued behind this hung future, causing both the playlist freeze and playback delay. Additionally, `onSetMediaItems` dispatched database queries on `Dispatchers.Main` instead of `Dispatchers.IO`, blocking the main thread during song selection and compounding the playback delay.

## Solution
Replaced the never-completing `SettableFuture` in `onPlaybackResumption` with `Futures.immediateFuture(emptyList())` so the callback completes instantly and unblocks the session. Added explicit `Dispatchers.IO` to `onSetMediaItems` to move database work off the main thread, consistent with how `onGetChildren` already runs.

## Testing
Built successfully with `assembleFossDebug`, no warnings or errors introduced. The fix is a minimal two-line change with no new dependencies or side effects.

## Related Issues
Closes #4055

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback resumption so the app now returns a stable, immediate result instead of leaving the request unresolved.
  * Made media item loading run on a background I/O thread for more reliable playback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->