### PR TITLE
fix: fix persisting shuffle toggle not working

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -1206,6 +1206,7 @@ class MusicService :
                                 playQueue(
                                     queue = restoredQueue,
                                     playWhenReady = false,
+                                    restoringQueue = true,
                                 )
                             }
                         }
@@ -1761,6 +1762,7 @@ class MusicService :
     fun playQueue(
         queue: Queue,
         playWhenReady: Boolean = true,
+        restoringQueue: Boolean = false,
     ) {
         if (!playerInitialized.value) {
             Timber.tag(TAG).w("playQueue called before player initialization, queuing request")
@@ -1774,8 +1776,7 @@ class MusicService :
         currentQueue = queue
         queueTitle = null
         val persistShuffleAcrossQueues = dataStore.get(PersistentShuffleAcrossQueuesKey, false)
-        val previousShuffleEnabled = player.shuffleModeEnabled
-        if (!persistShuffleAcrossQueues) {
+        if (!persistShuffleAcrossQueues && !restoringQueue) {
             player.shuffleModeEnabled = false
         }
         originalQueueSize = 0


### PR DESCRIPTION
## Problem
This fixes the persistent shuffle bug mentioned in this issue: #3668

## Cause
When starting the app, the queue is restored through the same function used for starting new queues, which resets the shuffle when the "Persistent shuffle" feature is disabled.

## Solution
I've added a new parameter to that function, so that when it's called while restoring the persisted queue on startup, the shuffle reset is skipped.

## Testing
I've used Android Studio to test the fix.

## Related Issues
- Related to #3668 
I think the issue should remain open, with the shuffle part removed, so that only the similar content issue is left.

---

Let me know if you have any questions,
Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored playback queues now preserve shuffle mode more reliably.
  * Queue restoration no longer resets shuffle settings in cases where shuffle was previously enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->