### PR TITLE
fix(playlists): sync playlist removals from menus

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/extensions/QueueExt.kt
+++ b/app/src/main/kotlin/com/metrolist/music/extensions/QueueExt.kt
@@ -13,6 +13,7 @@ import com.metrolist.music.playback.queues.ListQueue
 import com.metrolist.music.playback.queues.LocalAlbumRadio
 import com.metrolist.music.playback.queues.Queue
 import com.metrolist.music.playback.queues.YouTubeAlbumRadio
+import com.metrolist.music.playback.queues.YouTubePlaylistQueue
 import com.metrolist.music.playback.queues.YouTubeQueue
 
 fun Queue.toPersistQueue(
@@ -27,7 +28,19 @@ fun Queue.toPersistQueue(
             items = items,
             mediaItemIndex = mediaItemIndex,
             position = position,
-            queueType = QueueType.LIST
+            queueType = QueueType.LIST,
+            playlistBrowseId = playlistBrowseId,
+            playlistId = playlistId,
+            playlistIsEditable = playlistIsEditable,
+        )
+        is YouTubePlaylistQueue -> PersistQueue(
+            title = title,
+            items = items,
+            mediaItemIndex = mediaItemIndex,
+            position = position,
+            queueType = QueueType.LIST,
+            playlistBrowseId = playlistId,
+            playlistIsEditable = isEditable,
         )
         is YouTubeQueue -> {
             // Since endpoint is private, we'll store a simplified version
@@ -84,7 +97,10 @@ fun PersistQueue.toQueue(): Queue {
             title = title,
             items = items.map { it.toMediaItem() },
             startIndex = mediaItemIndex,
-            position = position
+            position = position,
+            playlistBrowseId = playlistBrowseId,
+            playlistId = playlistId,
+            playlistIsEditable = playlistIsEditable,
         )
         is QueueType.YOUTUBE -> {
             // For now, fallback to ListQueue since we can't reconstruct YouTubeQueue properly
@@ -92,7 +108,7 @@ fun PersistQueue.toQueue(): Queue {
                 title = title,
                 items = items.map { it.toMediaItem() },
                 startIndex = mediaItemIndex,
-                position = position
+                position = position,
             )
         }
         is QueueType.YOUTUBE_ALBUM_RADIO -> {
@@ -101,7 +117,7 @@ fun PersistQueue.toQueue(): Queue {
                 title = title,
                 items = items.map { it.toMediaItem() },
                 startIndex = mediaItemIndex,
-                position = position
+                position = position,
             )
         }
         is QueueType.LOCAL_ALBUM_RADIO -> {
@@ -110,7 +126,7 @@ fun PersistQueue.toQueue(): Queue {
                 title = title,
                 items = items.map { it.toMediaItem() },
                 startIndex = mediaItemIndex,
-                position = position
+                position = position,
             )
         }
     }

--- a/app/src/main/kotlin/com/metrolist/music/models/PersistQueue.kt
+++ b/app/src/main/kotlin/com/metrolist/music/models/PersistQueue.kt
@@ -14,6 +14,9 @@ data class PersistQueue(
     val position: Long,
     val queueType: QueueType = QueueType.LIST,
     val queueData: QueueData? = null,
+    val playlistBrowseId: String? = null,
+    val playlistId: String? = null,
+    val playlistIsEditable: Boolean = false,
 ) : Serializable
 
 sealed class QueueType : Serializable {

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -328,7 +328,8 @@ class MusicService :
 
     private lateinit var audioQuality: com.metrolist.music.constants.AudioQuality
 
-    private var currentQueue: Queue = EmptyQueue
+    var currentQueue: Queue = EmptyQueue
+        private set
     var queueTitle: String? = null
 
     val currentMediaMetadata = MutableStateFlow<com.metrolist.music.models.MediaMetadata?>(null)
@@ -4248,6 +4249,7 @@ class MusicService :
                 } else {
                     YouTubePlaylistQueue(
                         playlistId = targetId,
+                        isEditable = cachedPlaylist?.playlist?.isEditable ?: false,
                         playlistTitle = targetTitle,
                     )
                 }

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -337,8 +337,8 @@ class MusicService :
 
     private lateinit var audioQuality: com.metrolist.music.constants.AudioQuality
 
-    var currentQueue: Queue = EmptyQueue
-        private set
+    private val _currentQueue = MutableStateFlow<Queue>(EmptyQueue)
+    val currentQueue = _currentQueue.asStateFlow()
     var queueTitle: String? = null
 
     val currentMediaMetadata = MutableStateFlow<com.metrolist.music.models.MediaMetadata?>(null)
@@ -1754,7 +1754,7 @@ class MusicService :
             return
         }
 
-        currentQueue = queue
+        _currentQueue.value = queue
         queueTitle = null
         val persistShuffleAcrossQueues = dataStore.get(PersistentShuffleAcrossQueuesKey, false)
         if (!persistShuffleAcrossQueues && !restoringQueue) {
@@ -1874,7 +1874,7 @@ class MusicService :
                     }
                 }
 
-                currentQueue = radioQueue
+                _currentQueue.value = radioQueue
             } catch (e: Exception) {
                 try {
                     val nextResult =
@@ -2528,13 +2528,13 @@ class MusicService :
         if (cachedAutoLoadMore &&
             reason != Player.MEDIA_ITEM_TRANSITION_REASON_REPEAT &&
             player.mediaItemCount - player.currentMediaItemIndex <= 5 &&
-            currentQueue.hasNextPage() &&
+            _currentQueue.value.hasNextPage() &&
             !(cachedDisableLoadMoreWhenRepeatAll && player.repeatMode == REPEAT_MODE_ALL)
         ) {
             scope.launch(SilentHandler) {
                 val mediaItems =
                     withContext(Dispatchers.IO) {
-                        currentQueue
+                        _currentQueue.value
                             .nextPage()
                             .filterExplicit(cachedHideExplicit)
                             .filterVideoSongs(cachedHideVideoSongs)
@@ -3996,7 +3996,7 @@ class MusicService :
 
         try {
             val persistQueue =
-                currentQueue.toPersistQueue(
+                _currentQueue.value.toPersistQueue(
                     title = queueTitle,
                     items = player.mediaItems.mapNotNull { it.metadata },
                     mediaItemIndex = player.currentMediaItemIndex,

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -1816,7 +1816,7 @@ class MusicService :
     }
 
     fun adoptQueue(queue: Queue, title: String? = null, initialQueueSize: Int = 0) {
-        currentQueue = queue
+        _currentQueue.value = queue
         queueTitle = title
         originalQueueSize = initialQueueSize
     }
@@ -4373,10 +4373,13 @@ class MusicService :
                 if (targetId.isBlank()) return null
                 val songs = database.playlistSongs(targetId).first()
                 if (songs.isEmpty()) return null
-                val playlistName = database.playlist(targetId).first()?.playlist?.name ?: targetTitle
+                val playlist = database.playlist(targetId).first()?.playlist
                 ListQueue(
-                    title = playlistName,
+                    title = playlist?.name ?: targetTitle,
                     items = songs.map { it.song.toMediaItem() },
+                    playlistBrowseId = playlist?.browseId,
+                    playlistId = playlist?.id,
+                    playlistIsEditable = playlist?.isEditable == true,
                 )
             }
 
@@ -4388,6 +4391,9 @@ class MusicService :
                     ListQueue(
                         title = cachedPlaylist?.playlist?.name ?: targetTitle,
                         items = cachedSongs.map { it.song.toMediaItem() },
+                        playlistBrowseId = cachedPlaylist?.playlist?.browseId,
+                        playlistId = cachedPlaylist?.playlist?.id,
+                        playlistIsEditable = cachedPlaylist?.playlist?.isEditable == true,
                     )
                 } else {
                     YouTubePlaylistQueue(
@@ -4478,13 +4484,9 @@ class MusicService :
                     return@launch
                 }
                 val items = playlistSongs.map { it.song.toMediaItem() }
-                val playlistName =
+                val playlist =
                     withContext(Dispatchers.IO) {
-                        database
-                            .playlist(playlistId)
-                            .first()
-                            ?.playlist
-                            ?.name
+                        database.playlist(playlistId).first()?.playlist
                     }
                 withContext(Dispatchers.IO) {
                     MusicAlarmScheduler.scheduleFromPreferences(this@MusicService)
@@ -4507,10 +4509,13 @@ class MusicService :
                 player.clearMediaItems()
                 playQueue(
                     ListQueue(
-                        title = playlistName,
+                        title = playlist?.name,
                         items = alarmItems,
                         startIndex = 0,
                         position = 0L,
+                        playlistBrowseId = playlist?.browseId,
+                        playlistId = playlist?.id,
+                        playlistIsEditable = playlist?.isEditable == true,
                     ),
                     playWhenReady = true,
                 )

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -337,7 +337,8 @@ class MusicService :
 
     private lateinit var audioQuality: com.metrolist.music.constants.AudioQuality
 
-    private var currentQueue: Queue = EmptyQueue
+    var currentQueue: Queue = EmptyQueue
+        private set
     var queueTitle: String? = null
 
     val currentMediaMetadata = MutableStateFlow<com.metrolist.music.models.MediaMetadata?>(null)
@@ -4391,6 +4392,7 @@ class MusicService :
                 } else {
                     YouTubePlaylistQueue(
                         playlistId = targetId,
+                        isEditable = cachedPlaylist?.playlist?.isEditable ?: false,
                         playlistTitle = targetTitle,
                     )
                 }

--- a/app/src/main/kotlin/com/metrolist/music/playback/queues/ListQueue.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/queues/ListQueue.kt
@@ -13,6 +13,9 @@ class ListQueue(
     val items: List<MediaItem>,
     val startIndex: Int = 0,
     val position: Long = 0L,
+    val playlistBrowseId: String? = null,
+    val playlistId: String? = null,
+    val playlistSetVideoIds: Map<String, String> = emptyMap(),
 ) : Queue {
     override val preloadItem: MediaMetadata? = null
 

--- a/app/src/main/kotlin/com/metrolist/music/playback/queues/ListQueue.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/queues/ListQueue.kt
@@ -15,7 +15,7 @@ class ListQueue(
     val position: Long = 0L,
     val playlistBrowseId: String? = null,
     val playlistId: String? = null,
-    val playlistSetVideoIds: Map<String, String> = emptyMap(),
+    val playlistIsEditable: Boolean = false,
 ) : Queue {
     override val preloadItem: MediaMetadata? = null
 

--- a/app/src/main/kotlin/com/metrolist/music/playback/queues/PlaylistRemovalTarget.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/queues/PlaylistRemovalTarget.kt
@@ -1,0 +1,72 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.playback.queues
+
+import com.metrolist.music.db.entities.PlaylistSongMap
+
+/**
+ * Identifies the single playlist row that a "remove from playlist" action should delete.
+ *
+ * [setVideoId] is what distinguishes one occurrence of a song from another: YouTube assigns a
+ * distinct setVideoId to every row, so a song added twice to the same playlist has two targets.
+ */
+data class PlaylistRemovalTarget(
+    val playlistId: String,
+    val setVideoId: String,
+    val localPlaylistId: String?,
+    val source: String,
+)
+
+/**
+ * Resolves the removal target for the currently playing item, or null when the current queue has
+ * no editable playlist context or the occurrence cannot be identified.
+ */
+fun resolvePlaylistRemovalTarget(
+    queue: Queue?,
+    setVideoId: String?,
+): PlaylistRemovalTarget? {
+    val occurrenceId = setVideoId?.takeIf { it.isNotBlank() } ?: return null
+    return when (queue) {
+        is YouTubePlaylistQueue ->
+            if (queue.isEditable) {
+                PlaylistRemovalTarget(
+                    playlistId = queue.playlistId,
+                    setVideoId = occurrenceId,
+                    localPlaylistId = null,
+                    source = "queue",
+                )
+            } else {
+                null
+            }
+
+        is ListQueue -> {
+            val browseId = queue.playlistBrowseId?.takeIf { it.isNotBlank() }
+            if (queue.playlistIsEditable && browseId != null) {
+                PlaylistRemovalTarget(
+                    playlistId = browseId,
+                    setVideoId = occurrenceId,
+                    localPlaylistId = queue.playlistId,
+                    source = "listQueue",
+                )
+            } else {
+                null
+            }
+        }
+
+        else -> null
+    }
+}
+
+/**
+ * Picks the local playlist row matching a removal target. Matching on setVideoId (never on position
+ * or song id alone) keeps duplicate occurrences of the same song independent.
+ */
+fun selectLocalPlaylistRowToRemove(
+    maps: List<PlaylistSongMap>,
+    localPlaylistId: String,
+    setVideoId: String,
+): PlaylistSongMap? =
+    maps.firstOrNull { it.playlistId == localPlaylistId && it.setVideoId == setVideoId }

--- a/app/src/main/kotlin/com/metrolist/music/playback/queues/YouTubePlaylistQueue.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/queues/YouTubePlaylistQueue.kt
@@ -14,7 +14,8 @@ import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.withContext
 
 class YouTubePlaylistQueue(
-    private val playlistId: String,
+    val playlistId: String,
+    val isEditable: Boolean = false,
     private val playlistTitle: String? = null,
     private val initialSongs: List<SongItem> = emptyList(),
     private val initialContinuation: String? = null,
@@ -24,13 +25,21 @@ class YouTubePlaylistQueue(
     private var continuation: String? = initialContinuation
     private var retryCount = 0
     private val maxRetries = 3
+    private val setVideoIds = mutableMapOf<String, String>()
+
+    fun getSetVideoId(videoId: String): String? = setVideoIds[videoId]
+
+    private fun SongItem.toPlaylistItem(playlistId: String): MediaItem {
+        setVideoId?.takeIf { it.isNotBlank() }?.let { setVideoIds[id] = it }
+        return this.toMediaItem()
+    }
 
     override suspend fun getInitialStatus(): Queue.Status {
         return withContext(IO) {
             if (initialSongs.isNotEmpty()) {
                 Queue.Status(
                     title = playlistTitle,
-                    items = initialSongs.map { it.toMediaItem() },
+                    items = initialSongs.map { it.toPlaylistItem(playlistId) },
                     mediaItemIndex = startIndex,
                 )
             } else {
@@ -38,7 +47,7 @@ class YouTubePlaylistQueue(
                 continuation = playlistPage.songsContinuation
                 Queue.Status(
                     title = playlistPage.playlist.title,
-                    items = playlistPage.songs.map { it.toMediaItem() },
+                    items = playlistPage.songs.map { it.toPlaylistItem(playlistId) },
                     mediaItemIndex = startIndex,
                 )
             }
@@ -57,7 +66,7 @@ class YouTubePlaylistQueue(
                     val continuationPage = YouTube.playlistContinuation(currentContinuation).getOrThrow()
                     continuation = continuationPage.continuation
                     retryCount = 0
-                    return@withContext continuationPage.songs.map { it.toMediaItem() }
+                    return@withContext continuationPage.songs.map { it.toPlaylistItem(playlistId) }
                 } catch (e: Exception) {
                     lastException = e
                     retryCount++

--- a/app/src/main/kotlin/com/metrolist/music/playback/queues/YouTubePlaylistQueue.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/queues/YouTubePlaylistQueue.kt
@@ -25,21 +25,14 @@ class YouTubePlaylistQueue(
     private var continuation: String? = initialContinuation
     private var retryCount = 0
     private val maxRetries = 3
-    private val setVideoIds = mutableMapOf<String, String>()
-
-    fun getSetVideoId(videoId: String): String? = setVideoIds[videoId]
-
-    private fun SongItem.toPlaylistItem(playlistId: String): MediaItem {
-        setVideoId?.takeIf { it.isNotBlank() }?.let { setVideoIds[id] = it }
-        return this.toMediaItem()
-    }
+    private fun SongItem.toPlaylistItem(): MediaItem = toMediaItem()
 
     override suspend fun getInitialStatus(): Queue.Status {
         return withContext(IO) {
             if (initialSongs.isNotEmpty()) {
                 Queue.Status(
                     title = playlistTitle,
-                    items = initialSongs.map { it.toPlaylistItem(playlistId) },
+                    items = initialSongs.map { it.toPlaylistItem() },
                     mediaItemIndex = startIndex,
                 )
             } else {
@@ -47,7 +40,7 @@ class YouTubePlaylistQueue(
                 continuation = playlistPage.songsContinuation
                 Queue.Status(
                     title = playlistPage.playlist.title,
-                    items = playlistPage.songs.map { it.toPlaylistItem(playlistId) },
+                    items = playlistPage.songs.map { it.toPlaylistItem() },
                     mediaItemIndex = startIndex,
                 )
             }
@@ -66,7 +59,7 @@ class YouTubePlaylistQueue(
                     val continuationPage = YouTube.playlistContinuation(currentContinuation).getOrThrow()
                     continuation = continuationPage.continuation
                     retryCount = 0
-                    return@withContext continuationPage.songs.map { it.toPlaylistItem(playlistId) }
+                    return@withContext continuationPage.songs.map { it.toPlaylistItem() }
                 } catch (e: Exception) {
                     lastException = e
                     retryCount++

--- a/app/src/main/kotlin/com/metrolist/music/playback/queues/YouTubePlaylistQueue.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/queues/YouTubePlaylistQueue.kt
@@ -25,14 +25,13 @@ class YouTubePlaylistQueue(
     private var continuation: String? = initialContinuation
     private var retryCount = 0
     private val maxRetries = 3
-    private fun SongItem.toPlaylistItem(): MediaItem = toMediaItem()
 
     override suspend fun getInitialStatus(): Queue.Status {
         return withContext(IO) {
             if (initialSongs.isNotEmpty()) {
                 Queue.Status(
                     title = playlistTitle,
-                    items = initialSongs.map { it.toPlaylistItem() },
+                    items = initialSongs.map { it.toMediaItem() },
                     mediaItemIndex = startIndex,
                 )
             } else {
@@ -40,7 +39,7 @@ class YouTubePlaylistQueue(
                 continuation = playlistPage.songsContinuation
                 Queue.Status(
                     title = playlistPage.playlist.title,
-                    items = playlistPage.songs.map { it.toPlaylistItem() },
+                    items = playlistPage.songs.map { it.toMediaItem() },
                     mediaItemIndex = startIndex,
                 )
             }
@@ -59,7 +58,7 @@ class YouTubePlaylistQueue(
                     val continuationPage = YouTube.playlistContinuation(currentContinuation).getOrThrow()
                     continuation = continuationPage.continuation
                     retryCount = 0
-                    return@withContext continuationPage.songs.map { it.toPlaylistItem() }
+                    return@withContext continuationPage.songs.map { it.toMediaItem() }
                 } catch (e: Exception) {
                     lastException = e
                     retryCount++

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/PlayerMenu.kt
@@ -8,6 +8,7 @@ package com.metrolist.music.ui.menu
 import android.content.Context
 import android.content.Intent
 import android.media.audiofx.AudioEffect
+import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import android.content.res.Configuration
@@ -56,6 +57,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -84,6 +86,7 @@ import com.metrolist.music.LocalDatabase
 import com.metrolist.music.LocalDownloadUtil
 import com.metrolist.music.LocalListenTogetherManager
 import com.metrolist.music.LocalPlayerConnection
+import com.metrolist.music.LocalSyncUtils
 import com.metrolist.music.R
 import com.metrolist.music.constants.ListItemHeight
 import com.metrolist.music.constants.VarispeedKey
@@ -91,6 +94,8 @@ import com.metrolist.music.listentogether.ConnectionState
 import com.metrolist.music.listentogether.ListenTogetherEvent
 import com.metrolist.music.models.MediaMetadata
 import com.metrolist.music.playback.ExoDownloadService
+import com.metrolist.music.playback.queues.ListQueue
+import com.metrolist.music.playback.queues.YouTubePlaylistQueue
 import com.metrolist.music.db.entities.Song
 import com.metrolist.music.db.entities.SpeedDialItem
 import com.metrolist.music.ui.component.BottomSheetState
@@ -103,9 +108,19 @@ import com.metrolist.music.ui.component.VolumeSlider
 import com.metrolist.music.utils.rememberPreference
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlin.math.log2
 import kotlin.math.pow
 import kotlin.math.round
+
+private data class PlaylistRemovalTarget(
+    val playlistId: String,
+    val setVideoId: String,
+    val localPlaylistId: String?,
+    val source: String,
+)
+
+private const val PLAYER_MENU_TAG = "PlayerMenu"
 
 @Composable
 fun PlayerMenu(
@@ -119,6 +134,7 @@ fun PlayerMenu(
     val navController = LocalNavController.current
     val context = LocalContext.current
     val database = LocalDatabase.current
+    val syncUtils = LocalSyncUtils.current
     val playerConnection = LocalPlayerConnection.current ?: return
     val playerVolume = playerConnection.service.playerVolume.collectAsStateWithLifecycle()
 
@@ -139,6 +155,38 @@ fun PlayerMenu(
 
     val librarySong by database.song(mediaMetadata.id).collectAsStateWithLifecycle(initialValue = null)
     val coroutineScope = rememberCoroutineScope()
+    val playlistRemovalTarget by produceState<PlaylistRemovalTarget?>(
+        initialValue = null,
+        mediaMetadata.id,
+        mediaMetadata.setVideoId,
+    ) {
+        val queue = playerConnection.service.currentQueue as? YouTubePlaylistQueue
+        val queueSetVideoId = queue?.getSetVideoId(mediaMetadata.id)
+        if (queue?.isEditable == true && !queueSetVideoId.isNullOrBlank()) {
+            value = PlaylistRemovalTarget(
+                playlistId = queue.playlistId,
+                setVideoId = queueSetVideoId,
+                localPlaylistId = null,
+                source = "queue",
+            )
+            return@produceState
+        }
+
+        val listQueue = playerConnection.service.currentQueue as? ListQueue
+        val listQueueBrowseId = listQueue?.playlistBrowseId
+        val listQueueSetVideoId = listQueue?.playlistSetVideoIds?.get(mediaMetadata.id)
+        if (!listQueueBrowseId.isNullOrBlank() && !listQueueSetVideoId.isNullOrBlank()) {
+            value = PlaylistRemovalTarget(
+                playlistId = listQueueBrowseId,
+                setVideoId = listQueueSetVideoId,
+                localPlaylistId = listQueue.playlistId,
+                source = "listQueue",
+            )
+            return@produceState
+        }
+
+        value = null
+    }
 
     val download by LocalDownloadUtil.current
         .getDownload(mediaMetadata.id)
@@ -508,6 +556,62 @@ fun PlayerMenu(
                                 },
                             ),
                         )
+                        playlistRemovalTarget?.let { removalTarget ->
+                            add(
+                                Material3MenuItemData(
+                                    title = { Text(text = stringResource(R.string.remove_from_playlist)) },
+                                    icon = {
+                                        Icon(
+                                            painter = painterResource(R.drawable.delete),
+                                            contentDescription = null,
+                                            modifier = Modifier.size(24.dp),
+                                        )
+                                    },
+                                    onClick = {
+                                        coroutineScope.launch {
+                                            Log.d(
+                                                PLAYER_MENU_TAG,
+                                                "removeFromPlaylist: playlistId=${removalTarget.playlistId}, " +
+                                                    "videoId=${mediaMetadata.id}, setVideoId=${removalTarget.setVideoId}, " +
+                                                    "source=${removalTarget.source}",
+                                            )
+                                            syncUtils.scheduleRemoveFromPlaylist(
+                                                removalTarget.playlistId,
+                                                mediaMetadata.id,
+                                                removalTarget.localPlaylistId ?: removalTarget.playlistId,
+                                            ) {
+                                                removalTarget.setVideoId
+                                            }
+                                            removalTarget.localPlaylistId?.let { localPlaylistId ->
+                                                withContext(Dispatchers.IO) {
+                                                    database.playlistSongMaps(mediaMetadata.id)
+                                                        .firstOrNull { playlistSongMap ->
+                                                            playlistSongMap.playlistId == localPlaylistId &&
+                                                                playlistSongMap.setVideoId == removalTarget.setVideoId
+                                                        }
+                                                        ?.let { playlistSongMap ->
+                                                            database.transaction {
+                                                                move(
+                                                                    playlistSongMap.playlistId,
+                                                                    playlistSongMap.position,
+                                                                    Int.MAX_VALUE,
+                                                                )
+                                                                delete(playlistSongMap.copy(position = Int.MAX_VALUE))
+                                                            }
+                                                        }
+                                                }
+                                            }
+                                            Toast.makeText(
+                                                context,
+                                                R.string.remove_from_playlist,
+                                                Toast.LENGTH_SHORT,
+                                            ).show()
+                                            onDismiss()
+                                        }
+                                    },
+                                )
+                            )
+                        }
                         add(
                             Material3MenuItemData(
                                 title = {

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/PlayerMenu.kt
@@ -91,8 +91,8 @@ import com.metrolist.music.listentogether.ConnectionState
 import com.metrolist.music.listentogether.ListenTogetherEvent
 import com.metrolist.music.models.MediaMetadata
 import com.metrolist.music.playback.ExoDownloadService
-import com.metrolist.music.playback.queues.ListQueue
-import com.metrolist.music.playback.queues.YouTubePlaylistQueue
+import com.metrolist.music.playback.queues.resolvePlaylistRemovalTarget
+import com.metrolist.music.playback.queues.selectLocalPlaylistRowToRemove
 import com.metrolist.music.db.entities.Song
 import com.metrolist.music.db.entities.SpeedDialItem
 import com.metrolist.music.ui.component.BottomSheetState
@@ -109,13 +109,6 @@ import kotlinx.coroutines.withContext
 import kotlin.math.log2
 import kotlin.math.pow
 import kotlin.math.round
-
-private data class PlaylistRemovalTarget(
-    val playlistId: String,
-    val setVideoId: String,
-    val localPlaylistId: String?,
-    val source: String,
-)
 
 private const val PLAYER_MENU_TAG = "PlayerMenu"
 
@@ -154,22 +147,8 @@ fun PlayerMenu(
     val coroutineScope = rememberCoroutineScope()
     val downloadUtil = LocalDownloadUtil.current
     val currentQueue by playerConnection.service.currentQueue.collectAsStateWithLifecycle()
-    val playlistRemovalTarget = when (val queue = currentQueue) {
-        is YouTubePlaylistQueue -> mediaMetadata.setVideoId
-            ?.takeIf { queue.isEditable && it.isNotBlank() }
-            ?.let {
-                PlaylistRemovalTarget(queue.playlistId, it, null, "queue")
-            }
-        is ListQueue -> mediaMetadata.setVideoId
-            ?.takeIf {
-                queue.playlistIsEditable &&
-                    !queue.playlistBrowseId.isNullOrBlank() &&
-                    it.isNotBlank()
-            }
-            ?.let {
-                PlaylistRemovalTarget(queue.playlistBrowseId!!, it, queue.playlistId, "listQueue")
-            }
-        else -> null
+    val playlistRemovalTarget = remember(currentQueue, mediaMetadata.setVideoId) {
+        resolvePlaylistRemovalTarget(currentQueue, mediaMetadata.setVideoId)
     }
 
     val download by downloadUtil
@@ -551,11 +530,11 @@ fun PlayerMenu(
                                             }
                                             removalTarget.localPlaylistId?.let { localPlaylistId ->
                                                 withContext(Dispatchers.IO) {
-                                                    database.playlistSongMaps(mediaMetadata.id)
-                                                        .firstOrNull { playlistSongMap ->
-                                                            playlistSongMap.playlistId == localPlaylistId &&
-                                                                playlistSongMap.setVideoId == removalTarget.setVideoId
-                                                        }
+                                                    selectLocalPlaylistRowToRemove(
+                                                        database.playlistSongMaps(mediaMetadata.id),
+                                                        localPlaylistId,
+                                                        removalTarget.setVideoId,
+                                                    )
                                                         ?.let { playlistSongMap ->
                                                             database.transaction {
                                                                 move(

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/PlayerMenu.kt
@@ -57,7 +57,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -154,37 +153,23 @@ fun PlayerMenu(
     val librarySong by database.song(mediaMetadata.id).collectAsStateWithLifecycle(initialValue = null)
     val coroutineScope = rememberCoroutineScope()
     val downloadUtil = LocalDownloadUtil.current
-    val playlistRemovalTarget by produceState<PlaylistRemovalTarget?>(
-        initialValue = null,
-        mediaMetadata.id,
-        mediaMetadata.setVideoId,
-    ) {
-        val queue = playerConnection.service.currentQueue as? YouTubePlaylistQueue
-        val queueSetVideoId = queue?.getSetVideoId(mediaMetadata.id)
-        if (queue?.isEditable == true && !queueSetVideoId.isNullOrBlank()) {
-            value = PlaylistRemovalTarget(
-                playlistId = queue.playlistId,
-                setVideoId = queueSetVideoId,
-                localPlaylistId = null,
-                source = "queue",
-            )
-            return@produceState
-        }
-
-        val listQueue = playerConnection.service.currentQueue as? ListQueue
-        val listQueueBrowseId = listQueue?.playlistBrowseId
-        val listQueueSetVideoId = listQueue?.playlistSetVideoIds?.get(mediaMetadata.id)
-        if (!listQueueBrowseId.isNullOrBlank() && !listQueueSetVideoId.isNullOrBlank()) {
-            value = PlaylistRemovalTarget(
-                playlistId = listQueueBrowseId,
-                setVideoId = listQueueSetVideoId,
-                localPlaylistId = listQueue.playlistId,
-                source = "listQueue",
-            )
-            return@produceState
-        }
-
-        value = null
+    val currentQueue by playerConnection.service.currentQueue.collectAsStateWithLifecycle()
+    val playlistRemovalTarget = when (val queue = currentQueue) {
+        is YouTubePlaylistQueue -> mediaMetadata.setVideoId
+            ?.takeIf { queue.isEditable && it.isNotBlank() }
+            ?.let {
+                PlaylistRemovalTarget(queue.playlistId, it, null, "queue")
+            }
+        is ListQueue -> mediaMetadata.setVideoId
+            ?.takeIf {
+                queue.playlistIsEditable &&
+                    !queue.playlistBrowseId.isNullOrBlank() &&
+                    it.isNotBlank()
+            }
+            ?.let {
+                PlaylistRemovalTarget(queue.playlistBrowseId!!, it, queue.playlistId, "listQueue")
+            }
+        else -> null
     }
 
     val download by downloadUtil

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/PlayerMenu.kt
@@ -8,6 +8,7 @@ package com.metrolist.music.ui.menu
 import android.content.Context
 import android.content.Intent
 import android.media.audiofx.AudioEffect
+import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import android.content.res.Configuration
@@ -56,6 +57,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -82,6 +84,7 @@ import com.metrolist.music.LocalDatabase
 import com.metrolist.music.LocalDownloadUtil
 import com.metrolist.music.LocalListenTogetherManager
 import com.metrolist.music.LocalPlayerConnection
+import com.metrolist.music.LocalSyncUtils
 import com.metrolist.music.R
 import com.metrolist.music.constants.ListItemHeight
 import com.metrolist.music.constants.VarispeedKey
@@ -89,6 +92,8 @@ import com.metrolist.music.listentogether.ConnectionState
 import com.metrolist.music.listentogether.ListenTogetherEvent
 import com.metrolist.music.models.MediaMetadata
 import com.metrolist.music.playback.ExoDownloadService
+import com.metrolist.music.playback.queues.ListQueue
+import com.metrolist.music.playback.queues.YouTubePlaylistQueue
 import com.metrolist.music.db.entities.Song
 import com.metrolist.music.db.entities.SpeedDialItem
 import com.metrolist.music.ui.component.BottomSheetState
@@ -101,9 +106,19 @@ import com.metrolist.music.ui.component.VolumeSlider
 import com.metrolist.music.utils.rememberPreference
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlin.math.log2
 import kotlin.math.pow
 import kotlin.math.round
+
+private data class PlaylistRemovalTarget(
+    val playlistId: String,
+    val setVideoId: String,
+    val localPlaylistId: String?,
+    val source: String,
+)
+
+private const val PLAYER_MENU_TAG = "PlayerMenu"
 
 @Composable
 fun PlayerMenu(
@@ -117,6 +132,7 @@ fun PlayerMenu(
     val navController = LocalNavController.current
     val context = LocalContext.current
     val database = LocalDatabase.current
+    val syncUtils = LocalSyncUtils.current
     val playerConnection = LocalPlayerConnection.current ?: return
     val playerVolume = playerConnection.service.playerVolume.collectAsStateWithLifecycle()
 
@@ -138,6 +154,38 @@ fun PlayerMenu(
     val librarySong by database.song(mediaMetadata.id).collectAsStateWithLifecycle(initialValue = null)
     val coroutineScope = rememberCoroutineScope()
     val downloadUtil = LocalDownloadUtil.current
+    val playlistRemovalTarget by produceState<PlaylistRemovalTarget?>(
+        initialValue = null,
+        mediaMetadata.id,
+        mediaMetadata.setVideoId,
+    ) {
+        val queue = playerConnection.service.currentQueue as? YouTubePlaylistQueue
+        val queueSetVideoId = queue?.getSetVideoId(mediaMetadata.id)
+        if (queue?.isEditable == true && !queueSetVideoId.isNullOrBlank()) {
+            value = PlaylistRemovalTarget(
+                playlistId = queue.playlistId,
+                setVideoId = queueSetVideoId,
+                localPlaylistId = null,
+                source = "queue",
+            )
+            return@produceState
+        }
+
+        val listQueue = playerConnection.service.currentQueue as? ListQueue
+        val listQueueBrowseId = listQueue?.playlistBrowseId
+        val listQueueSetVideoId = listQueue?.playlistSetVideoIds?.get(mediaMetadata.id)
+        if (!listQueueBrowseId.isNullOrBlank() && !listQueueSetVideoId.isNullOrBlank()) {
+            value = PlaylistRemovalTarget(
+                playlistId = listQueueBrowseId,
+                setVideoId = listQueueSetVideoId,
+                localPlaylistId = listQueue.playlistId,
+                source = "listQueue",
+            )
+            return@produceState
+        }
+
+        value = null
+    }
 
     val download by downloadUtil
         .getDownload(mediaMetadata.id)
@@ -490,6 +538,62 @@ fun PlayerMenu(
                                 },
                             ),
                         )
+                        playlistRemovalTarget?.let { removalTarget ->
+                            add(
+                                Material3MenuItemData(
+                                    title = { Text(text = stringResource(R.string.remove_from_playlist)) },
+                                    icon = {
+                                        Icon(
+                                            painter = painterResource(R.drawable.delete),
+                                            contentDescription = null,
+                                            modifier = Modifier.size(24.dp),
+                                        )
+                                    },
+                                    onClick = {
+                                        coroutineScope.launch {
+                                            Log.d(
+                                                PLAYER_MENU_TAG,
+                                                "removeFromPlaylist: playlistId=${removalTarget.playlistId}, " +
+                                                    "videoId=${mediaMetadata.id}, setVideoId=${removalTarget.setVideoId}, " +
+                                                    "source=${removalTarget.source}",
+                                            )
+                                            syncUtils.scheduleRemoveFromPlaylist(
+                                                removalTarget.playlistId,
+                                                mediaMetadata.id,
+                                                removalTarget.localPlaylistId ?: removalTarget.playlistId,
+                                            ) {
+                                                removalTarget.setVideoId
+                                            }
+                                            removalTarget.localPlaylistId?.let { localPlaylistId ->
+                                                withContext(Dispatchers.IO) {
+                                                    database.playlistSongMaps(mediaMetadata.id)
+                                                        .firstOrNull { playlistSongMap ->
+                                                            playlistSongMap.playlistId == localPlaylistId &&
+                                                                playlistSongMap.setVideoId == removalTarget.setVideoId
+                                                        }
+                                                        ?.let { playlistSongMap ->
+                                                            database.transaction {
+                                                                move(
+                                                                    playlistSongMap.playlistId,
+                                                                    playlistSongMap.position,
+                                                                    Int.MAX_VALUE,
+                                                                )
+                                                                delete(playlistSongMap.copy(position = Int.MAX_VALUE))
+                                                            }
+                                                        }
+                                                }
+                                            }
+                                            Toast.makeText(
+                                                context,
+                                                R.string.remove_from_playlist,
+                                                Toast.LENGTH_SHORT,
+                                            ).show()
+                                            onDismiss()
+                                        }
+                                    },
+                                )
+                            )
+                        }
                         add(
                             Material3MenuItemData(
                                 title = {

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeSongMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeSongMenu.kt
@@ -8,6 +8,7 @@ package com.metrolist.music.ui.menu
 import android.annotation.SuppressLint
 import android.content.Intent
 import android.content.res.Configuration
+import android.util.Log
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -92,12 +93,17 @@ import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.time.LocalDateTime
 
+private const val YOUTUBE_SONG_MENU_TAG = "YouTubeSongMenu"
+
 @SuppressLint("MutableCollectionMutableState")
 @Composable
 fun YouTubeSongMenu(
     song: SongItem,
     onDismiss: () -> Unit,
-    onHistoryRemoved: () -> Unit = {}
+    onHistoryRemoved: () -> Unit = {},
+    playlistId: String? = null,
+    isEditable: Boolean = false,
+    onSongRemovedFromPlaylist: () -> Unit = {}
 ) {
     val navController = LocalNavController.current
     val context = LocalContext.current
@@ -558,9 +564,41 @@ fun YouTubeSongMenu(
                                         )
                                     }
                                 }
+                                onDismiss()
                             }
                         )
                     )
+                    val setVideoId = song.setVideoId
+                    if (isEditable && playlistId != null && setVideoId != null) {
+                        add(
+                            Material3MenuItemData(
+                                title = { Text(text = stringResource(R.string.remove_from_playlist)) },
+                                icon = {
+                                    Icon(
+                                        painter = painterResource(R.drawable.delete),
+                                        contentDescription = null,
+                                    )
+                                },
+                                onClick = {
+                                    coroutineScope.launch {
+                                        Log.d(
+                                            YOUTUBE_SONG_MENU_TAG,
+                                            "removeFromPlaylist: playlistId=$playlistId, videoId=${song.id}, setVideoId=$setVideoId",
+                                        )
+                                        syncUtils.scheduleRemoveFromPlaylist(
+                                            playlistId,
+                                            song.id,
+                                            playlistId,
+                                        ) {
+                                            setVideoId
+                                        }
+                                        onSongRemovedFromPlaylist()
+                                    }
+                                    onDismiss()
+                                }
+                            )
+                        )
+                    }
                 }
             )
         }

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeSongMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeSongMenu.kt
@@ -8,6 +8,7 @@ package com.metrolist.music.ui.menu
 import android.annotation.SuppressLint
 import android.content.Intent
 import android.content.res.Configuration
+import android.util.Log
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -92,12 +93,17 @@ import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.time.LocalDateTime
 
+private const val YOUTUBE_SONG_MENU_TAG = "YouTubeSongMenu"
+
 @SuppressLint("MutableCollectionMutableState")
 @Composable
 fun YouTubeSongMenu(
     song: SongItem,
     onDismiss: () -> Unit,
-    onHistoryRemoved: () -> Unit = {}
+    onHistoryRemoved: () -> Unit = {},
+    playlistId: String? = null,
+    isEditable: Boolean = false,
+    onSongRemovedFromPlaylist: () -> Unit = {}
 ) {
     val navController = LocalNavController.current
     val context = LocalContext.current
@@ -565,9 +571,41 @@ fun YouTubeSongMenu(
                                         )
                                     }
                                 }
+                                onDismiss()
                             }
                         )
                     )
+                    val setVideoId = song.setVideoId
+                    if (isEditable && playlistId != null && setVideoId != null) {
+                        add(
+                            Material3MenuItemData(
+                                title = { Text(text = stringResource(R.string.remove_from_playlist)) },
+                                icon = {
+                                    Icon(
+                                        painter = painterResource(R.drawable.delete),
+                                        contentDescription = null,
+                                    )
+                                },
+                                onClick = {
+                                    coroutineScope.launch {
+                                        Log.d(
+                                            YOUTUBE_SONG_MENU_TAG,
+                                            "removeFromPlaylist: playlistId=$playlistId, videoId=${song.id}, setVideoId=$setVideoId",
+                                        )
+                                        syncUtils.scheduleRemoveFromPlaylist(
+                                            playlistId,
+                                            song.id,
+                                            playlistId,
+                                        ) {
+                                            setVideoId
+                                        }
+                                        onSongRemovedFromPlaylist()
+                                    }
+                                    onDismiss()
+                                }
+                            )
+                        )
+                    }
                 }
             )
         }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -676,13 +676,22 @@ fun LocalPlaylistScreen(
                                                 playerConnection.togglePlayPause()
                                             } else {
                                                 playerConnection.playQueue(
-                                                    ListQueue(
-                                                        title = playlist!!.playlist.name,
-                                                        items = songs.map { it.song.toMediaItem() },
-                                                        startIndex = songs.indexOfFirst { it.map.id == song.map.id },
-                                                    ),
-                                                )
-                                            }
+                                                ListQueue(
+                                                    title = playlist!!.playlist.name,
+                                                    items = songs.map { it.song.toMediaItem() },
+                                                    startIndex = songs.indexOfFirst { it.map.id == song.map.id },
+                                                    playlistBrowseId = playlist?.playlist?.browseId,
+                                                    playlistId = playlist?.playlist?.id,
+                                                    playlistSetVideoIds = songs
+                                                        .mapNotNull { playlistSong ->
+                                                            playlistSong.map.setVideoId?.let { setVideoId ->
+                                                                playlistSong.map.songId to setVideoId
+                                                            }
+                                                        }
+                                                        .toMap(),
+                                                ),
+                                            )
+                                        }
                                         },
                                         onLongClick = {
                                             if (!inSelectMode) {
@@ -1335,14 +1344,24 @@ fun LocalPlaylistHeader(
         ) {
             // Shuffle Button - Smaller secondary button
             Surface(
-                onClick = {
-                    playerConnection.playQueue(
-                        ListQueue(
-                            title = playlist.playlist.name,
-                            items = songs.shuffled().map { it.song.toMediaItem() },
-                        ),
-                    )
-                },
+              onClick = {
+                  val shuffledSongs = songs.shuffled()
+                  playerConnection.playQueue(
+                      ListQueue(
+                          title = playlist.playlist.name,
+                          items = shuffledSongs.map { it.song.toMediaItem() },
+                          playlistBrowseId = playlist.playlist.browseId,
+                          playlistId = playlist.playlist.id,
+                          playlistSetVideoIds = shuffledSongs
+                              .mapNotNull { playlistSong ->
+                                  playlistSong.map.setVideoId?.let { setVideoId ->
+                                      playlistSong.map.songId to setVideoId
+                                  }
+                              }
+                              .toMap(),
+                      ),
+                  )
+              },
                 shape = CircleShape,
                 color = MaterialTheme.colorScheme.surfaceVariant,
                 modifier = Modifier.size(48.dp),
@@ -1363,12 +1382,21 @@ fun LocalPlaylistHeader(
             Surface(
                 onClick = {
                     playerConnection.playQueue(
-                        ListQueue(
-                            title = playlist.playlist.name,
-                            items = songs.map { it.song.toMediaItem() },
-                        ),
-                    )
-                },
+                      ListQueue(
+                          title = playlist.playlist.name,
+                          items = songs.map { it.song.toMediaItem() },
+                          playlistBrowseId = playlist.playlist.browseId,
+                          playlistId = playlist.playlist.id,
+                          playlistSetVideoIds = songs
+                              .mapNotNull { playlistSong ->
+                                  playlistSong.map.setVideoId?.let { setVideoId ->
+                                      playlistSong.map.songId to setVideoId
+                                  }
+                              }
+                              .toMap(),
+                      ),
+                  )
+              },
                 color = MaterialTheme.colorScheme.primary,
                 shape = CircleShape,
                 modifier = Modifier.size(72.dp),

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -666,20 +666,12 @@ fun LocalPlaylistScreen(
                                                 playerConnection.togglePlayPause()
                                             } else {
                                                 playerConnection.playQueue(
-                                                ListQueue(
-                                                    title = playlist!!.playlist.name,
-                                                    items = songs.map {
-                                                        it.song.toMediaMetadata()
-                                                            .copy(setVideoId = it.map.setVideoId)
-                                                            .toMediaItem()
-                                                    },
-                                                    startIndex = songs.indexOfFirst { it.map.id == song.map.id },
-                                                    playlistBrowseId = playlist?.playlist?.browseId,
-                                                    playlistId = playlist?.playlist?.id,
-                                                    playlistIsEditable = playlist?.playlist?.isEditable == true,
-                                                ),
-                                            )
-                                        }
+                                                    playlist!!.toListQueue(
+                                                        songs,
+                                                        startIndex = songs.indexOfFirst { it.map.id == song.map.id },
+                                                    ),
+                                                )
+                                            }
                                         },
                                         onLongClick = {
                                             if (!inSelectMode) {
@@ -1332,22 +1324,11 @@ fun LocalPlaylistHeader(
         ) {
             // Shuffle Button - Smaller secondary button
             Surface(
-              onClick = {
-                  val shuffledSongs = songs.shuffled()
-                  playerConnection.playQueue(
-                      ListQueue(
-                          title = playlist.playlist.name,
-                          items = shuffledSongs.map {
-                              it.song.toMediaMetadata()
-                                  .copy(setVideoId = it.map.setVideoId)
-                                  .toMediaItem()
-                          },
-                          playlistBrowseId = playlist.playlist.browseId,
-                          playlistId = playlist.playlist.id,
-                          playlistIsEditable = playlist.playlist.isEditable,
-                      ),
-                  )
-              },
+                onClick = {
+                    playerConnection.playQueue(
+                        playlist.toListQueue(songs.shuffled()),
+                    )
+                },
                 shape = CircleShape,
                 color = MaterialTheme.colorScheme.surfaceVariant,
                 modifier = Modifier.size(48.dp),
@@ -1368,19 +1349,9 @@ fun LocalPlaylistHeader(
             Surface(
                 onClick = {
                     playerConnection.playQueue(
-                      ListQueue(
-                          title = playlist.playlist.name,
-                          items = songs.map {
-                              it.song.toMediaMetadata()
-                                  .copy(setVideoId = it.map.setVideoId)
-                                  .toMediaItem()
-                          },
-                          playlistBrowseId = playlist.playlist.browseId,
-                          playlistId = playlist.playlist.id,
-                          playlistIsEditable = playlist.playlist.isEditable,
-                      ),
-                  )
-              },
+                        playlist.toListQueue(songs),
+                    )
+                },
                 color = MaterialTheme.colorScheme.primary,
                 shape = CircleShape,
                 modifier = Modifier.size(72.dp),
@@ -1481,6 +1452,28 @@ fun LocalPlaylistHeader(
         }
     }
 }
+
+/**
+ * Builds a queue that carries the playlist context needed by "remove from playlist": the browse id
+ * to edit remotely, the local playlist id to edit in the database, and each row's setVideoId so a
+ * song added to the playlist more than once stays distinguishable while playing.
+ */
+fun Playlist.toListQueue(
+    songs: List<PlaylistSong>,
+    startIndex: Int = 0,
+): ListQueue =
+    ListQueue(
+        title = playlist.name,
+        items = songs.map {
+            it.song.toMediaMetadata()
+                .copy(setVideoId = it.map.setVideoId)
+                .toMediaItem()
+        },
+        startIndex = startIndex,
+        playlistBrowseId = playlist.browseId,
+        playlistId = playlist.id,
+        playlistIsEditable = playlist.isEditable,
+    )
 
 fun uriToByteArray(
     context: Context,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -666,13 +666,22 @@ fun LocalPlaylistScreen(
                                                 playerConnection.togglePlayPause()
                                             } else {
                                                 playerConnection.playQueue(
-                                                    ListQueue(
-                                                        title = playlist!!.playlist.name,
-                                                        items = songs.map { it.song.toMediaItem() },
-                                                        startIndex = songs.indexOfFirst { it.map.id == song.map.id },
-                                                    ),
-                                                )
-                                            }
+                                                ListQueue(
+                                                    title = playlist!!.playlist.name,
+                                                    items = songs.map { it.song.toMediaItem() },
+                                                    startIndex = songs.indexOfFirst { it.map.id == song.map.id },
+                                                    playlistBrowseId = playlist?.playlist?.browseId,
+                                                    playlistId = playlist?.playlist?.id,
+                                                    playlistSetVideoIds = songs
+                                                        .mapNotNull { playlistSong ->
+                                                            playlistSong.map.setVideoId?.let { setVideoId ->
+                                                                playlistSong.map.songId to setVideoId
+                                                            }
+                                                        }
+                                                        .toMap(),
+                                                ),
+                                            )
+                                        }
                                         },
                                         onLongClick = {
                                             if (!inSelectMode) {
@@ -1325,14 +1334,24 @@ fun LocalPlaylistHeader(
         ) {
             // Shuffle Button - Smaller secondary button
             Surface(
-                onClick = {
-                    playerConnection.playQueue(
-                        ListQueue(
-                            title = playlist.playlist.name,
-                            items = songs.shuffled().map { it.song.toMediaItem() },
-                        ),
-                    )
-                },
+              onClick = {
+                  val shuffledSongs = songs.shuffled()
+                  playerConnection.playQueue(
+                      ListQueue(
+                          title = playlist.playlist.name,
+                          items = shuffledSongs.map { it.song.toMediaItem() },
+                          playlistBrowseId = playlist.playlist.browseId,
+                          playlistId = playlist.playlist.id,
+                          playlistSetVideoIds = shuffledSongs
+                              .mapNotNull { playlistSong ->
+                                  playlistSong.map.setVideoId?.let { setVideoId ->
+                                      playlistSong.map.songId to setVideoId
+                                  }
+                              }
+                              .toMap(),
+                      ),
+                  )
+              },
                 shape = CircleShape,
                 color = MaterialTheme.colorScheme.surfaceVariant,
                 modifier = Modifier.size(48.dp),
@@ -1353,12 +1372,21 @@ fun LocalPlaylistHeader(
             Surface(
                 onClick = {
                     playerConnection.playQueue(
-                        ListQueue(
-                            title = playlist.playlist.name,
-                            items = songs.map { it.song.toMediaItem() },
-                        ),
-                    )
-                },
+                      ListQueue(
+                          title = playlist.playlist.name,
+                          items = songs.map { it.song.toMediaItem() },
+                          playlistBrowseId = playlist.playlist.browseId,
+                          playlistId = playlist.playlist.id,
+                          playlistSetVideoIds = songs
+                              .mapNotNull { playlistSong ->
+                                  playlistSong.map.setVideoId?.let { setVideoId ->
+                                      playlistSong.map.songId to setVideoId
+                                  }
+                              }
+                              .toMap(),
+                      ),
+                  )
+              },
                 color = MaterialTheme.colorScheme.primary,
                 shape = CircleShape,
                 modifier = Modifier.size(72.dp),

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -668,17 +668,15 @@ fun LocalPlaylistScreen(
                                                 playerConnection.playQueue(
                                                 ListQueue(
                                                     title = playlist!!.playlist.name,
-                                                    items = songs.map { it.song.toMediaItem() },
+                                                    items = songs.map {
+                                                        it.song.toMediaMetadata()
+                                                            .copy(setVideoId = it.map.setVideoId)
+                                                            .toMediaItem()
+                                                    },
                                                     startIndex = songs.indexOfFirst { it.map.id == song.map.id },
                                                     playlistBrowseId = playlist?.playlist?.browseId,
                                                     playlistId = playlist?.playlist?.id,
-                                                    playlistSetVideoIds = songs
-                                                        .mapNotNull { playlistSong ->
-                                                            playlistSong.map.setVideoId?.let { setVideoId ->
-                                                                playlistSong.map.songId to setVideoId
-                                                            }
-                                                        }
-                                                        .toMap(),
+                                                    playlistIsEditable = playlist?.playlist?.isEditable == true,
                                                 ),
                                             )
                                         }
@@ -1339,16 +1337,14 @@ fun LocalPlaylistHeader(
                   playerConnection.playQueue(
                       ListQueue(
                           title = playlist.playlist.name,
-                          items = shuffledSongs.map { it.song.toMediaItem() },
+                          items = shuffledSongs.map {
+                              it.song.toMediaMetadata()
+                                  .copy(setVideoId = it.map.setVideoId)
+                                  .toMediaItem()
+                          },
                           playlistBrowseId = playlist.playlist.browseId,
                           playlistId = playlist.playlist.id,
-                          playlistSetVideoIds = shuffledSongs
-                              .mapNotNull { playlistSong ->
-                                  playlistSong.map.setVideoId?.let { setVideoId ->
-                                      playlistSong.map.songId to setVideoId
-                                  }
-                              }
-                              .toMap(),
+                          playlistIsEditable = playlist.playlist.isEditable,
                       ),
                   )
               },
@@ -1374,16 +1370,14 @@ fun LocalPlaylistHeader(
                     playerConnection.playQueue(
                       ListQueue(
                           title = playlist.playlist.name,
-                          items = songs.map { it.song.toMediaItem() },
+                          items = songs.map {
+                              it.song.toMediaMetadata()
+                                  .copy(setVideoId = it.map.setVideoId)
+                                  .toMediaItem()
+                          },
                           playlistBrowseId = playlist.playlist.browseId,
                           playlistId = playlist.playlist.id,
-                          playlistSetVideoIds = songs
-                              .mapNotNull { playlistSong ->
-                                  playlistSong.map.setVideoId?.let { setVideoId ->
-                                      playlistSong.map.songId to setVideoId
-                                  }
-                              }
-                              .toMap(),
+                          playlistIsEditable = playlist.playlist.isEditable,
                       ),
                   )
               },

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/OnlinePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/OnlinePlaylistScreen.kt
@@ -288,6 +288,7 @@ fun OnlinePlaylistScreen(
                                                 playerConnection.playQueue(
                                                     YouTubePlaylistQueue(
                                                         playlistId = playlist.id,
+                                                        isEditable = playlist.isEditable,
                                                         playlistTitle = playlist.title,
                                                         initialSongs = filteredSongs.map { it.second },
                                                         initialContinuation = viewModel.continuation,
@@ -332,7 +333,15 @@ fun OnlinePlaylistScreen(
                                 } else {
                                     IconButton(onClick = {
                                         menuState.show {
-                                            YouTubeSongMenu(songItem, menuState::dismiss)
+                                            YouTubeSongMenu(
+                                                song = songItem,
+                                                playlistId = playlist.id,
+                                                isEditable = playlist.isEditable,
+                                                onSongRemovedFromPlaylist = {
+                                                    viewModel.removeSongFromLocalList(songItem.id)
+                                                },
+                                                onDismiss = menuState::dismiss
+                                            )
                                         }
                                     }) {
                                         Icon(painterResource(R.drawable.more_vert), null)
@@ -690,6 +699,7 @@ private fun OnlinePlaylistHeader(
                         playerConnection.playQueue(
                             YouTubePlaylistQueue(
                                 playlistId = playlist.id,
+                                isEditable = playlist.isEditable,
                                 playlistTitle = playlist.title,
                                 initialSongs = songs,
                                 initialContinuation = continuation,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/OnlinePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/OnlinePlaylistScreen.kt
@@ -338,7 +338,9 @@ fun OnlinePlaylistScreen(
                                                 playlistId = playlist.id,
                                                 isEditable = playlist.isEditable,
                                                 onSongRemovedFromPlaylist = {
-                                                    viewModel.removeSongFromLocalList(songItem.id)
+                                                    songItem.setVideoId?.let { setVideoId ->
+                                                        viewModel.removeSongFromLocalList(songItem.id, setVideoId)
+                                                    }
                                                 },
                                                 onDismiss = menuState::dismiss
                                             )

--- a/app/src/main/kotlin/com/metrolist/music/utils/SetVideoIdResolver.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/SetVideoIdResolver.kt
@@ -1,0 +1,39 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.utils
+
+import kotlinx.coroutines.delay
+import timber.log.Timber
+
+const val SET_VIDEO_ID_REMOTE_ATTEMPTS = 3
+const val SET_VIDEO_ID_RETRY_DELAY_MS = 2_000L
+
+/**
+ * Resolves the setVideoId identifying the playlist row to remove, preferring the locally stored one
+ * and falling back to a bounded number of remote lookups.
+ *
+ * Returns null when the occurrence cannot be identified. Callers must skip the removal in that case:
+ * removing without a setVideoId would let YouTube pick an arbitrary occurrence of the song.
+ */
+suspend fun resolveSetVideoIdForRemoval(
+    songId: String,
+    fromDb: suspend () -> String?,
+    fromRemote: suspend () -> String?,
+    attempts: Int = SET_VIDEO_ID_REMOTE_ATTEMPTS,
+    retryDelayMs: Long = SET_VIDEO_ID_RETRY_DELAY_MS,
+    onDelay: suspend (Long) -> Unit = { delay(it) },
+): String? {
+    fromDb()?.let { return it }
+
+    Timber.w("scheduleRemoveFromPlaylist: setVideoId not in DB, fetching from YouTube")
+    for (attempt in 0 until attempts) {
+        runCatching { fromRemote() }.getOrNull()?.let { return it }
+        if (attempt < attempts - 1) onDelay(retryDelayMs)
+    }
+
+    Timber.w("scheduleRemoveFromPlaylist: setVideoId not found on YouTube, skipping remove for songId=$songId")
+    return null
+}

--- a/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
@@ -1767,24 +1767,14 @@ class SyncUtils @Inject constructor(
         syncScope.launch {
             try {
                 runQueuedPlaylistEdit {
-                    var setVideoId = getSetVideoId()
-
-                    if (setVideoId == null) {
-                        Timber.w("scheduleRemoveFromPlaylist: setVideoId not in DB, fetching from YouTube")
-                        for (attempt in 0 until 3) {
-                            setVideoId = runCatching {
-                                YouTube.playlist(browseId).completed().getOrThrow()
-                                    .songs.lastOrNull { it.id == songId }?.setVideoId
-                            }.getOrNull()
-                            if (setVideoId != null) break
-                            if (attempt < 2) delay(2_000L)
-                        }
-                    }
-
-                    if (setVideoId == null) {
-                        Timber.w("scheduleRemoveFromPlaylist: setVideoId not found on YouTube, skipping remove for songId=$songId")
-                        return@runQueuedPlaylistEdit
-                    }
+                    val setVideoId = resolveSetVideoIdForRemoval(
+                        songId = songId,
+                        fromDb = getSetVideoId,
+                        fromRemote = {
+                            YouTube.playlist(browseId).completed().getOrThrow()
+                                .songs.lastOrNull { it.id == songId }?.setVideoId
+                        },
+                    ) ?: return@runQueuedPlaylistEdit
 
                     YouTube.removeFromPlaylist(browseId, songId, setVideoId).getOrThrow()
                 }

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/OnlinePlaylistViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/OnlinePlaylistViewModel.kt
@@ -223,7 +223,7 @@ class OnlinePlaylistViewModel @Inject constructor(
                         playlistSongs.value = applySongFilters(currentSongs)
                         currentProactiveToken = playlistContinuationPage.continuation
                         // Update the class-level continuation for manual loadMore if needed
-                        this@OnlinePlaylistViewModel.continuation = currentProactiveToken 
+                        this@OnlinePlaylistViewModel.continuation = currentProactiveToken
                     }.onFailure { throwable ->
                         reportException(throwable)
                         currentProactiveToken = null // Stop proactive loading on error
@@ -263,6 +263,21 @@ class OnlinePlaylistViewModel @Inject constructor(
     fun retry() {
         proactiveLoadJob?.cancel()
         fetchInitialPlaylistData() // This will also restart proactive loading if applicable
+    }
+
+    fun removeSongFromLocalList(songId: String) {
+        playlistSongs.value = playlistSongs.value.filter { it.id != songId }
+        playlist.value = playlist.value?.let { 
+            it.copy(songCountText = it.songCountText?.let { countText ->
+                val match = Regex("""\d+""").find(countText)
+                if (match != null) {
+                    val count = match.value.toIntOrNull() ?: return@let countText
+                    countText.replace(match.value, (count - 1).coerceAtLeast(0).toString())
+                } else {
+                    countText
+                }
+            })
+        }
     }
 
     private fun applySongFilters(songs: List<SongItem>): List<SongItem> {

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/OnlinePlaylistViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/OnlinePlaylistViewModel.kt
@@ -265,8 +265,10 @@ class OnlinePlaylistViewModel @Inject constructor(
         fetchInitialPlaylistData() // This will also restart proactive loading if applicable
     }
 
-    fun removeSongFromLocalList(songId: String) {
-        playlistSongs.value = playlistSongs.value.filter { it.id != songId }
+    fun removeSongFromLocalList(songId: String, setVideoId: String) {
+        playlistSongs.value = playlistSongs.value.filter {
+            it.id != songId || it.setVideoId != setVideoId
+        }
         playlist.value = playlist.value?.let { 
             it.copy(songCountText = it.songCountText?.let { countText ->
                 val match = Regex("""\d+""").find(countText)
@@ -283,7 +285,6 @@ class OnlinePlaylistViewModel @Inject constructor(
     private fun applySongFilters(songs: List<SongItem>): List<SongItem> {
         val hideVideoSongs = context.dataStore.get(HideVideoSongsKey, false)
         return songs
-            .distinctBy { it.id }
             .filterVideoSongs(hideVideoSongs)
     }
 

--- a/app/src/test/kotlin/com/metrolist/music/extensions/QueuePlaylistContextTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/extensions/QueuePlaylistContextTest.kt
@@ -1,0 +1,146 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.extensions
+
+import com.metrolist.music.models.MediaMetadata
+import com.metrolist.music.models.PersistQueue
+import com.metrolist.music.playback.queues.ListQueue
+import com.metrolist.music.playback.queues.YouTubePlaylistQueue
+import com.metrolist.music.playback.queues.resolvePlaylistRemovalTarget
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+
+/**
+ * A queue restored from disk must keep its playlist context, otherwise "remove from playlist"
+ * silently disappears (or worse, targets the wrong playlist) after the app is restarted.
+ */
+@RunWith(RobolectricTestRunner::class)
+class QueuePlaylistContextTest {
+
+    private fun metadata(id: String, setVideoId: String?) = MediaMetadata(
+        id = id,
+        title = "title-$id",
+        artists = listOf(MediaMetadata.Artist(id = "artist", name = "Artist")),
+        duration = 100,
+        setVideoId = setVideoId,
+    )
+
+    /** The same song added twice to one playlist: two rows, two distinct setVideoIds. */
+    private val songs = listOf(
+        metadata("song-1", "setVideoId-A"),
+        metadata("song-1", "setVideoId-B"),
+    )
+
+    private fun listQueue() = ListQueue(
+        title = "My playlist",
+        items = listOf(
+            metadata("song-1", "setVideoId-A").toMediaItem(),
+            metadata("song-1", "setVideoId-B").toMediaItem(),
+        ),
+        playlistBrowseId = "VLPL_browse",
+        playlistId = "local-1",
+        playlistIsEditable = true,
+    )
+
+    @Test
+    fun `list queue keeps playlist context through persist and restore`() {
+        val persisted = listQueue().toPersistQueue(title = "My playlist", items = songs, mediaItemIndex = 1, position = 0L)
+
+        assertEquals("VLPL_browse", persisted.playlistBrowseId)
+        assertEquals("local-1", persisted.playlistId)
+        assertEquals(true, persisted.playlistIsEditable)
+
+        val restored = persisted.toQueue() as ListQueue
+
+        assertEquals("VLPL_browse", restored.playlistBrowseId)
+        assertEquals("local-1", restored.playlistId)
+        assertEquals(true, restored.playlistIsEditable)
+    }
+
+    @Test
+    fun `restored queue still resolves per occurrence removal targets`() {
+        val restored = listQueue().toPersistQueue(title = "My playlist", items = songs, mediaItemIndex = 1, position = 0L).toQueue()
+
+        val restoredItems = (restored as ListQueue).items
+        val occurrenceIds = restoredItems.map { it.metadata?.setVideoId }
+        assertEquals(listOf("setVideoId-A", "setVideoId-B"), occurrenceIds)
+
+        val target = resolvePlaylistRemovalTarget(restored, occurrenceIds[1])
+        assertEquals("VLPL_browse", target?.playlistId)
+        assertEquals("setVideoId-B", target?.setVideoId)
+        assertEquals("local-1", target?.localPlaylistId)
+    }
+
+    @Test
+    fun `restored non editable queue offers no removal target`() {
+        val restored = ListQueue(
+            title = "Someone else's playlist",
+            items = listOf(metadata("song-1", "setVideoId-A").toMediaItem()),
+            playlistBrowseId = "VLPL_browse",
+            playlistId = null,
+            playlistIsEditable = false,
+        ).toPersistQueue(title = "title", items = listOf(metadata("song-1", "setVideoId-A")), mediaItemIndex = 0, position = 0L).toQueue()
+
+        assertNull(resolvePlaylistRemovalTarget(restored, "setVideoId-A"))
+    }
+
+    @Test
+    fun `youtube playlist queue persists its editability and browse id`() {
+        val persisted = YouTubePlaylistQueue(playlistId = "PL123", isEditable = true)
+            .toPersistQueue(title = "title", items = listOf(metadata("song-1", "setVideoId-A")), mediaItemIndex = 0, position = 0L)
+
+        assertEquals("PL123", persisted.playlistBrowseId)
+        assertEquals(true, persisted.playlistIsEditable)
+
+        val restored = persisted.toQueue() as ListQueue
+        assertEquals("PL123", restored.playlistBrowseId)
+        assertEquals(true, restored.playlistIsEditable)
+        assertNull(restored.playlistId)
+
+        val target = resolvePlaylistRemovalTarget(restored, "setVideoId-A")
+        assertEquals("PL123", target?.playlistId)
+        assertNull(target?.localPlaylistId)
+    }
+
+    @Test
+    fun `queues without playlist context restore without one`() {
+        val persisted = ListQueue(
+            title = "Ad hoc queue",
+            items = listOf(metadata("song-1", null).toMediaItem()),
+        ).toPersistQueue(title = "title", items = listOf(metadata("song-1", "setVideoId-A")), mediaItemIndex = 0, position = 0L)
+
+        assertNull(persisted.playlistBrowseId)
+        assertNull(persisted.playlistId)
+        assertEquals(false, persisted.playlistIsEditable)
+        assertNull(resolvePlaylistRemovalTarget(persisted.toQueue(), "setVideoId-A"))
+    }
+
+    @Test
+    fun `persist queue survives java serialization with its playlist context`() {
+        val original = listQueue().toPersistQueue(title = "My playlist", items = songs, mediaItemIndex = 1, position = 42L)
+
+        val bytes = ByteArrayOutputStream().also { out ->
+            ObjectOutputStream(out).use { it.writeObject(original) }
+        }.toByteArray()
+        val roundTripped = ObjectInputStream(ByteArrayInputStream(bytes)).use {
+            it.readObject() as PersistQueue
+        }
+
+        assertEquals("VLPL_browse", roundTripped.playlistBrowseId)
+        assertEquals("local-1", roundTripped.playlistId)
+        assertEquals(true, roundTripped.playlistIsEditable)
+        assertEquals(listOf("setVideoId-A", "setVideoId-B"), roundTripped.items.map { it.setVideoId })
+        assertNotNull(roundTripped.toQueue())
+    }
+}

--- a/app/src/test/kotlin/com/metrolist/music/playback/queues/PlaylistRemovalTargetTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/playback/queues/PlaylistRemovalTargetTest.kt
@@ -1,0 +1,144 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.playback.queues
+
+import com.metrolist.music.db.entities.PlaylistSongMap
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Removing a song from a playlist is destructive and irreversible from the UI, so the target has to
+ * be identified exactly. These tests pin the rules: an occurrence is identified by setVideoId, and
+ * no target is produced when the playlist is not editable or the occurrence is unknown.
+ */
+class PlaylistRemovalTargetTest {
+
+    private fun listQueue(
+        browseId: String? = "VLPL_browse",
+        localId: String? = "local-1",
+        editable: Boolean = true,
+    ) = ListQueue(
+        title = "playlist",
+        items = emptyList(),
+        playlistBrowseId = browseId,
+        playlistId = localId,
+        playlistIsEditable = editable,
+    )
+
+    @Test
+    fun `list queue resolves target from browse id and set video id`() {
+        val target = resolvePlaylistRemovalTarget(listQueue(), "setVideoId-A")
+
+        assertEquals("VLPL_browse", target?.playlistId)
+        assertEquals("setVideoId-A", target?.setVideoId)
+        assertEquals("local-1", target?.localPlaylistId)
+        assertEquals("listQueue", target?.source)
+    }
+
+    @Test
+    fun `youtube playlist queue resolves target without a local playlist id`() {
+        val target = resolvePlaylistRemovalTarget(
+            YouTubePlaylistQueue(playlistId = "PL123", isEditable = true),
+            "setVideoId-A",
+        )
+
+        assertEquals("PL123", target?.playlistId)
+        assertEquals("setVideoId-A", target?.setVideoId)
+        assertNull(target?.localPlaylistId)
+        assertEquals("queue", target?.source)
+    }
+
+    // --- editability ---
+
+    @Test
+    fun `non editable youtube playlist yields no target`() {
+        assertNull(
+            resolvePlaylistRemovalTarget(
+                YouTubePlaylistQueue(playlistId = "PL123", isEditable = false),
+                "setVideoId-A",
+            ),
+        )
+    }
+
+    @Test
+    fun `non editable list queue yields no target`() {
+        assertNull(resolvePlaylistRemovalTarget(listQueue(editable = false), "setVideoId-A"))
+    }
+
+    @Test
+    fun `list queue without browse id yields no target`() {
+        assertNull(resolvePlaylistRemovalTarget(listQueue(browseId = null), "setVideoId-A"))
+        assertNull(resolvePlaylistRemovalTarget(listQueue(browseId = "   "), "setVideoId-A"))
+    }
+
+    // --- setVideoId identity ---
+
+    @Test
+    fun `missing or blank set video id yields no target`() {
+        assertNull(resolvePlaylistRemovalTarget(listQueue(), null))
+        assertNull(resolvePlaylistRemovalTarget(listQueue(), ""))
+        assertNull(resolvePlaylistRemovalTarget(listQueue(), "   "))
+        assertNull(
+            resolvePlaylistRemovalTarget(
+                YouTubePlaylistQueue(playlistId = "PL123", isEditable = true),
+                null,
+            ),
+        )
+    }
+
+    @Test
+    fun `queue types without playlist context yield no target`() {
+        assertNull(resolvePlaylistRemovalTarget(EmptyQueue, "setVideoId-A"))
+        assertNull(resolvePlaylistRemovalTarget(null, "setVideoId-A"))
+    }
+
+    // --- duplicate occurrences ---
+
+    @Test
+    fun `duplicate occurrences of one song resolve to different targets`() {
+        val queue = listQueue()
+
+        val first = resolvePlaylistRemovalTarget(queue, "setVideoId-A")
+        val second = resolvePlaylistRemovalTarget(queue, "setVideoId-B")
+
+        assertEquals("setVideoId-A", first?.setVideoId)
+        assertEquals("setVideoId-B", second?.setVideoId)
+    }
+
+    @Test
+    fun `local row lookup picks the occurrence matching the set video id`() {
+        val maps = listOf(
+            PlaylistSongMap(id = 1, playlistId = "local-1", songId = "song", position = 0, setVideoId = "setVideoId-A"),
+            PlaylistSongMap(id = 2, playlistId = "local-1", songId = "song", position = 4, setVideoId = "setVideoId-B"),
+        )
+
+        assertEquals(2, selectLocalPlaylistRowToRemove(maps, "local-1", "setVideoId-B")?.id)
+        assertEquals(4, selectLocalPlaylistRowToRemove(maps, "local-1", "setVideoId-B")?.position)
+        assertEquals(1, selectLocalPlaylistRowToRemove(maps, "local-1", "setVideoId-A")?.id)
+    }
+
+    @Test
+    fun `local row lookup ignores the same song in other playlists`() {
+        val maps = listOf(
+            PlaylistSongMap(id = 1, playlistId = "local-2", songId = "song", position = 0, setVideoId = "setVideoId-A"),
+            PlaylistSongMap(id = 2, playlistId = "local-1", songId = "song", position = 1, setVideoId = "setVideoId-A"),
+        )
+
+        assertEquals(2, selectLocalPlaylistRowToRemove(maps, "local-1", "setVideoId-A")?.id)
+    }
+
+    @Test
+    fun `local row lookup returns null when no occurrence matches`() {
+        val maps = listOf(
+            PlaylistSongMap(id = 1, playlistId = "local-1", songId = "song", position = 0, setVideoId = "setVideoId-A"),
+            PlaylistSongMap(id = 2, playlistId = "local-1", songId = "song", position = 1, setVideoId = null),
+        )
+
+        assertNull(selectLocalPlaylistRowToRemove(maps, "local-1", "setVideoId-Z"))
+        assertNull(selectLocalPlaylistRowToRemove(emptyList(), "local-1", "setVideoId-A"))
+    }
+}

--- a/app/src/test/kotlin/com/metrolist/music/utils/SetVideoIdResolverTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/utils/SetVideoIdResolverTest.kt
@@ -1,0 +1,97 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.utils
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * The remote lookup is the last line of defence before a destructive call: if it never yields a
+ * setVideoId, the removal must be abandoned rather than guessing an occurrence.
+ */
+class SetVideoIdResolverTest {
+
+    private var remoteCalls = 0
+    private var delays = 0
+
+    private fun resolve(
+        fromDb: suspend () -> String?,
+        fromRemote: suspend () -> String?,
+    ): String? = runBlocking {
+        resolveSetVideoIdForRemoval(
+            songId = "song-1",
+            fromDb = fromDb,
+            fromRemote = {
+                remoteCalls++
+                fromRemote()
+            },
+            onDelay = { delays++ },
+        )
+    }
+
+    @Test
+    fun `local set video id is used without any remote lookup`() {
+        val result = resolve(fromDb = { "setVideoId-A" }, fromRemote = { "setVideoId-REMOTE" })
+
+        assertEquals("setVideoId-A", result)
+        assertEquals(0, remoteCalls)
+        assertEquals(0, delays)
+    }
+
+    @Test
+    fun `falls back to a single remote lookup when the local id is missing`() {
+        val result = resolve(fromDb = { null }, fromRemote = { "setVideoId-REMOTE" })
+
+        assertEquals("setVideoId-REMOTE", result)
+        assertEquals(1, remoteCalls)
+        assertEquals(0, delays)
+    }
+
+    @Test
+    fun `retries the remote lookup until it succeeds`() {
+        val result = resolve(
+            fromDb = { null },
+            fromRemote = { if (remoteCalls < 3) null else "setVideoId-REMOTE" },
+        )
+
+        assertEquals("setVideoId-REMOTE", result)
+        assertEquals(3, remoteCalls)
+        assertEquals(2, delays)
+    }
+
+    @Test
+    fun `retries after a failing remote lookup`() {
+        val result = resolve(
+            fromDb = { null },
+            fromRemote = {
+                if (remoteCalls < 2) error("network down") else "setVideoId-REMOTE"
+            },
+        )
+
+        assertEquals("setVideoId-REMOTE", result)
+        assertEquals(2, remoteCalls)
+        assertEquals(1, delays)
+    }
+
+    @Test
+    fun `gives up after the attempt budget instead of removing an unknown occurrence`() {
+        val result = resolve(fromDb = { null }, fromRemote = { null })
+
+        assertNull(result)
+        assertEquals(SET_VIDEO_ID_REMOTE_ATTEMPTS, remoteCalls)
+        assertEquals(SET_VIDEO_ID_REMOTE_ATTEMPTS - 1, delays)
+    }
+
+    @Test
+    fun `gives up when every remote lookup throws`() {
+        val result = resolve(fromDb = { null }, fromRemote = { error("network down") })
+
+        assertNull(result)
+        assertEquals(SET_VIDEO_ID_REMOTE_ATTEMPTS, remoteCalls)
+    }
+}


### PR DESCRIPTION
## Problem
The `Remove from playlist` action was missing from the player menu when
selecting a currently playing song from a playlist.

## Cause
The player menu could not reliably identify the playlist context for the
currently playing item. Playlist browse IDs and set video IDs were
available in some queue paths, but the local playlist ID was not preserved,

## Solution
- Preserve the local playlist ID in list queues.
- Pass local playlist IDs when starting playback from local playlists.
- Use queue playlist context to determine when `Remove from playlist`
should be shown in the player menu.
- Schedule playlist removals through sync utilities instead of relying on
direct removal calls from the menu.
- Remove playlist request metadata handling from YouTube playlist queue
items.
- Keep the YouTube song menu remove action limited to editable playlists.

## Review follow-up
Addressing the request for a rebase and regression coverage on this
destructive path:

- Rebased onto current `main`; the two merge commits are gone and the
  branch is now a clean series on top of `chore(deps): bump InnerTubeX to 0.4.1`.
- Fixed a build break that the rebase surfaced: `adoptQueue()` (added
  upstream in #4214) assigned to `currentQueue`, which this PR turns into
  a read-only `StateFlow`. It now writes `_currentQueue.value`.
- Moved the logic that decides *which* row to delete out of composables
  and out of the fire-and-forget sync coroutine into pure functions, so it
  can be tested directly:
  - `resolvePlaylistRemovalTarget()` / `selectLocalPlaylistRowToRemove()`
    (extracted from `PlayerMenu`)
  - `resolveSetVideoIdForRemoval()` (extracted from `SyncUtils`), which
    makes the remote lookup budget injectable and pins the rule that a
    removal is **abandoned, never guessed**, when no setVideoId resolves.
- Deduplicated the three playlist queue builders in `LocalPlaylistScreen`
  into `Playlist.toListQueue()`, and dropped the `SongItem.toPlaylistItem()`
  indirection that just called `toMediaItem()`.

### Regression coverage
23 new unit tests, covering each case raised in review:

| Case | Tests |
| --- | --- |
| Duplicate song occurrences | `duplicate occurrences of one song resolve to different targets`, `local row lookup picks the occurrence matching the set video id` |
| setVideoId identity | `missing or blank set video id yields no target`, `local row lookup ignores the same song in other playlists`, `local row lookup returns null when no occurrence matches` |
| Restored queues | `QueuePlaylistContextTest` (persist/restore round trip, Java serialization round trip, per-occurrence targets after restore) |
| Non-editable playlists | `non editable youtube playlist yields no target`, `non editable list queue yields no target`, `list queue without browse id yields no target` |
| Remote removal failure / retry | `SetVideoIdResolverTest` (retry until success, retry after a thrown lookup, give up after the attempt budget instead of removing an unknown occurrence) |

### Known migration cost
`PersistQueue` gains three fields, which changes its Java
`serialVersionUID`. A queue persisted by an older build therefore fails to
deserialize once on upgrade. The failure is already caught and the file is
cleared, so there is no crash — users lose the restored queue a single
time, and it is repopulated on the next playback. Flagging it rather than
pinning the previous UID; happy to do that instead if you would prefer to
keep old queues readable.

## Testing
- `./gradlew :app:assembleFossDebug :app:testFossDebugUnitTest` — build successful,
  new tests pass (23 tests, 0 failures, 0 errors).
- Tested on Galaxy S23 (Android 16, One UI 8.5).
- Verified the 'Remove from playlist' action across multiple playlists, cross-checking with YouTube to ensure consistent state sync.

## Related Issues
- Closes #
- Related to #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for removing songs from editable playlists during playback.
  * Added “Remove from playlist” actions to song and player menus.
  * Preserved playlist details and song mappings during playback and queue restoration.

* **Bug Fixes**
  * Playlist views now accurately reflect removed songs.
  * Improved handling of songs with matching identifiers and playlist mappings.

* **Chores**
  * Improved queue and playlist metadata handling across playback screens.
  * Added more reliable queue persistence and restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
