### PR TITLE
[wontfix] fix(playback): reset silence detector state on media item transition to prevent false silence skip across tracks

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -2511,6 +2511,7 @@ class MusicService :
 
         lastPlaybackSpeed = -1.0f // force update song
 
+        playerSilenceProcessors[player]?.resetTracking()
         setupAudioNormalization()
 
         scrobbleManager?.onSongStop()

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -3739,6 +3739,7 @@ class MusicService :
                         mediaId,
                         audioQuality = audioQuality,
                         connectivityManager = connectivityManager,
+                        offloadEnabled = currentOffloadEnabled,
                         contentHints = ContentHints(
                             isExplicit = song?.explicit,
                             isUploaded = song?.isUploaded,
@@ -4604,6 +4605,7 @@ class MusicService :
                             videoId = mediaId,
                             audioQuality = audioQuality,
                             connectivityManager = connectivityManager,
+                            offloadEnabled = currentOffloadEnabled,
                             contentHints = ContentHints(
                                 isExplicit = song?.explicit,
                                 isUploaded = song?.isUploaded,

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -543,6 +543,8 @@ class MusicService :
     private val MAX_RETRY_PER_SONG = 3
     private val RETRY_DELAY_MS = 1000L
     private val OFFLOAD_STALL_TIMEOUT_MS = 10_000L
+    private val OFFLOAD_POSITION_CHECK_INTERVAL_MS = 2_000L
+    private val OFFLOAD_STALE_CHECKS_THRESHOLD = 3
 
     // Track failed songs to prevent infinite retry loops
     private val recentlyFailedSongs = mutableSetOf<String>()
@@ -2623,29 +2625,51 @@ class MusicService :
                 Timber.tag(TAG).d("Playback successful for $mediaId, reset retry count")
             }
             scheduleCrossfade()
+            startOffloadPositionMonitor()
         }
 
-        if (playbackState == Player.STATE_BUFFERING && currentOffloadEnabled && player.playWhenReady) {
+        if (playbackState == Player.STATE_IDLE || playbackState == Player.STATE_ENDED) {
             offloadStallJob?.cancel()
-            offloadStallJob = scope.launch {
-                delay(OFFLOAD_STALL_TIMEOUT_MS)
-                if (player.playbackState == Player.STATE_BUFFERING && currentOffloadEnabled) {
-                    Timber.tag(TAG).w("Offload stall detected — disabling offload")
-                    player.setOffloadEnabled(false)
-                    secondaryPlayer?.setOffloadEnabled(false)
-                    currentOffloadEnabled = false
-                    playerSilenceProcessors.values.forEach { it.offloadMode = false }
-                    safeDataStoreEdit { settings -> settings[AudioOffload] = false }
-                    val idx = player.currentMediaItemIndex
-                    val pos = player.currentPosition
-                    player.seekTo(idx, pos)
-                    player.prepare()
-                }
-            }
         }
 
         if (playbackState == Player.STATE_IDLE || playbackState == Player.STATE_ENDED) {
             scrobbleManager?.onSongStop()
+        }
+    }
+
+    private fun disableOffload() {
+        Timber.tag(TAG).w("Offload stall detected, disabling offload")
+        player.setOffloadEnabled(false)
+        secondaryPlayer?.setOffloadEnabled(false)
+        currentOffloadEnabled = false
+        playerSilenceProcessors.values.forEach { it.offloadMode = false }
+        scope.launch { safeDataStoreEdit { settings -> settings[AudioOffload] = false } }
+    }
+
+    private fun startOffloadPositionMonitor() {
+        offloadStallJob?.cancel()
+        if (!currentOffloadEnabled || !player.playWhenReady) return
+        offloadStallJob = scope.launch {
+            var lastPosition = player.currentPosition
+            var staleChecks = 0
+            while (currentOffloadEnabled && player.isPlaying) {
+                delay(OFFLOAD_POSITION_CHECK_INTERVAL_MS)
+                if (!currentOffloadEnabled || !player.isPlaying) break
+                val currentPosition = player.currentPosition
+                if (currentPosition == lastPosition) {
+                    staleChecks++
+                    if (staleChecks >= OFFLOAD_STALE_CHECKS_THRESHOLD) {
+                        disableOffload()
+                        val idx = player.currentMediaItemIndex
+                        player.seekTo(idx, currentPosition)
+                        player.prepare()
+                        break
+                    }
+                } else {
+                    staleChecks = 0
+                    lastPosition = currentPosition
+                }
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -928,12 +928,12 @@ class MusicService :
             dataStore.data.map { it[AudioOffload] ?: false },
             dataStore.data.map { it[CrossfadeEnabledKey] ?: false },
         ) { offloadPref, crossfadeEnabled ->
-            // Force disable offload if crossfade is enabled to prevent volume ramp issues
             if (crossfadeEnabled) false else offloadPref
         }.distinctUntilChanged()
             .collectLatest(scope) { useOffload ->
                 player.setOffloadEnabled(useOffload)
                 secondaryPlayer?.setOffloadEnabled(useOffload)
+                playerSilenceProcessors.values.forEach { it.offloadMode = useOffload }
             }
 
         var isFirstAudioTrackParamsEmit = true
@@ -1351,14 +1351,18 @@ class MusicService :
         if (prefs != null) {
             val offload = prefs[AudioOffload] ?: false
             val crossfade = prefs[CrossfadeEnabledKey] ?: false
-            player.setOffloadEnabled(if (crossfade) false else offload)
+            val effectiveOffload = if (crossfade) false else offload
+            player.setOffloadEnabled(effectiveOffload)
+            silenceProcessor.offloadMode = effectiveOffload
             player.skipSilenceEnabled = prefs[SkipSilenceKey] ?: false
         } else {
             player.apply {
                 runBlocking {
                     val offload = dataStore.get(AudioOffload, false)
                     val crossfade = dataStore.get(CrossfadeEnabledKey, false)
-                    setOffloadEnabled(if (crossfade) false else offload)
+                    val effectiveOffload = if (crossfade) false else offload
+                    setOffloadEnabled(effectiveOffload)
+                    silenceProcessor.offloadMode = effectiveOffload
                     skipSilenceEnabled = dataStore.get(SkipSilenceKey, false)
                 }
             }

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -2521,6 +2521,8 @@ class MusicService :
 
         lastPlaybackSpeed = -1.0f // force update song
 
+        silenceSkipJob?.cancel()
+        isSilenceSkipping = false
         playerSilenceProcessors[player]?.resetTracking()
         setupAudioNormalization()
 
@@ -3420,17 +3422,26 @@ class MusicService :
 
     private fun handleLongSilenceDetected() {
         if (!instantSilenceSkipEnabled.value) return
-        if (silenceSkipJob?.isActive == true) return
 
-        silenceSkipJob =
-            scope.launch {
+        scope.launch(Dispatchers.Main) {
+            if (silenceSkipJob?.isActive == true) return@launch
+            
+            if (player.currentPosition < 2000) {
+                Timber.tag(TAG).d("Ignoring silence detected at start of track (bleed-over)")
+                return@launch
+            }
+
+            val expectedMediaItemIndex = player.currentMediaItemIndex
+
+            silenceSkipJob = launch {
                 // Debounce so short fades or transitions do not trigger a jump.
                 delay(200)
-                performInstantSilenceSkip()
+                performInstantSilenceSkip(expectedMediaItemIndex)
             }
+        }
     }
 
-    private suspend fun performInstantSilenceSkip() {
+    private suspend fun performInstantSilenceSkip(expectedMediaItemIndex: Int) {
         val duration = player.duration.takeIf { it != C.TIME_UNSET && it > 0 } ?: return
         if (duration <= INSTANT_SILENCE_SKIP_STEP_MS) return
 
@@ -3439,6 +3450,11 @@ class MusicService :
             var hops = 0
             val silenceProcessor = playerSilenceProcessors[player] ?: return
             while (coroutineContext.isActive && instantSilenceSkipEnabled.value && silenceProcessor.isCurrentlySilent()) {
+                if (player.currentMediaItemIndex != expectedMediaItemIndex) {
+                    Timber.tag(TAG).d("Media item changed, aborting silence skip")
+                    break
+                }
+
                 val current = player.currentPosition
                 val target = (current + INSTANT_SILENCE_SKIP_STEP_MS).coerceAtMost(duration - 500)
 

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -466,6 +466,8 @@ class MusicService :
     private var originalQueueSize: Int = 0
 
     private var consecutivePlaybackErr = 0
+    private var currentOffloadEnabled = false
+    private var offloadStallJob: Job? = null
     private var retryJob: Job? = null
     private var retryCount = 0
     // True only when stopOnError() paused playback purely because of a network outage
@@ -540,6 +542,7 @@ class MusicService :
     private var currentMediaIdRetryCount = mutableMapOf<String, Int>()
     private val MAX_RETRY_PER_SONG = 3
     private val RETRY_DELAY_MS = 1000L
+    private val OFFLOAD_STALL_TIMEOUT_MS = 10_000L
 
     // Track failed songs to prevent infinite retry loops
     private val recentlyFailedSongs = mutableSetOf<String>()
@@ -931,6 +934,7 @@ class MusicService :
             if (crossfadeEnabled) false else offloadPref
         }.distinctUntilChanged()
             .collectLatest(scope) { useOffload ->
+                currentOffloadEnabled = useOffload
                 player.setOffloadEnabled(useOffload)
                 secondaryPlayer?.setOffloadEnabled(useOffload)
                 playerSilenceProcessors.values.forEach { it.offloadMode = useOffload }
@@ -2612,12 +2616,32 @@ class MusicService :
             retryCount = 0
             waitingForNetworkConnection.value = false
             retryJob?.cancel()
+            offloadStallJob?.cancel()
 
             player.currentMediaItem?.mediaId?.let { mediaId ->
                 resetRetryCount(mediaId)
                 Timber.tag(TAG).d("Playback successful for $mediaId, reset retry count")
             }
             scheduleCrossfade()
+        }
+
+        if (playbackState == Player.STATE_BUFFERING && currentOffloadEnabled && player.playWhenReady) {
+            offloadStallJob?.cancel()
+            offloadStallJob = scope.launch {
+                delay(OFFLOAD_STALL_TIMEOUT_MS)
+                if (player.playbackState == Player.STATE_BUFFERING && currentOffloadEnabled) {
+                    Timber.tag(TAG).w("Offload stall detected — disabling offload")
+                    player.setOffloadEnabled(false)
+                    secondaryPlayer?.setOffloadEnabled(false)
+                    currentOffloadEnabled = false
+                    playerSilenceProcessors.values.forEach { it.offloadMode = false }
+                    safeDataStoreEdit { settings -> settings[AudioOffload] = false }
+                    val idx = player.currentMediaItemIndex
+                    val pos = player.currentPosition
+                    player.seekTo(idx, pos)
+                    player.prepare()
+                }
+            }
         }
 
         if (playbackState == Player.STATE_IDLE || playbackState == Player.STATE_ENDED) {

--- a/app/src/main/kotlin/com/metrolist/music/playback/audio/SilenceDetectorAudioProcessor.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/audio/SilenceDetectorAudioProcessor.kt
@@ -71,6 +71,8 @@ class SilenceDetectorAudioProcessor(
             outputBuffer = EMPTY_BUFFER
             return
         }
+        
+        inputEnded = false
 
         if (offloadMode) {
             val out = replaceOutputBuffer(inputBuffer.remaining())
@@ -137,6 +139,7 @@ class SilenceDetectorAudioProcessor(
 
     override fun queueEndOfStream() {
         inputEnded = true
+        clearSilenceState()
     }
 
     override fun getOutput(): ByteBuffer {

--- a/app/src/main/kotlin/com/metrolist/music/playback/audio/SilenceDetectorAudioProcessor.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/audio/SilenceDetectorAudioProcessor.kt
@@ -36,6 +36,13 @@ class SilenceDetectorAudioProcessor(
     var instantModeEnabled: Boolean = false
 
     @Volatile
+    var offloadMode: Boolean = false
+        set(value) {
+            field = value
+            if (value) clearSilenceState()
+        }
+
+    @Volatile
     private var consecutiveSilentFrames: Long = 0
 
     @Volatile
@@ -44,6 +51,8 @@ class SilenceDetectorAudioProcessor(
     private var notifiedThisSilence = false
 
     override fun configure(inputAudioFormat: AudioProcessor.AudioFormat): AudioProcessor.AudioFormat {
+        if (offloadMode) return inputAudioFormat
+
         sampleRate = inputAudioFormat.sampleRate
         channelCount = inputAudioFormat.channelCount
         encoding = inputAudioFormat.encoding
@@ -55,7 +64,7 @@ class SilenceDetectorAudioProcessor(
         return inputAudioFormat
     }
 
-    override fun isActive(): Boolean = true
+    override fun isActive(): Boolean = !offloadMode
 
     override fun queueInput(inputBuffer: ByteBuffer) {
         if (!inputBuffer.hasRemaining()) {
@@ -63,7 +72,13 @@ class SilenceDetectorAudioProcessor(
             return
         }
 
-        // Analyze the incoming PCM for silence without mutating the buffer position.
+        if (offloadMode) {
+            val out = replaceOutputBuffer(inputBuffer.remaining())
+            out.put(inputBuffer)
+            out.flip()
+            return
+        }
+
         if (instantModeEnabled && sampleRate > 0 && channelCount > 0) {
             detectSilence(inputBuffer)
         } else {

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -5,8 +5,12 @@
 
 package com.metrolist.music.utils
 
+import android.media.AudioAttributes
+import android.media.AudioFormat
+import android.media.AudioManager
 import android.net.ConnectivityManager
 import android.net.Uri
+import android.os.Build
 import androidx.media3.common.PlaybackException
 import com.metrolist.innertube.NewPipeExtractor
 import com.metrolist.innertube.YouTube
@@ -138,6 +142,7 @@ object YTPlayerUtils {
         audioQuality: AudioQuality,
         connectivityManager: ConnectivityManager,
         contentHints: ContentHints = ContentHints(),
+        offloadEnabled: Boolean = false,
     ): Result<PlaybackData> = runCatching {
         Timber.tag(TAG).d("Player response for playback")
         Timber.tag(TAG).d("videoId: $videoId")
@@ -306,6 +311,7 @@ object YTPlayerUtils {
                         responseToUse,
                         audioQuality,
                         connectivityManager,
+                        offloadEnabled,
                     )
 
                 if (format == null) {
@@ -546,19 +552,51 @@ object YTPlayerUtils {
             .onFailure { Timber.tag(logTag).e(it, "Failed to fetch metadata player response") }
     }
 
+    private fun isOffloadCompatible(format: PlayerResponse.StreamingData.Format): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return false
+        val encoding = when {
+            format.mimeType.contains("opus", ignoreCase = true) -> AudioFormat.ENCODING_OPUS
+            format.mimeType.contains("mp4a", ignoreCase = true) -> AudioFormat.ENCODING_AAC_LC
+            else -> return false
+        }
+        val sampleRate = format.audioSampleRate ?: return false
+        val channelCount = format.audioChannels ?: 2
+        val channelMask = if (channelCount == 1) AudioFormat.CHANNEL_OUT_MONO else AudioFormat.CHANNEL_OUT_STEREO
+        val audioFormat = AudioFormat.Builder()
+            .setEncoding(encoding)
+            .setSampleRate(sampleRate)
+            .setChannelMask(channelMask)
+            .build()
+        val attributes = AudioAttributes.Builder()
+            .setUsage(AudioAttributes.USAGE_MEDIA)
+            .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+            .build()
+        return AudioManager.isOffloadedPlaybackSupported(audioFormat, attributes)
+    }
+
     private fun findFormat(
         playerResponse: PlayerResponse,
         audioQuality: AudioQuality,
         connectivityManager: ConnectivityManager,
+        offloadEnabled: Boolean = false,
     ): PlayerResponse.StreamingData.Format? {
-        Timber.tag(logTag).d("Finding format with audioQuality: $audioQuality, network metered: ${connectivityManager.isActiveNetworkMetered}")
+        Timber.tag(logTag).d("Finding format with audioQuality: $audioQuality, network metered: ${connectivityManager.isActiveNetworkMetered}, offload: $offloadEnabled")
 
         val adaptiveFormats = playerResponse.streamingData?.adaptiveFormats ?: return null
 
         val audioCapableFormats = adaptiveFormats.filter { it.isAudio }
         if (audioCapableFormats.isEmpty()) return null
 
-        val maxBitrate = audioCapableFormats.maxOfOrNull { it.bitrate } ?: return null
+        val offloadFormats = if (offloadEnabled) {
+            audioCapableFormats.filter { isOffloadCompatible(it) }.ifEmpty {
+                Timber.tag(logTag).w("No offload-compatible formats found, falling back to all formats")
+                audioCapableFormats
+            }
+        } else {
+            audioCapableFormats
+        }
+
+        val maxBitrate = offloadFormats.maxOfOrNull { it.bitrate } ?: return null
 
         fun scoreCodec(mimeType: String): Int = when {
             mimeType.contains("opus", ignoreCase = true) -> 2
@@ -568,7 +606,7 @@ object YTPlayerUtils {
 
         val format = when (audioQuality) {
             AudioQuality.HIGH -> {
-                audioCapableFormats.maxWithOrNull(
+                offloadFormats.maxWithOrNull(
                     compareBy<PlayerResponse.StreamingData.Format> { format ->
                         when (format.audioQuality) {
                             "AUDIO_QUALITY_HIGH" -> 3
@@ -583,15 +621,15 @@ object YTPlayerUtils {
             }
 
             AudioQuality.LOW -> {
-                val cappedFormats = audioCapableFormats.filter { it.bitrate <= 128000 }
+                val cappedFormats = offloadFormats.filter { it.bitrate <= 128000 }
                 val lowFormat = cappedFormats
                     .filter { it.isOriginal }
                     .maxByOrNull { it.bitrate }
                     ?: cappedFormats.maxByOrNull { it.bitrate }
-                    ?: audioCapableFormats
+                    ?: offloadFormats
                         .filter { it.isOriginal }
                         .minByOrNull { kotlin.math.abs(it.bitrate.toDouble() - 128000.0) }
-                    ?: audioCapableFormats.maxByOrNull { it.bitrate }
+                    ?: offloadFormats.maxByOrNull { it.bitrate }
 
                 if (lowFormat != null) {
                     Timber.tag(logTag).d("Selected LOW format: itag=${lowFormat.itag}, bitrate: ${lowFormat.bitrate}")
@@ -602,15 +640,15 @@ object YTPlayerUtils {
 
             AudioQuality.AUTO -> {
                 val targetBitrate = if (connectivityManager.isActiveNetworkMetered) 128000.0 else maxBitrate.toDouble()
-                val cappedFormats = audioCapableFormats.filter { it.bitrate <= targetBitrate }
+                val cappedFormats = offloadFormats.filter { it.bitrate <= targetBitrate }
                 val autoFormat = cappedFormats
                     .filter { it.isOriginal }
                     .maxByOrNull { it.bitrate }
                     ?: cappedFormats.maxByOrNull { it.bitrate }
-                    ?: audioCapableFormats
+                    ?: offloadFormats
                         .filter { it.isOriginal }
                         .minByOrNull { kotlin.math.abs(it.bitrate - targetBitrate) }
-                    ?: audioCapableFormats.maxByOrNull { it.bitrate }
+                    ?: offloadFormats.maxByOrNull { it.bitrate }
 
                 if (autoFormat != null) {
                     Timber.tag(logTag).d("Selected AUTO format: itag=${autoFormat.itag}, bitrate: ${autoFormat.bitrate}")

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -139,7 +139,7 @@ object YTPlayerUtils {
         connectivityManager: ConnectivityManager,
         contentHints: ContentHints = ContentHints(),
     ): Result<PlaybackData> = runCatching {
-        Timber.tag(TAG).d("=== PLAYER RESPONSE FOR PLAYBACK ===")
+        Timber.tag(TAG).d("Player response for playback")
         Timber.tag(TAG).d("videoId: $videoId")
         Timber.tag(TAG).d("playlistId: $playlistId")
         Timber.tag(TAG).d("audioQuality: $audioQuality")
@@ -326,7 +326,7 @@ object YTPlayerUtils {
 
                 val musicVideoType = streamPlayerResponse.videoDetails?.musicVideoType
 
-                Timber.tag(TAG).d("=== N-TRANSFORM DECISION ===")
+                Timber.tag(TAG).d("N-transform decision")
                 Timber.tag(TAG).d("Content type analysis:")
                 Timber.tag(TAG).d("  musicVideoType: $musicVideoType")
                 Timber.tag(TAG).d("  isUploadedTrack (from playlistId): $isUploadedTrack")
@@ -437,7 +437,7 @@ object YTPlayerUtils {
                 if (currentClient.clientName == "WEB_REMIX" &&
                     !webRemixFailedIds.contains(videoId)
                 ) {
-                    Timber.tag(logTag).d("WEB_REMIX — skipping HEAD validation, letting ExoPlayer try directly")
+                    Timber.tag(logTag).d("WEB_REMIX skipping HEAD validation, letting ExoPlayer try directly")
                     Timber.tag(TAG).i("Playback: client=${currentClient.clientName}, videoId=$videoId")
                     successClient = currentClient.clientName
                     break
@@ -810,7 +810,7 @@ object YTPlayerUtils {
         playlistId: String? = null,
         connectivityManager: ConnectivityManager,
     ): Result<VideoStreamData> = runCatching {
-        Timber.tag(TAG).d("=== VIDEO STREAM FOR PLAYBACK ===")
+        Timber.tag(TAG).d("Video stream for playback")
         Timber.tag(TAG).d("videoId: $videoId")
 
         val signatureTimestamp = getSignatureTimestampOrNull(videoId)
@@ -901,7 +901,7 @@ object YTPlayerUtils {
             if (isLastFallback) {
                 Timber.tag(TAG).d("Using last fallback client without validation: ${currentClient.clientName}")
             } else if (currentClient.clientName == "WEB_REMIX" && !webRemixFailedIds.contains(videoId)) {
-                Timber.tag(TAG).d("WEB_REMIX — skipping HEAD validation for video stream")
+                Timber.tag(TAG).d("WEB_REMIX skipping HEAD validation for video stream")
             } else if (!validateStatus(finalUrl)) {
                 Timber.tag(TAG).d("Video stream validation failed for client: ${currentClient.clientName}")
                 continue

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -71,6 +71,19 @@ object YTPlayerUtils {
     private val MAIN_CLIENT: YouTubeClient = WEB_REMIX
     private val fallbackStrategy = ContentAwareFallbackStrategy()
 
+    /** Client fallback chain used by [videoStreamForPlayback] to resolve a video-capable stream. */
+    private val STREAM_FALLBACK_CLIENTS: Array<YouTubeClient> = arrayOf(
+        YouTubeClient.VISIONOS,
+        YouTubeClient.WEB_CREATOR,
+        YouTubeClient.TVHTML5,
+        YouTubeClient.IOS,
+        YouTubeClient.IPADOS,
+        YouTubeClient.ANDROID_CREATOR,
+        YouTubeClient.ANDROID_VR_NO_AUTH,
+        YouTubeClient.MOBILE,
+        YouTubeClient.WEB,
+    )
+
     /** Client names disabled by the user in Settings → Stream sources. Updated reactively by MusicService. */
     @Volatile
     var disabledStreamClients: Set<String> = emptySet()
@@ -104,6 +117,15 @@ object YTPlayerUtils {
         val streamUrl: String,
         val streamExpiresInSeconds: Int,
         val streamClient: String = "unknown",
+    )
+
+    data class VideoStreamData(
+        val streamUrl: String,
+        val streamExpiresInSeconds: Int,
+        val width: Int,
+        val height: Int,
+        val mimeType: String,
+        val streamClient: String,
     )
     /**
      * Custom player response intended to use for playback.
@@ -466,17 +488,8 @@ object YTPlayerUtils {
 
         if (streamPlayerResponse.playabilityStatus.status != "OK") {
             val errorReason = streamPlayerResponse.playabilityStatus.reason
-            // YouTube often surfaces generic reasons (e.g. "error 2000") for restricted or
-            // unavailable streams; Metrolist cannot recover those without official playback.
-            Timber.tag(logTag).e("Playability status not OK: $errorReason")
-            if (isUploadedTrack) {
-                println("[PLAYBACK_DEBUG] FAILURE: Playability not OK for uploaded track - status=${streamPlayerResponse.playabilityStatus.status}, reason=$errorReason")
-            }
-            throw PlaybackException(
-                errorReason,
-                null,
-                PlaybackException.ERROR_CODE_REMOTE_ERROR
-            )
+            Timber.tag(logTag).e("Playability not OK: $errorReason (status=${streamPlayerResponse.playabilityStatus.status})")
+            throw PlaybackException(errorReason, null, PlaybackException.ERROR_CODE_REMOTE_ERROR)
         }
 
         if (streamExpiresInSeconds == null) {
@@ -769,5 +782,152 @@ object YTPlayerUtils {
 
     fun forceRefreshForVideo(videoId: String) {
         Timber.tag(logTag).d("Force refreshing for videoId: $videoId")
+    }
+
+    /**
+     * Find a video-capable format (muxed audio+video or video-only) from the player response.
+     * Prefers muxed formats to avoid A/V sync issues.
+     */
+    private fun findVideoFormat(
+        playerResponse: PlayerResponse,
+    ): PlayerResponse.StreamingData.Format? {
+        val muxedFormats = playerResponse.streamingData?.formats
+            ?.filter { !it.isAudio && it.width != null }
+        if (!muxedFormats.isNullOrEmpty()) {
+            return muxedFormats.maxByOrNull { (it.height ?: 0) * (it.bitrate) }
+        }
+        val videoAdaptive = playerResponse.streamingData?.adaptiveFormats
+            ?.filter { !it.isAudio && it.width != null }
+        return videoAdaptive?.maxByOrNull { (it.height ?: 0) * (it.bitrate) }
+    }
+
+    /**
+     * Resolves a video stream URL for the given videoId.
+     * Reuses the same client fallback chain and cipher/poToken infrastructure as audio playback.
+     */
+    suspend fun videoStreamForPlayback(
+        videoId: String,
+        playlistId: String? = null,
+        connectivityManager: ConnectivityManager,
+    ): Result<VideoStreamData> = runCatching {
+        Timber.tag(TAG).d("=== VIDEO STREAM FOR PLAYBACK ===")
+        Timber.tag(TAG).d("videoId: $videoId")
+
+        val signatureTimestamp = getSignatureTimestampOrNull(videoId)
+        val sessionId = YouTube.visitorData
+        var poToken: PoTokenResult? = null
+        if (MAIN_CLIENT.useWebPoTokens && sessionId != null) {
+            try {
+                poToken = poTokenGenerator.getWebClientPoToken(videoId, sessionId)
+            } catch (_: Exception) { }
+        }
+
+        var mainPlayerResponse = YouTube.player(videoId, playlistId, MAIN_CLIENT, signatureTimestamp.timestamp, poToken?.playerRequestPoToken).getOrThrow()
+
+        val isLoggedIn = YouTube.cookie != null
+        val currentStatus = mainPlayerResponse.playabilityStatus.status
+        val isAgeRestricted = currentStatus in listOf("AGE_CHECK_REQUIRED", "AGE_VERIFICATION_REQUIRED", "LOGIN_REQUIRED", "CONTENT_CHECK_REQUIRED")
+
+        if (isAgeRestricted && isLoggedIn) {
+            val creatorResponse = YouTube.player(videoId, playlistId, YouTubeClient.WEB_CREATOR, null, null).getOrNull()
+            if (creatorResponse?.playabilityStatus?.status == "OK") {
+                mainPlayerResponse = creatorResponse
+            }
+        }
+
+        var bestFormat: PlayerResponse.StreamingData.Format? = null
+        var bestUrl: String? = null
+        var bestExpiry: Int? = null
+        var bestClient: String? = null
+
+        val startIndex = if (isAgeRestricted) 0 else -1
+
+        for (clientIndex in (startIndex until STREAM_FALLBACK_CLIENTS.size)) {
+            val client: YouTubeClient
+            val streamPlayerResponse: PlayerResponse?
+            if (clientIndex == -1) {
+                client = MAIN_CLIENT
+                if (client.clientName in disabledStreamClients) continue
+                streamPlayerResponse = mainPlayerResponse
+            } else {
+                client = STREAM_FALLBACK_CLIENTS[clientIndex]
+                if (client.clientName in disabledStreamClients) continue
+                if (client.loginRequired && !isLoggedIn && YouTube.cookie == null) continue
+                val clientPoToken = if (client.useWebPoTokens) poToken?.playerRequestPoToken else null
+                val clientSigTimestamp = if (isAgeRestricted) null else signatureTimestamp.timestamp
+                streamPlayerResponse = YouTube.player(videoId, playlistId, client, clientSigTimestamp, clientPoToken).getOrNull()
+            }
+
+            if (streamPlayerResponse?.playabilityStatus?.status != "OK") continue
+
+            val responseToUse = if (isAgeRestricted) {
+                streamPlayerResponse
+            } else {
+                YouTube.newPipePlayer(videoId, streamPlayerResponse) ?: streamPlayerResponse
+            }
+
+            val format = findVideoFormat(responseToUse) ?: continue
+            val streamUrl = findUrlOrNull(format, videoId, responseToUse, skipNewPipe = isAgeRestricted) ?: continue
+
+            val currentClient = if (clientIndex == -1) {
+                MAIN_CLIENT
+            } else {
+                STREAM_FALLBACK_CLIENTS[clientIndex]
+            }
+
+            val needsNTransform = currentClient.useWebPoTokens ||
+                currentClient.clientName in listOf("WEB", "WEB_REMIX", "WEB_CREATOR", "TVHTML5")
+
+            var finalUrl = streamUrl
+            if (needsNTransform) {
+                try {
+                    finalUrl = CipherDeobfuscator.transformNParamInUrl(streamUrl)
+                    if (currentClient.useWebPoTokens && poToken?.streamingDataPoToken != null) {
+                        val separator = if ("?" in finalUrl) "&" else "?"
+                        finalUrl = "${finalUrl}${separator}pot=${Uri.encode(poToken.streamingDataPoToken)}"
+                    }
+                } catch (_: Exception) { }
+            }
+
+            val expiry = responseToUse.streamingData?.expiresInSeconds ?: continue
+
+            bestFormat = format
+            bestUrl = finalUrl
+            bestExpiry = expiry
+            bestClient = currentClient.clientName
+            break
+        }
+
+        if (bestUrl == null || bestFormat == null || bestExpiry == null) {
+            throw Exception("No video stream found for videoId=$videoId")
+        }
+
+        VideoStreamData(
+            streamUrl = bestUrl,
+            streamExpiresInSeconds = bestExpiry,
+            width = bestFormat.width ?: 0,
+            height = bestFormat.height ?: 0,
+            mimeType = bestFormat.mimeType,
+            streamClient = bestClient ?: "unknown",
+        )
+    }
+
+    /**
+     * Quick check if a video stream is available for the given videoId.
+     * Does a lightweight player response check without resolving the full stream URL.
+     */
+    suspend fun hasVideoStream(videoId: String): Boolean = try {
+        val signatureTimestamp = getSignatureTimestampOrNull(videoId)
+        val sessionId = YouTube.visitorData
+        var poToken: PoTokenResult? = null
+        if (MAIN_CLIENT.useWebPoTokens && sessionId != null) {
+            try {
+                poToken = poTokenGenerator.getWebClientPoToken(videoId, sessionId)
+            } catch (_: Exception) { }
+        }
+        val response = YouTube.player(videoId, null, MAIN_CLIENT, signatureTimestamp.timestamp, poToken?.playerRequestPoToken).getOrNull()
+        response?.playabilityStatus?.status == "OK" && findVideoFormat(response) != null
+    } catch (_: Exception) {
+        false
     }
 }

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -897,6 +897,16 @@ object YTPlayerUtils {
 
             val expiry = responseToUse.streamingData?.expiresInSeconds ?: continue
 
+            val isLastFallback = clientIndex == STREAM_FALLBACK_CLIENTS.lastIndex
+            if (isLastFallback) {
+                Timber.tag(TAG).d("Using last fallback client without validation: ${currentClient.clientName}")
+            } else if (currentClient.clientName == "WEB_REMIX" && !webRemixFailedIds.contains(videoId)) {
+                Timber.tag(TAG).d("WEB_REMIX — skipping HEAD validation for video stream")
+            } else if (!validateStatus(finalUrl)) {
+                Timber.tag(TAG).d("Video stream validation failed for client: ${currentClient.clientName}")
+                continue
+            }
+
             bestFormat = format
             bestUrl = finalUrl
             bestExpiry = expiry

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -819,13 +819,17 @@ object YTPlayerUtils {
         if (MAIN_CLIENT.useWebPoTokens && sessionId != null) {
             try {
                 poToken = poTokenGenerator.getWebClientPoToken(videoId, sessionId)
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
             } catch (_: Exception) { }
         }
 
-        var mainPlayerResponse = YouTube.player(videoId, playlistId, MAIN_CLIENT, signatureTimestamp.timestamp, poToken?.playerRequestPoToken).getOrThrow()
+        var mainPlayerResponse = YouTube.player(videoId, playlistId, MAIN_CLIENT, signatureTimestamp.timestamp, poToken?.playerRequestPoToken)
+            .onFailure { Timber.tag(TAG).w(it, "Main client failed for video stream; continuing with fallbacks") }
+            .getOrNull()
 
         val isLoggedIn = YouTube.cookie != null
-        val currentStatus = mainPlayerResponse.playabilityStatus.status
+        val currentStatus = mainPlayerResponse?.playabilityStatus?.status
         val isAgeRestricted = currentStatus in listOf("AGE_CHECK_REQUIRED", "AGE_VERIFICATION_REQUIRED", "LOGIN_REQUIRED", "CONTENT_CHECK_REQUIRED")
 
         if (isAgeRestricted && isLoggedIn) {
@@ -886,6 +890,8 @@ object YTPlayerUtils {
                         val separator = if ("?" in finalUrl) "&" else "?"
                         finalUrl = "${finalUrl}${separator}pot=${Uri.encode(poToken.streamingDataPoToken)}"
                     }
+                } catch (e: kotlinx.coroutines.CancellationException) {
+                    throw e
                 } catch (_: Exception) { }
             }
 
@@ -923,10 +929,14 @@ object YTPlayerUtils {
         if (MAIN_CLIENT.useWebPoTokens && sessionId != null) {
             try {
                 poToken = poTokenGenerator.getWebClientPoToken(videoId, sessionId)
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
             } catch (_: Exception) { }
         }
         val response = YouTube.player(videoId, null, MAIN_CLIENT, signatureTimestamp.timestamp, poToken?.playerRequestPoToken).getOrNull()
         response?.playabilityStatus?.status == "OK" && findVideoFormat(response) != null
+    } catch (e: kotlinx.coroutines.CancellationException) {
+        throw e
     } catch (_: Exception) {
         false
     }

--- a/app/src/main/kotlin/com/metrolist/music/utils/potoken/PoTokenGenerator.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/potoken/PoTokenGenerator.kt
@@ -29,12 +29,18 @@ class PoTokenGenerator {
             return null
         }
 
+        val deadlineMs = System.currentTimeMillis() + POTOKEN_TIMEOUT_MS
         repeat(POTOKEN_MAX_RETRIES) { attempt ->
+            val remainingMs = deadlineMs - System.currentTimeMillis()
+            if (remainingMs <= 0) {
+                Timber.tag(TAG).w("PoToken deadline exceeded; aborting retry loop")
+                return null
+            }
             val isLastAttempt = attempt == POTOKEN_MAX_RETRIES - 1
             try {
-                Timber.tag(TAG).d("PoToken attempt ${attempt + 1}/$POTOKEN_MAX_RETRIES (timeout=${POTOKEN_TIMEOUT_MS}ms)")
+                Timber.tag(TAG).d("PoToken attempt ${attempt + 1}/$POTOKEN_MAX_RETRIES (${remainingMs}ms remaining)")
                 val result = runBlocking {
-                    withTimeout(POTOKEN_TIMEOUT_MS) {
+                    withTimeout(remainingMs) {
                         getWebClientPoToken(videoId, sessionId, forceRecreate = attempt > 0)
                     }
                 }
@@ -51,8 +57,11 @@ class PoTokenGenerator {
                 return null
             } catch (e: BadWebViewException) {
                 Timber.tag(TAG).e(e, "WebView broken; disabling PoToken")
+                resetWebViewState()
                 webViewBadImpl = true
                 return null
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Timber.tag(TAG).e(e, "PoToken attempt ${attempt + 1} failed: ${e.message}")
                 if (!isLastAttempt) {

--- a/app/src/main/kotlin/com/metrolist/music/utils/potoken/PoTokenGenerator.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/potoken/PoTokenGenerator.kt
@@ -24,49 +24,61 @@ class PoTokenGenerator {
 
     fun getWebClientPoToken(videoId: String, sessionId: String): PoTokenResult? {
         Timber.tag(TAG).d("getWebClientPoToken called: videoId=$videoId, sessionId=$sessionId")
-        Timber.tag(TAG).d("WebView state: supported=$webViewSupported, badImpl=$webViewBadImpl")
         if (!webViewSupported || webViewBadImpl) {
             Timber.tag(TAG).d("WebView not available: supported=$webViewSupported, badImpl=$webViewBadImpl")
             return null
         }
 
-        return try {
-            Timber.tag(TAG).d("Calling runBlocking to generate poToken (timeout=${POTOKEN_TIMEOUT_MS}ms)...")
-            runBlocking {
-                withTimeout(POTOKEN_TIMEOUT_MS) {
-                    getWebClientPoToken(videoId, sessionId, forceRecreate = false)
-                }
-            }
-        } catch (e: TimeoutCancellationException) {
-            // The WebView's sandboxed process can be culled by the OS (storage pressure, low
-            // memory, etc.) which leaves the PoToken WebView call hung indefinitely. Cap it so
-            // playerResponseForPlayback can fall through to non-PoToken fallback clients (e.g.
-            // ANDROID_VR) instead of blocking the entire playback path.
-            Timber.tag(TAG).w("poToken generation timed out after ${POTOKEN_TIMEOUT_MS}ms; proceeding without PoToken")
-            runBlocking {
-                webPoTokenGenLock.withLock {
-                    try {
-                        withContext(Dispatchers.Main) {
-                            webPoTokenGenerator?.close()
-                        }
-                    } catch (closeEx: Exception) {
-                        Timber.tag(TAG).e(closeEx, "Exception closing PoTokenWebView during timeout cleanup")
+        repeat(POTOKEN_MAX_RETRIES) { attempt ->
+            val isLastAttempt = attempt == POTOKEN_MAX_RETRIES - 1
+            try {
+                Timber.tag(TAG).d("PoToken attempt ${attempt + 1}/$POTOKEN_MAX_RETRIES (timeout=${POTOKEN_TIMEOUT_MS}ms)")
+                val result = runBlocking {
+                    withTimeout(POTOKEN_TIMEOUT_MS) {
+                        getWebClientPoToken(videoId, sessionId, forceRecreate = attempt > 0)
                     }
-                    webPoTokenGenerator = null
-                    webPoTokenStreamingPot = null
-                    webPoTokenSessionId = null
                 }
+                if (result != null) return result
+                Timber.tag(TAG).w("PoToken returned null on attempt ${attempt + 1}; not retrying")
+                return null
+            } catch (e: TimeoutCancellationException) {
+                Timber.tag(TAG).w("PoToken timed out on attempt ${attempt + 1}/${POTOKEN_MAX_RETRIES}")
+                resetWebViewState()
+                if (!isLastAttempt) {
+                    Timber.tag(TAG).d("Retrying PoToken after timeout...")
+                    return@repeat
+                }
+                return null
+            } catch (e: BadWebViewException) {
+                Timber.tag(TAG).e(e, "WebView broken; disabling PoToken")
+                webViewBadImpl = true
+                return null
+            } catch (e: Exception) {
+                Timber.tag(TAG).e(e, "PoToken attempt ${attempt + 1} failed: ${e.message}")
+                if (!isLastAttempt) {
+                    Timber.tag(TAG).d("Retrying PoToken after failure...")
+                    resetWebViewState()
+                    return@repeat
+                }
+                throw e
             }
-            null
-        } catch (e: Exception) {
-            Timber.tag(TAG).e(e, "poToken generation exception: ${e.javaClass.simpleName}: ${e.message}")
-            when (e) {
-                is BadWebViewException -> {
-                    Timber.tag(TAG).e(e, "Could not obtain poToken because WebView is broken")
-                    webViewBadImpl = true
-                    null
+        }
+        return null
+    }
+
+    private fun resetWebViewState() {
+        runBlocking {
+            webPoTokenGenLock.withLock {
+                try {
+                    withContext(Dispatchers.Main) {
+                        webPoTokenGenerator?.close()
+                    }
+                } catch (e: Exception) {
+                    Timber.tag(TAG).w(e, "Exception closing PoTokenWebView during reset")
                 }
-                else -> throw e // includes PoTokenException
+                webPoTokenGenerator = null
+                webPoTokenStreamingPot = null
+                webPoTokenSessionId = null
             }
         }
     }
@@ -76,6 +88,7 @@ class PoTokenGenerator {
         // 8s leaves slack for a slow device without making the user wait too long before the
         // fallback chain (ANDROID_VR, etc.) takes over when the WebView hangs.
         const val POTOKEN_TIMEOUT_MS = 8_000L
+        const val POTOKEN_MAX_RETRIES = 2
     }
 
     /**

--- a/app/src/main/kotlin/com/metrolist/music/utils/potoken/PoTokenGenerator.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/potoken/PoTokenGenerator.kt
@@ -108,72 +108,58 @@ class PoTokenGenerator {
     private suspend fun getWebClientPoToken(videoId: String, sessionId: String, forceRecreate: Boolean): PoTokenResult {
         Timber.tag(TAG).d("Web poToken requested: videoId=$videoId, sessionId=$sessionId")
 
-        val (poTokenGenerator, streamingPot, hasBeenRecreated) =
-            webPoTokenGenLock.withLock {
-                val shouldRecreate =
-                    forceRecreate || webPoTokenGenerator == null || webPoTokenGenerator!!.isExpired ||
-                        // Renderer died (OOM kill) — recreate proactively instead of letting the
-                        // first post-crash generatePoToken() fail against the dead instance.
-                        webPoTokenGenerator!!.isDead ||
-                        webPoTokenSessionId != sessionId
+        return webPoTokenGenLock.withLock {
+            val shouldRecreate =
+                forceRecreate || webPoTokenGenerator == null || webPoTokenGenerator!!.isExpired ||
+                    webPoTokenGenerator!!.isDead ||
+                    webPoTokenSessionId != sessionId
 
-                if (shouldRecreate) {
-                    Timber.tag(TAG).d("Creating new PoTokenWebView (forceRecreate=$forceRecreate)")
+            if (shouldRecreate) {
+                Timber.tag(TAG).d("Creating new PoTokenWebView (forceRecreate=$forceRecreate)")
 
-                    withContext(Dispatchers.Main) {
-                        webPoTokenGenerator?.close()
-                    }
-
-                    // Clear the committed state BEFORE the fallible steps below: if creation or
-                    // the streaming-pot mint throws, the next call must compute
-                    // shouldRecreate=true instead of pairing the already-updated sessionId with
-                    // a null/stale streaming pot at the Triple below.
-                    webPoTokenGenerator = null
-                    webPoTokenStreamingPot = null
-                    webPoTokenSessionId = null
-
-                    val newGenerator = PoTokenWebView.getNewPoTokenGenerator(CipherDeobfuscator.appContext)
-
-                    // The streaming poToken needs to be generated exactly once before generating
-                    // any other (player) tokens.
-                    val newStreamingPot = try {
-                        newGenerator.generatePoToken(sessionId)
-                    } catch (t: Throwable) {
-                        // Don't leak the freshly created WebView (close() hops to Main itself).
-                        runCatching { newGenerator.close() }
-                        throw t
-                    }
-
-                    webPoTokenGenerator = newGenerator
-                    webPoTokenStreamingPot = newStreamingPot
-                    webPoTokenSessionId = sessionId
-                    Timber.tag(TAG).d("Streaming poToken generated for sessionId=${sessionId.take(20)}...")
+                withContext(Dispatchers.Main) {
+                    webPoTokenGenerator?.close()
                 }
 
-                Triple(webPoTokenGenerator!!, webPoTokenStreamingPot!!, shouldRecreate)
+                webPoTokenGenerator = null
+                webPoTokenStreamingPot = null
+                webPoTokenSessionId = null
+
+                val newGenerator = PoTokenWebView.getNewPoTokenGenerator(CipherDeobfuscator.appContext)
+
+                val newStreamingPot = try {
+                    newGenerator.generatePoToken(sessionId)
+                } catch (t: Throwable) {
+                    runCatching { newGenerator.close() }
+                    throw t
+                }
+
+                webPoTokenGenerator = newGenerator
+                webPoTokenStreamingPot = newStreamingPot
+                webPoTokenSessionId = sessionId
+                Timber.tag(TAG).d("Streaming poToken generated for sessionId=${sessionId.take(20)}...")
             }
 
-        val playerPot = try {
-            poTokenGenerator.generatePoToken(videoId)
-        } catch (throwable: Throwable) {
-            if (hasBeenRecreated) {
-                // the poTokenGenerator has just been recreated (and possibly this is already the
-                // second time we try), so there is likely nothing we can do
-                throw throwable
-            } else {
-                // retry, this time recreating the [webPoTokenGenerator] from scratch;
-                // this might happen for example if the app goes in the background and the WebView
-                // content is lost
-                Timber.tag(TAG).e(throwable, "Failed to obtain poToken, retrying")
-                return getWebClientPoToken(videoId = videoId, sessionId = sessionId, forceRecreate = true)
+            val generator = webPoTokenGenerator!!
+            val streamingPot = webPoTokenStreamingPot!!
+
+            val playerPot = try {
+                generator.generatePoToken(videoId)
+            } catch (throwable: Throwable) {
+                if (shouldRecreate) {
+                    throw throwable
+                } else {
+                    Timber.tag(TAG).e(throwable, "Failed to obtain poToken, retrying")
+                    return@withLock getWebClientPoToken(videoId = videoId, sessionId = sessionId, forceRecreate = true)
+                }
             }
+
+            Timber.tag(TAG).d("poToken generated successfully: session=${streamingPot.take(20)}..., video=${playerPot.take(20)}...")
+
+            PoTokenResult(
+                playerRequestPoToken = streamingPot,
+                streamingDataPoToken = playerPot,
+            )
         }
-
-        Timber.tag(TAG).d("poToken generated successfully: session=${streamingPot.take(20)}..., video=${playerPot.take(20)}...")
-
-        return PoTokenResult(
-            playerRequestPoToken = streamingPot,
-            streamingDataPoToken = playerPot,
-        )
     }
 }

--- a/app/src/main/kotlin/com/metrolist/music/utils/potoken/PoTokenWebView.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/potoken/PoTokenWebView.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.Handler
 import android.os.Looper
 import android.webkit.ConsoleMessage
+import android.webkit.CookieManager
 import android.webkit.JavascriptInterface
 import android.webkit.RenderProcessGoneDetail
 import android.webkit.WebChromeClient
@@ -460,6 +461,13 @@ class PoTokenWebView private constructor(
 
         suspend fun getNewPoTokenGenerator(context: Context): PoTokenWebView {
             var created: PoTokenWebView? = null
+            // BotGuard runs inside a WebView that shares the process-global CookieManager.
+            // After login, YouTube/Google auth cookies (SID, SAPISID, ...) are visible to the
+            // WebView's JS engine via document.cookie. BotGuard uses this browser state as part
+            // of its attestation, but the botguard HTTP requests go through OkHttp with NO
+            // cookies — a mismatch that causes attestation to fail. Temporarily clear these
+            // cookies so BotGuard sees an anonymous state consistent with the API calls.
+            val savedCookies = clearYouTubeCookiesForBotguard()
             try {
                 return withTimeout(INIT_TIMEOUT_MS) {
                     withContext(Dispatchers.Main) {
@@ -475,10 +483,42 @@ class PoTokenWebView private constructor(
                 closeQuietly(created)
                 throw PoTokenException("PoTokenWebView init timed out after ${INIT_TIMEOUT_MS}ms")
             } catch (e: CancellationException) {
-                // Caller cancelled — don't leak the half-initialized WebView.
                 closeQuietly(created)
                 throw e
+            } finally {
+                restoreYouTubeCookies(savedCookies)
             }
+        }
+
+        private val YOUTUBE_COOKIE_DOMAINS = listOf(
+            ".youtube.com", "youtube.com",
+            ".google.com", "google.com",
+            ".youtube-nocookie.com", "youtube-nocookie.com",
+        )
+
+        private fun clearYouTubeCookiesForBotguard(): Map<String, String> {
+            val cookieManager = CookieManager.getInstance()
+            val saved = mutableMapOf<String, String>()
+            for (domain in YOUTUBE_COOKIE_DOMAINS) {
+                val cookies = cookieManager.getCookie(domain)
+                if (!cookies.isNullOrEmpty()) {
+                    saved[domain] = cookies
+                    cookieManager.setCookie(domain, "")
+                }
+            }
+            if (saved.isNotEmpty()) {
+                Timber.tag(TAG).d("Cleared ${saved.size} YouTube cookie domains for BotGuard")
+            }
+            return saved
+        }
+
+        private fun restoreYouTubeCookies(saved: Map<String, String>) {
+            if (saved.isEmpty()) return
+            val cookieManager = CookieManager.getInstance()
+            for ((domain, cookies) in saved) {
+                cookieManager.setCookie(domain, cookies)
+            }
+            Timber.tag(TAG).d("Restored ${saved.size} YouTube cookie domains after BotGuard")
         }
 
         private suspend fun closeQuietly(potWv: PoTokenWebView?) {

--- a/app/src/main/kotlin/com/metrolist/music/utils/potoken/PoTokenWebView.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/potoken/PoTokenWebView.kt
@@ -490,35 +490,40 @@ class PoTokenWebView private constructor(
             }
         }
 
-        private val YOUTUBE_COOKIE_DOMAINS = listOf(
-            ".youtube.com", "youtube.com",
-            ".google.com", "google.com",
-            ".youtube-nocookie.com", "youtube-nocookie.com",
+        private val YOUTUBE_COOKIE_URLS = listOf(
+            "https://youtube.com",
+            "https://google.com",
+            "https://youtube-nocookie.com",
         )
 
-        private fun clearYouTubeCookiesForBotguard(): Map<String, String> {
+        private fun clearYouTubeCookiesForBotguard(): Map<String, List<String>> {
             val cookieManager = CookieManager.getInstance()
-            val saved = mutableMapOf<String, String>()
-            for (domain in YOUTUBE_COOKIE_DOMAINS) {
-                val cookies = cookieManager.getCookie(domain)
-                if (!cookies.isNullOrEmpty()) {
-                    saved[domain] = cookies
-                    cookieManager.setCookie(domain, "")
+            val saved = mutableMapOf<String, List<String>>()
+            for (url in YOUTUBE_COOKIE_URLS) {
+                val raw = cookieManager.getCookie(url) ?: continue
+                val cookies = raw.split("; ").filter { it.isNotEmpty() }
+                if (cookies.isEmpty()) continue
+                saved[url] = cookies
+                for (cookie in cookies) {
+                    val name = cookie.substringBefore("=")
+                    cookieManager.setCookie(url, "$name=; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/")
                 }
             }
             if (saved.isNotEmpty()) {
-                Timber.tag(TAG).d("Cleared ${saved.size} YouTube cookie domains for BotGuard")
+                Timber.tag(TAG).d("Cleared cookies from ${saved.size} YouTube URLs for BotGuard")
             }
             return saved
         }
 
-        private fun restoreYouTubeCookies(saved: Map<String, String>) {
+        private fun restoreYouTubeCookies(saved: Map<String, List<String>>) {
             if (saved.isEmpty()) return
             val cookieManager = CookieManager.getInstance()
-            for ((domain, cookies) in saved) {
-                cookieManager.setCookie(domain, cookies)
+            for ((url, cookies) in saved) {
+                for (cookie in cookies) {
+                    cookieManager.setCookie(url, cookie)
+                }
             }
-            Timber.tag(TAG).d("Restored ${saved.size} YouTube cookie domains after BotGuard")
+            Timber.tag(TAG).d("Restored cookies to ${saved.size} YouTube URLs after BotGuard")
         }
 
         private suspend fun closeQuietly(potWv: PoTokenWebView?) {

--- a/app/src/main/kotlin/com/metrolist/music/utils/potoken/PoTokenWebView.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/potoken/PoTokenWebView.kt
@@ -461,12 +461,7 @@ class PoTokenWebView private constructor(
 
         suspend fun getNewPoTokenGenerator(context: Context): PoTokenWebView {
             var created: PoTokenWebView? = null
-            // BotGuard runs inside a WebView that shares the process-global CookieManager.
-            // After login, YouTube/Google auth cookies (SID, SAPISID, ...) are visible to the
-            // WebView's JS engine via document.cookie. BotGuard uses this browser state as part
-            // of its attestation, but the botguard HTTP requests go through OkHttp with NO
-            // cookies — a mismatch that causes attestation to fail. Temporarily clear these
-            // cookies so BotGuard sees an anonymous state consistent with the API calls.
+            // Clear YouTube cookies so BotGuard attestation matches the anonymous HTTP requests
             val savedCookies = clearYouTubeCookiesForBotguard()
             try {
                 return withTimeout(INIT_TIMEOUT_MS) {


### PR DESCRIPTION
## Problem

Playback freezes after auto-advancing to the next track when instant silence skip is enabled. The track jumps forward and then gets stuck, requiring a manual slider move to resume playback.

## Cause

The SilenceDetectorAudioProcessor retains its in-silence state across track transitions when ExoPlayer does not flush the audio processor pipeline (which happens when both tracks share the same audio format, a common scenario for YouTube Music streams). When the previous track ends with a fade-out silence, the detector triggers a coroutine that seeks forward 15 seconds into the new track after a 200ms debounce delay, causing the player to enter an inconsistent state.

## Solution

Reset the silence detector tracking state at every media item transition in onMediaItemTransition. This ensures the detector starts fresh for each new track regardless of whether ExoPlayer flushes the audio pipeline, eliminating false triggers that seek into the new track.

## Testing

Compiled successfully with `./gradlew :app:assembleFossDebug`. The change is a single-line addition of `playerSilenceProcessors[player]?.resetTracking()` in the `onMediaItemTransition` callback, which directly addresses the stale state retention at the root.

## Related Issues

Closes #4014

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved playback transitions by resetting silence detection when moving to a new track.
  - Enhanced video stream availability handling with improved selection of playable video formats and more detailed failure reporting.
  - Reduced playback start failures by generating poTokens with bounded retries and safer WebView session/cookie cleanup during attestation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->