### PR TITLE
fix(player): recover from WebView renderer death; surface swallowed stream-resolution failures

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -202,7 +202,12 @@ object YTPlayerUtils {
             // Age-restricted: use WEB_CREATOR directly (no NewPipe needed from here)
             Timber.tag(logTag).d("Age-restricted detected, using WEB_CREATOR")
             Timber.tag(TAG).i("Age-restricted: using WEB_CREATOR for videoId=$videoId")
-            val creatorResponse = YouTube.player(videoId, playlistId, WEB_CREATOR, null, null).getOrNull()
+            val creatorResponse = YouTube.player(videoId, playlistId, WEB_CREATOR, null, null)
+                .onFailure {
+                    // Distinguish thrown request/parse failures from genuine playability
+                    // rejections (both otherwise surface as a null response downstream).
+                    Timber.tag(logTag).e(it, "player() request FAILED for WEB_CREATOR")
+                }.getOrNull()
             if (creatorResponse?.playabilityStatus?.status == "OK") {
                 Timber.tag(logTag).d("WEB_CREATOR works for age-restricted content")
                 mainPlayerResponse = creatorResponse
@@ -286,7 +291,10 @@ object YTPlayerUtils {
                 // Skip signature timestamp for age-restricted (faster), use it for normal content
                 val clientSigTimestamp = if (wasOriginallyAgeRestricted) null else signatureTimestamp.timestamp
                 streamPlayerResponse =
-                    YouTube.player(videoId, playlistId, client, clientSigTimestamp, clientPoToken).getOrNull()
+                    YouTube.player(videoId, playlistId, client, clientSigTimestamp, clientPoToken)
+                        .onFailure {
+                            Timber.tag(logTag).e(it, "player() request FAILED for %s", client.clientName)
+                        }.getOrNull()
             }
 
             // process current client response

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherDeobfuscator.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherDeobfuscator.kt
@@ -2,6 +2,7 @@ package com.metrolist.music.utils.cipher
 
 import android.content.Context
 import android.net.Uri
+import android.os.SystemClock
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
@@ -59,6 +60,13 @@ object CipherDeobfuscator {
 
     private val deobfuscateMutex = Mutex()
 
+    // After repeated renderer deaths (low-RAM device under sustained memory pressure OOM-killing
+    // the sandboxed renderer), skip re-parsing ~2.8 MB of player.js per song for a SHORT backoff
+    // window. The window must stay short/half-open: the non-WebView fallbacks are unreliable, so
+    // the cipher WebView is the primary path and we retry it as soon as pressure may have eased.
+    // Guarded by deobfuscateMutex.
+    private val rendererRecoveryPolicy = RendererRecoveryPolicy()
+
     /**
      * SignatureTimestamp of the player JS this cipher actually deciphers with, fetching (or
      * reusing the cached) player JS if needed. API callers must send THIS value in the
@@ -86,7 +94,13 @@ object CipherDeobfuscator {
     suspend fun prewarm() {
         Timber.tag(TAG).d("Prewarming cipher WebView...")
         deobfuscateMutex.withLock {
-            getOrCreateWebView(forceRefresh = false)
+            try {
+                getOrCreateWebView(forceRefresh = false)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: CipherRendererGoneException) {
+                onRendererGone(e, "prewarm")
+            }
         }
     }
 
@@ -103,16 +117,26 @@ object CipherDeobfuscator {
     suspend fun deobfuscateStreamUrl(signatureCipher: String, videoId: String): String? = deobfuscateMutex.withLock {
         try {
             deobfuscateInternal(signatureCipher, videoId, isRetry = false)
+                ?.also { rendererRecoveryPolicy.onSuccess() }
         } catch (e: CancellationException) {
             throw e // request superseded/cancelled — propagate, don't treat as a decipher failure
+        } catch (e: CipherRendererGoneException) {
+            // Renderer died (OOM kill) — a fresh-JS retry would just re-parse ~2.8 MB under the
+            // same memory pressure. Fail fast so playback falls through to the other paths.
+            onRendererGone(e, "deobfuscate")
+            null
         } catch (e: Exception) {
             Timber.tag(TAG).e(e, "Cipher deobfuscation failed, retrying with fresh JS: ${e.message}")
             try {
                 PlayerJsFetcher.invalidateCache()
                 closeWebView()
                 deobfuscateInternal(signatureCipher, videoId, isRetry = true)
+                    ?.also { rendererRecoveryPolicy.onSuccess() }
             } catch (retryE: CancellationException) {
                 throw retryE
+            } catch (retryE: CipherRendererGoneException) {
+                onRendererGone(retryE, "deobfuscate-retry")
+                null
             } catch (retryE: Exception) {
                 Timber.tag(TAG).e(retryE, "Cipher deobfuscation retry also failed: ${retryE.message}")
                 null
@@ -193,6 +217,9 @@ object CipherDeobfuscator {
             transformNInternal(url)
         } catch (e: CancellationException) {
             throw e // request superseded/cancelled — propagate rather than masking as a no-op transform
+        } catch (e: CipherRendererGoneException) {
+            onRendererGone(e, "n-transform")
+            url
         } catch (e: Exception) {
             Timber.tag(TAG).e(e, "N-transform failed, returning original URL: ${e.message}")
             url
@@ -231,6 +258,7 @@ object CipherDeobfuscator {
 
         Timber.tag(TAG).d("Calling webView.transformN()...")
         val transformedN = webView.transformN(nValue)
+        rendererRecoveryPolicy.onSuccess()
 
         Timber.tag(TAG).d("=== N-TRANSFORM SUCCESS ===")
         Timber.tag(TAG).d("N-param: $nValue -> $transformedN")
@@ -245,8 +273,41 @@ object CipherDeobfuscator {
         return transformedUrl
     }
 
+    /**
+     * A renderer death (or renderer-gone-equivalent timeout) was detected: drop the dead
+     * instance so the next call recreates it, and record the failure so repeated deaths open
+     * the [rendererRecoveryPolicy] backoff window. Must be called with [deobfuscateMutex] held.
+     */
+    private suspend fun onRendererGone(e: CipherRendererGoneException, where: String) {
+        rendererRecoveryPolicy.onFailure(SystemClock.elapsedRealtime())
+        Timber.tag(TAG).e(
+            e,
+            "WebView renderer gone during $where (consecutive failures: " +
+                "${rendererRecoveryPolicy.consecutiveFailures}) — dropping cipher WebView"
+        )
+        closeWebView()
+    }
+
     private suspend fun getOrCreateWebView(forceRefresh: Boolean): CipherWebView? {
         Timber.tag(TAG).d("getOrCreateWebView: forceRefresh=$forceRefresh, existing=${cipherWebView != null}")
+
+        // A dead renderer means the cached instance is a zombie — drop it so we rebuild below.
+        if (cipherWebView?.isDead == true) {
+            Timber.tag(TAG).w("Cached cipher WebView renderer is dead — discarding")
+            closeWebView()
+        }
+
+        // Under sustained memory pressure the fresh renderer gets OOM-killed again seconds in;
+        // during the (short, half-open) backoff window skip WebView creation so the current song
+        // fails over fast instead of stalling on a doomed ~2.8 MB player.js parse. The next song
+        // after the window retries the WebView — the fallback paths are too weak to live on.
+        if (!rendererRecoveryPolicy.shouldAttempt(SystemClock.elapsedRealtime())) {
+            Timber.tag(TAG).w(
+                "Skipping cipher WebView creation: ${rendererRecoveryPolicy.consecutiveFailures} " +
+                    "consecutive renderer deaths, in backoff window"
+            )
+            return null
+        }
 
         // Snapshot the epoch BEFORE extracting/building. A refresh that lands on another thread
         // during this (multi-second) build then leaves builtConfigEpoch behind the live epoch,
@@ -341,7 +402,8 @@ object CipherDeobfuscator {
     private suspend fun closeWebView() {
         Timber.tag(TAG).d("closeWebView: existing=${cipherWebView != null}")
         withContext(Dispatchers.Main) {
-            cipherWebView?.close()
+            runCatching { cipherWebView?.close() }
+                .onFailure { Timber.tag(TAG).w("closeWebView threw: $it") }
         }
         cipherWebView = null
         currentPlayerHash = null

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherWebView.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherWebView.kt
@@ -3,11 +3,17 @@ package com.metrolist.music.utils.cipher
 import android.content.Context
 import android.webkit.ConsoleMessage
 import android.webkit.JavascriptInterface
+import android.webkit.RenderProcessGoneDetail
 import android.webkit.WebChromeClient
 import android.webkit.WebView
+import android.webkit.WebViewClient
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import timber.log.Timber
 import java.io.File
 import kotlin.coroutines.Continuation
@@ -25,11 +31,28 @@ class CipherWebView private constructor(
     private val playerJs: String,
     private val sigInfo: FunctionNameExtractor.SigFunctionInfo?,
     private val nFuncInfo: FunctionNameExtractor.NFunctionInfo?,
-    private val initContinuation: Continuation<CipherWebView>,
+    initContinuation: Continuation<CipherWebView>,
 ) {
     private val webView = WebView(context)
+
+    // Single-shot continuation slots. All resumes go through takeAndNull-style helpers so a late
+    // or duplicate JS-bridge callback (or a renderer-gone racing a normal resume) can never
+    // double-resume and crash inside a @JavascriptInterface method.
+    private var initContinuation: Continuation<CipherWebView>? = initContinuation
     private var sigContinuation: Continuation<String>? = null
     private var nContinuation: Continuation<String>? = null
+
+    /**
+     * Set once the WebView's renderer process has died (or an evaluate timed out, which on a
+     * wedged renderer is indistinguishable). A dead instance must be discarded and recreated —
+     * per Android docs a WebView whose render process is gone cannot be reused.
+     */
+    @Volatile
+    var isDead: Boolean = false
+        private set
+
+    @Volatile
+    private var destroyed = false
 
     @Volatile
     var nFunctionAvailable: Boolean = false
@@ -85,7 +108,57 @@ class CipherWebView private constructor(
             }
         }
 
+        webView.webViewClient = object : WebViewClient() {
+            // API 26+ callback (never fires below 26; the withTimeout nets in create()/
+            // deobfuscateSignature()/transformN() carry recovery on providers that don't
+            // deliver it, e.g. Chromium-61-era WebViews).
+            @androidx.annotation.RequiresApi(android.os.Build.VERSION_CODES.O)
+            override fun onRenderProcessGone(view: WebView, detail: RenderProcessGoneDetail): Boolean {
+                Timber.tag(TAG).e(
+                    "=== RENDER PROCESS GONE === didCrash=${runCatching { detail.didCrash() }.getOrNull()}"
+                )
+                onRendererGone("WebView render process gone (didCrash=${runCatching { detail.didCrash() }.getOrNull()})")
+                // Consume the event so the framework doesn't kill the app process.
+                return true
+            }
+        }
+
         Timber.tag(TAG).d("WebView settings configured")
+    }
+
+    /**
+     * The renderer died (or is treated as dead after a timeout): fail every pending continuation
+     * with [CipherRendererGoneException] so create()/decipher fail fast instead of hanging forever
+     * on JS-bridge callbacks that will never come (and so CipherDeobfuscator's mutex is released),
+     * then destroy the WebView — it cannot be reused after a render-process crash.
+     */
+    private fun onRendererGone(reason: String) {
+        isDead = true
+        val e = CipherRendererGoneException(reason)
+        takeInitContinuation()?.resumeSafely { it.resumeWithException(e) }
+        takeSigContinuation()?.resumeSafely { it.resumeWithException(e) }
+        takeNContinuation()?.resumeSafely { it.resumeWithException(e) }
+        destroyWebView()
+    }
+
+    // Single-shot takes — synchronized because JS-bridge callbacks arrive on a WebView-internal
+    // thread while onRenderProcessGone/timeouts run on the main thread.
+    @Synchronized
+    private fun takeInitContinuation(): Continuation<CipherWebView>? =
+        initContinuation.also { initContinuation = null }
+
+    @Synchronized
+    private fun takeSigContinuation(): Continuation<String>? =
+        sigContinuation.also { sigContinuation = null }
+
+    @Synchronized
+    private fun takeNContinuation(): Continuation<String>? =
+        nContinuation.also { nContinuation = null }
+
+    private inline fun <T> T.resumeSafely(block: (T) -> Unit) {
+        // A continuation cancelled by withTimeout may already be completed; never let that
+        // throw out of a WebView callback.
+        runCatching { block(this) }
     }
 
     private fun loadPlayerJsFromFile() {
@@ -447,14 +520,16 @@ function discoverAndInit() {
         Timber.tag(TAG).d("discoveredNFuncName=$discoveredNFuncName")
         Timber.tag(TAG).d("usingHardcodedMode=$usingHardcodedMode")
 
-        initContinuation.resume(this)
+        takeInitContinuation()?.resumeSafely { it.resume(this) }
     }
 
     @JavascriptInterface
     fun onPlayerJsError(error: String) {
         Timber.tag(TAG).e("=== PLAYER.JS LOAD FAILED ===")
         Timber.tag(TAG).e("Error: $error")
-        initContinuation.resumeWithException(CipherException("Player JS load failed: $error"))
+        takeInitContinuation()?.resumeSafely {
+            it.resumeWithException(CipherException("Player JS load failed: $error"))
+        }
     }
 
     // ==================== SIGNATURE DEOBFUSCATION ====================
@@ -469,15 +544,25 @@ function discoverAndInit() {
             Timber.tag(TAG).e("Signature function info not available")
             throw CipherException("Signature function info not available")
         }
+        throwIfDead()
 
-        return withContext(Dispatchers.Main) {
-            suspendCancellableCoroutine { cont ->
-                sigContinuation = cont
-                val constArgJs = if (sigInfo.constantArg != null) "${sigInfo.constantArg}" else "null"
-                val jsCall = "deobfuscateSig('${sigInfo.name}', $constArgJs, '${escapeJsString(obfuscatedSig)}')"
-                Timber.tag(TAG).d("Evaluating JS: ${jsCall.take(100)}...")
-                webView.evaluateJavascript(jsCall, null)
+        return try {
+            withTimeout(EVAL_TIMEOUT_MS) {
+                withContext(Dispatchers.Main) {
+                    suspendCancellableCoroutine { cont ->
+                        sigContinuation = cont
+                        val constArgJs = if (sigInfo.constantArg != null) "${sigInfo.constantArg}" else "null"
+                        val jsCall = "deobfuscateSig('${sigInfo.name}', $constArgJs, '${escapeJsString(obfuscatedSig)}')"
+                        Timber.tag(TAG).d("Evaluating JS: ${jsCall.take(100)}...")
+                        webView.evaluateJavascript(jsCall, null)
+                    }
+                }
             }
+        } catch (e: TimeoutCancellationException) {
+            // A renderer that never answers evaluateJavascript is wedged/dead — safety net for
+            // providers where onRenderProcessGone doesn't fire.
+            Timber.tag(TAG).e("Sig deobfuscation timed out after ${EVAL_TIMEOUT_MS}ms — treating renderer as gone")
+            failAsRendererGone("Sig deobfuscation timed out after ${EVAL_TIMEOUT_MS}ms")
         }
     }
 
@@ -486,16 +571,16 @@ function discoverAndInit() {
         Timber.tag(TAG).d("========== SIGNATURE RESULT ==========")
         Timber.tag(TAG).d("Result length: ${result.length}")
         Timber.tag(TAG).d("Result preview: ${result.take(50)}...")
-        sigContinuation?.resume(result)
-        sigContinuation = null
+        takeSigContinuation()?.resumeSafely { it.resume(result) }
     }
 
     @JavascriptInterface
     fun onSigError(error: String) {
         Timber.tag(TAG).e("========== SIGNATURE ERROR ==========")
         Timber.tag(TAG).e("Error: $error")
-        sigContinuation?.resumeWithException(CipherException("Sig deobfuscation failed: $error"))
-        sigContinuation = null
+        takeSigContinuation()?.resumeSafely {
+            it.resumeWithException(CipherException("Sig deobfuscation failed: $error"))
+        }
     }
 
     // ==================== N-TRANSFORM ====================
@@ -510,14 +595,22 @@ function discoverAndInit() {
             Timber.tag(TAG).e("N-transform function not discovered")
             throw CipherException("N-transform function not discovered")
         }
+        throwIfDead()
 
-        return withContext(Dispatchers.Main) {
-            suspendCancellableCoroutine { cont ->
-                nContinuation = cont
-                val jsCall = "transformN('${escapeJsString(nValue)}')"
-                Timber.tag(TAG).d("Evaluating JS: $jsCall")
-                webView.evaluateJavascript(jsCall, null)
+        return try {
+            withTimeout(EVAL_TIMEOUT_MS) {
+                withContext(Dispatchers.Main) {
+                    suspendCancellableCoroutine { cont ->
+                        nContinuation = cont
+                        val jsCall = "transformN('${escapeJsString(nValue)}')"
+                        Timber.tag(TAG).d("Evaluating JS: $jsCall")
+                        webView.evaluateJavascript(jsCall, null)
+                    }
+                }
             }
+        } catch (e: TimeoutCancellationException) {
+            Timber.tag(TAG).e("N-transform timed out after ${EVAL_TIMEOUT_MS}ms — treating renderer as gone")
+            failAsRendererGone("N-transform timed out after ${EVAL_TIMEOUT_MS}ms")
         }
     }
 
@@ -526,29 +619,52 @@ function discoverAndInit() {
         Timber.tag(TAG).d("========== N-TRANSFORM RESULT ==========")
         Timber.tag(TAG).d("Result: $result")
         Timber.tag(TAG).d("Result length: ${result.length}")
-        nContinuation?.resume(result)
-        nContinuation = null
+        takeNContinuation()?.resumeSafely { it.resume(result) }
     }
 
     @JavascriptInterface
     fun onNError(error: String) {
         Timber.tag(TAG).e("========== N-TRANSFORM ERROR ==========")
         Timber.tag(TAG).e("Error: $error")
-        nContinuation?.resumeWithException(CipherException("N-transform failed: $error"))
-        nContinuation = null
+        takeNContinuation()?.resumeSafely {
+            it.resumeWithException(CipherException("N-transform failed: $error"))
+        }
+    }
+
+    private fun throwIfDead() {
+        if (isDead) {
+            throw CipherRendererGoneException("CipherWebView renderer is gone — instance must be recreated")
+        }
+    }
+
+    /** Timeout path: mark this instance dead, clear pending slots, throw renderer-gone. */
+    private fun failAsRendererGone(reason: String): Nothing {
+        isDead = true
+        takeSigContinuation()
+        takeNContinuation()
+        throw CipherRendererGoneException(reason)
     }
 
     // ==================== CLEANUP ====================
 
     fun close() {
         Timber.tag(TAG).d("Closing CipherWebView...")
-        webView.clearHistory()
-        webView.clearCache(true)
-        webView.loadUrl("about:blank")
-        webView.onPause()
-        webView.removeAllViews()
-        webView.destroy()
+        destroyWebView()
         Timber.tag(TAG).d("CipherWebView closed")
+    }
+
+    private fun destroyWebView() {
+        if (destroyed) return
+        destroyed = true
+        // After a render-process crash some WebView methods can throw — never let teardown crash.
+        runCatching {
+            webView.clearHistory()
+            webView.clearCache(true)
+            webView.loadUrl("about:blank")
+            webView.onPause()
+            webView.removeAllViews()
+            webView.destroy()
+        }.onFailure { Timber.tag(TAG).w("WebView teardown threw: $it") }
     }
 
     // ==================== UTILITIES ====================
@@ -566,6 +682,14 @@ function discoverAndInit() {
         private const val TAG = "Metrolist_CipherWebView"
         private const val JS_INTERFACE = "CipherBridge"
 
+        // Loading + parsing ~2.8 MB player.js on a slow device takes seconds; a renderer that
+        // hasn't answered after this long is dead or wedged (observed OOM kills happen ~1.2 s in).
+        private const val CREATE_TIMEOUT_MS = 30_000L
+
+        // A live renderer answers sig/n evaluate calls in milliseconds; this only fires when the
+        // renderer died without onRenderProcessGone being delivered (old providers).
+        private const val EVAL_TIMEOUT_MS = 15_000L
+
         suspend fun create(
             context: Context,
             playerJs: String,
@@ -577,14 +701,44 @@ function discoverAndInit() {
             Timber.tag(TAG).d("sigInfo: $sigInfo")
             Timber.tag(TAG).d("nFuncInfo: $nFuncInfo")
 
-            return withContext(Dispatchers.Main) {
-                suspendCancellableCoroutine { cont ->
-                    val wv = CipherWebView(context, playerJs, sigInfo, nFuncInfo, cont)
-                    wv.loadPlayerJsFromFile()
+            var created: CipherWebView? = null
+            try {
+                return withTimeout(CREATE_TIMEOUT_MS) {
+                    withContext(Dispatchers.Main) {
+                        suspendCancellableCoroutine { cont ->
+                            val wv = CipherWebView(context, playerJs, sigInfo, nFuncInfo, cont)
+                            created = wv
+                            wv.loadPlayerJsFromFile()
+                        }
+                    }
                 }
+            } catch (e: TimeoutCancellationException) {
+                Timber.tag(TAG).e("CipherWebView init timed out after ${CREATE_TIMEOUT_MS}ms — treating renderer as gone")
+                destroyQuietly(created)
+                throw CipherRendererGoneException("CipherWebView init timed out after ${CREATE_TIMEOUT_MS}ms")
+            } catch (e: CancellationException) {
+                // Caller cancelled — don't leak the half-initialized WebView.
+                destroyQuietly(created)
+                throw e
+            }
+        }
+
+        private suspend fun destroyQuietly(wv: CipherWebView?) {
+            if (wv == null) return
+            withContext(NonCancellable + Dispatchers.Main) {
+                wv.isDead = true
+                wv.takeInitContinuation() // never resume a cancelled continuation later
+                wv.destroyWebView()
             }
         }
     }
 }
 
 class CipherException(message: String) : Exception(message)
+
+/**
+ * The cipher WebView's render process died (kernel OOM kill, crash) or stopped responding.
+ * The instance is unusable; callers must drop it and decide whether recreating is worth it
+ * (see [RendererRecoveryPolicy]).
+ */
+class CipherRendererGoneException(message: String) : Exception(message)

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/RendererRecoveryPolicy.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/RendererRecoveryPolicy.kt
@@ -1,0 +1,51 @@
+package com.metrolist.music.utils.cipher
+
+/**
+ * Pure (no Android deps) policy for recovering from WebView renderer deaths.
+ *
+ * A killed renderer under sustained memory pressure will typically be killed again while
+ * re-parsing the ~2.8 MB player.js, so after [maxConsecutiveFailures] consecutive failures the
+ * policy opens a backoff window during which [shouldAttempt] is false and callers skip the
+ * doomed multi-second rebuild for that song.
+ *
+ * The window is deliberately SHORT and half-open: the non-WebView paths (NewPipe extractor,
+ * fallback clients) are unreliable — the cipher WebView is the primary path — so we must get
+ * back to retrying it quickly once memory pressure may have eased. Once the window expires, one
+ * attempt is allowed. Success fully resets the policy; another failure re-arms the window
+ * immediately.
+ *
+ * Callers pass a monotonic clock value (e.g. SystemClock.elapsedRealtime()) so the policy stays
+ * JVM-testable.
+ */
+class RendererRecoveryPolicy(
+    private val maxConsecutiveFailures: Int = DEFAULT_MAX_CONSECUTIVE_FAILURES,
+    private val backoffMs: Long = DEFAULT_BACKOFF_MS,
+) {
+    var consecutiveFailures = 0
+        private set
+
+    private var backoffUntilMs = 0L
+
+    /** Whether creating/using a WebView is currently worth attempting. */
+    fun shouldAttempt(nowMs: Long): Boolean =
+        consecutiveFailures < maxConsecutiveFailures || nowMs >= backoffUntilMs
+
+    /** Record a renderer death (or renderer-gone-equivalent timeout). */
+    fun onFailure(nowMs: Long) {
+        consecutiveFailures++
+        if (consecutiveFailures >= maxConsecutiveFailures) {
+            backoffUntilMs = nowMs + backoffMs
+        }
+    }
+
+    /** Record a successful WebView operation — fully resets the policy. */
+    fun onSuccess() {
+        consecutiveFailures = 0
+        backoffUntilMs = 0L
+    }
+
+    companion object {
+        const val DEFAULT_MAX_CONSECUTIVE_FAILURES = 3
+        const val DEFAULT_BACKOFF_MS = 60_000L
+    }
+}

--- a/app/src/main/kotlin/com/metrolist/music/utils/potoken/PoTokenGenerator.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/potoken/PoTokenGenerator.kt
@@ -89,7 +89,11 @@ class PoTokenGenerator {
         val (poTokenGenerator, streamingPot, hasBeenRecreated) =
             webPoTokenGenLock.withLock {
                 val shouldRecreate =
-                    forceRecreate || webPoTokenGenerator == null || webPoTokenGenerator!!.isExpired || webPoTokenSessionId != sessionId
+                    forceRecreate || webPoTokenGenerator == null || webPoTokenGenerator!!.isExpired ||
+                        // Renderer died (OOM kill) — recreate proactively instead of letting the
+                        // first post-crash generatePoToken() fail against the dead instance.
+                        webPoTokenGenerator!!.isDead ||
+                        webPoTokenSessionId != sessionId
 
                 if (shouldRecreate) {
                     Timber.tag(TAG).d("Creating new PoTokenWebView (forceRecreate=$forceRecreate)")

--- a/app/src/main/kotlin/com/metrolist/music/utils/potoken/PoTokenWebView.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/potoken/PoTokenWebView.kt
@@ -1,6 +1,8 @@
 package com.metrolist.music.utils.potoken
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import android.webkit.ConsoleMessage
 import android.webkit.JavascriptInterface
 import android.webkit.RenderProcessGoneDetail
@@ -374,13 +376,24 @@ class PoTokenWebView private constructor(
         }
     }
 
-    @MainThread
     fun close() {
         if (closed) return
         closed = true
 
         scope.cancel()
 
+        // WebView methods must run on the thread that created the WebView (main), but some
+        // callers arrive on the JavaBridge thread (onJsInitializationError) — post the teardown
+        // there instead of letting it throw and leak the instance.
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            destroyWebView()
+        } else {
+            Handler(Looper.getMainLooper()).post { destroyWebView() }
+        }
+    }
+
+    @MainThread
+    private fun destroyWebView() {
         // After a render-process crash some WebView methods can throw — never let teardown crash.
         runCatching {
             webView.clearHistory()

--- a/app/src/main/kotlin/com/metrolist/music/utils/potoken/PoTokenWebView.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/potoken/PoTokenWebView.kt
@@ -3,19 +3,25 @@ package com.metrolist.music.utils.potoken
 import android.content.Context
 import android.webkit.ConsoleMessage
 import android.webkit.JavascriptInterface
+import android.webkit.RenderProcessGoneDetail
 import android.webkit.WebChromeClient
 import android.webkit.WebView
+import android.webkit.WebViewClient
 import androidx.annotation.MainThread
 import androidx.collection.ArrayMap
 import com.metrolist.innertube.YouTube
 import com.metrolist.music.BuildConfig
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import okhttp3.Headers.Companion.toHeaders
 import okhttp3.OkHttpClient
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -23,6 +29,7 @@ import timber.log.Timber
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.Collections
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -34,6 +41,22 @@ class PoTokenWebView private constructor(
 ) {
     private val webView = WebView(context)
     private val scope = MainScope()
+
+    // Guards the single-shot init continuation: initialization errors can arrive from several
+    // paths (JS console "Uncaught", botguard request failure, renderer-gone) and a second resume
+    // on a plain Continuation throws IllegalStateException.
+    private val initResumed = AtomicBoolean(false)
+
+    @Volatile
+    private var closed = false
+
+    /**
+     * Set when the renderer died or a generate timed out. The render-gone callback isn't
+     * delivered reliably enough on its own; callers check this to recreate immediately.
+     */
+    @Volatile
+    var isDead: Boolean = false
+        private set
     private val poTokenContinuations =
         Collections.synchronizedMap(ArrayMap<String, Continuation<String>>())
     private val exceptionHandler = CoroutineExceptionHandler { _, t ->
@@ -71,6 +94,26 @@ class PoTokenWebView private constructor(
                     popAllPoTokenContinuations().forEach { (_, cont) -> cont.resumeWithException(exception) }
                 }
                 return super.onConsoleMessage(m)
+            }
+        }
+
+        webView.webViewClient = object : WebViewClient() {
+            // API 26+ callback; on providers that don't deliver it the withTimeout nets in
+            // getNewPoTokenGenerator()/generatePoToken() carry the recovery.
+            @androidx.annotation.RequiresApi(android.os.Build.VERSION_CODES.O)
+            override fun onRenderProcessGone(view: WebView, detail: RenderProcessGoneDetail): Boolean {
+                val didCrash = runCatching { detail.didCrash() }.getOrNull()
+                Timber.tag(TAG).e("PoToken WebView render process gone (didCrash=$didCrash)")
+                isDead = true
+                // Transient (OOM kill under memory pressure), NOT a BadWebViewException — that
+                // would permanently disable poTokens for the session in PoTokenGenerator.
+                val exception = PoTokenException("WebView render process gone (didCrash=$didCrash)")
+                onInitializationErrorCloseAndCancel(exception)
+                popAllPoTokenContinuations().forEach { (_, cont) ->
+                    runCatching { cont.resumeWithException(exception) }
+                }
+                // Consume the event so the framework doesn't kill the app process.
+                return true
             }
         }
     }
@@ -188,12 +231,35 @@ class PoTokenWebView private constructor(
     @JavascriptInterface
     fun onMinterCreated() {
         Timber.tag(TAG).d("poToken minter created successfully, initialization complete")
-        continuation.resume(this)
+        if (initResumed.compareAndSet(false, true)) {
+            continuation.resume(this)
+        }
     }
     //endregion
 
     //region Obtaining poTokens
     suspend fun generatePoToken(identifier: String): String {
+        if (isDead || closed) {
+            // Fail fast (no fixed timeout wait): PoTokenGenerator's retry path recreates the
+            // WebView from scratch.
+            throw PoTokenException("PoToken WebView is dead/closed — instance must be recreated")
+        }
+        return try {
+            withTimeout(GENERATE_TIMEOUT_MS) {
+                generatePoTokenInternal(identifier)
+            }
+        } catch (e: TimeoutCancellationException) {
+            // A renderer that never answers is wedged/dead (safety net for providers where
+            // onRenderProcessGone doesn't fire) — drop the pending continuation and fail fast;
+            // PoTokenGenerator's retry recreates the WebView from scratch.
+            isDead = true
+            popPoTokenContinuation(identifier)
+            Timber.tag(TAG).e("generatePoToken($identifier) timed out after ${GENERATE_TIMEOUT_MS}ms")
+            throw PoTokenException("poToken generation timed out after ${GENERATE_TIMEOUT_MS}ms")
+        }
+    }
+
+    private suspend fun generatePoTokenInternal(identifier: String): String {
         return withContext(Dispatchers.Main) {
             suspendCancellableCoroutine { cont ->
                 Timber.tag(TAG).d("generatePoToken() called with identifier $identifier")
@@ -302,21 +368,30 @@ class PoTokenWebView private constructor(
 
     private fun onInitializationErrorCloseAndCancel(error: Throwable) {
         close()
-        continuation.resumeWithException(error)
+        if (initResumed.compareAndSet(false, true)) {
+            // The continuation may have been cancelled by the init timeout.
+            runCatching { continuation.resumeWithException(error) }
+        }
     }
 
     @MainThread
     fun close() {
+        if (closed) return
+        closed = true
+
         scope.cancel()
 
-        webView.clearHistory()
-        webView.clearCache(true)
+        // After a render-process crash some WebView methods can throw — never let teardown crash.
+        runCatching {
+            webView.clearHistory()
+            webView.clearCache(true)
 
-        webView.loadUrl("about:blank")
+            webView.loadUrl("about:blank")
 
-        webView.onPause()
-        webView.removeAllViews()
-        webView.destroy()
+            webView.onPause()
+            webView.removeAllViews()
+            webView.destroy()
+        }.onFailure { Timber.tag(TAG).w("PoToken WebView teardown threw: $it") }
     }
     //endregion
 
@@ -328,16 +403,47 @@ class PoTokenWebView private constructor(
                 "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.3"
         private const val JS_INTERFACE = "PoTokenWebView"
 
+        // Init does network round-trips (botguard Create/GenerateIT) + JS execution; a WebView
+        // that hasn't finished after this long has a dead/wedged renderer or dead network.
+        private const val INIT_TIMEOUT_MS = 45_000L
+
+        // A live renderer mints a poToken in well under a second.
+        private const val GENERATE_TIMEOUT_MS = 15_000L
+
         private val httpClient = OkHttpClient.Builder()
             .proxy(YouTube.proxy)
             .build()
 
         suspend fun getNewPoTokenGenerator(context: Context): PoTokenWebView {
-            return withContext(Dispatchers.Main) {
-                suspendCancellableCoroutine { cont ->
-                    val potWv = PoTokenWebView(context, cont)
-                    potWv.loadHtmlAndObtainBotguard()
+            var created: PoTokenWebView? = null
+            try {
+                return withTimeout(INIT_TIMEOUT_MS) {
+                    withContext(Dispatchers.Main) {
+                        suspendCancellableCoroutine { cont ->
+                            val potWv = PoTokenWebView(context, cont)
+                            created = potWv
+                            potWv.loadHtmlAndObtainBotguard()
+                        }
+                    }
                 }
+            } catch (e: TimeoutCancellationException) {
+                Timber.tag(TAG).e("PoTokenWebView init timed out after ${INIT_TIMEOUT_MS}ms")
+                closeQuietly(created)
+                throw PoTokenException("PoTokenWebView init timed out after ${INIT_TIMEOUT_MS}ms")
+            } catch (e: CancellationException) {
+                // Caller cancelled — don't leak the half-initialized WebView.
+                closeQuietly(created)
+                throw e
+            }
+        }
+
+        private suspend fun closeQuietly(potWv: PoTokenWebView?) {
+            if (potWv == null) return
+            withContext(NonCancellable + Dispatchers.Main) {
+                // Mark init resumed so a late JS/network callback can't resume a cancelled
+                // continuation.
+                potWv.initResumed.set(true)
+                potWv.close()
             }
         }
     }


### PR DESCRIPTION
## Problem
On low-RAM devices under sustained memory pressure, playback can break for the rest of the session: every song stalls for ~12–22 seconds and then falls back to the unreliable non-WebView paths (or fails outright), until the app is restarted. Separately, when stream resolution fails, the logs don't show why — a network/parse error and a genuine "not playable" rejection both surface as `Status NOT OK: null`, making these failures very hard to diagnose from user reports.

## Cause
- The kernel can OOM-kill the sandboxed WebView renderer process. The cipher WebView (and the poToken WebView) never noticed: the dead instance stayed cached for the whole session, so every decipher call hung until its 15 s timeout. On old WebView providers `onRenderProcessGone` is never delivered at all.
- The per-client `player()` calls used bare `.getOrNull()`, silently discarding thrown request/deserialization failures.

## Solution
- Handle `onRenderProcessGone` in `CipherWebView` and `PoTokenWebView`: fail all pending continuations immediately (fail fast instead of waiting out the 15 s timeout), destroy the dead instance, and rebuild it on demand for the next call.
- Add evaluate/init timeout safety nets that treat a non-responsive renderer as gone, covering old WebView providers that never deliver the callback.
- Add `RendererRecoveryPolicy`: after 3 consecutive renderer deaths, skip the doomed multi-second player.js re-parse for a short (60 s, half-open) backoff window, then retry — the WebView stays the primary path.
- Treat poToken renderer death as transient instead of a `BadWebViewException` that permanently disables poTokens for the session.
- Log per-client `player()` request failures before `getOrNull()` so thrown failures are distinguishable from playability rejections.

## Testing
`assembleFossDebug` built and tested on-device (OnePlus 12, Android 16, rooted). Renderer failures were forced with `su -c kill` on the app's sandboxed WebView renderer process — SIGKILL is the same signal the kernel OOM killer delivers, and SIGSTOP simulates a wedged renderer where `onRenderProcessGone` is never delivered. Each signal was verified via `/proc/<pid>` state before counting a trial.

**Renderer killed (OOM simulation), 5/5 recoveries:**

| | detection (kill → `onRenderProcessGone`) | rebuild → decipher success | skip → playback data |
|---|---|---|---|
| range over 5 runs | 50–73 ms | 184–201 ms | 1.6–3.3 s |

(baseline skip → playback with a healthy renderer: ~0.6 s; the renderer PID changed on every iteration, confirming a genuinely new process each rebuild)

**Wedged renderer (SIGSTOP, callback never fires):** all timeout safety nets fired — sig eval 15 s and WebView-init 30 s both ended in "treating renderer as gone"; poToken attempts were capped at 8 s and playback proceeded without a poToken. Every affected song still played via fallback clients ~1 s after the cipher gave up; zero playback failures across the whole test.

**Backoff (`RendererRecoveryPolicy`):** after 3 consecutive renderer deaths the next song logged "Skipping cipher WebView creation: 3 consecutive renderer deaths, in backoff window" and skipped the doomed ~30 s rebuild instantly; after the 60 s window expired, a fresh WebView was created and deciphered in ~150 ms with the policy fully reset.

For comparison, before this fix a single renderer death left the cached WebView a session-permanent zombie: every subsequent song stalled 12–22 s until app restart.

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added smarter recovery for WebView-based playback and token generation after renderer crashes or timeouts, including controlled retry backoff.

* **Bug Fixes**
  * Improved fallback behavior when playback/resolution requests fail, ensuring continued playback attempts instead of stalling.
  * Hardened WebView lifecycle handling for safer initialization/teardown, preventing hangs/crashes and improving resilience during renderer death.
  * Token generation now proactively refreshes when the existing WebView session is marked dead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->