### PR TITLE
Harden cipher/poToken pipeline: token races, WebView leaks, clock-skew wedges, main-thread jank

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherDeobfuscator.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherDeobfuscator.kt
@@ -80,7 +80,7 @@ object CipherDeobfuscator {
             Timber.tag(TAG).w("signatureTimestamp: could not fetch player JS")
             return null
         }
-        val sts = FunctionNameExtractor.extractSignatureTimestamp(playerJs)
+        val sts = FunctionNameExtractor.extractSignatureTimestamp(playerJs, hash)
         Timber.tag(TAG).d("Cipher player STS (hash=$hash): $sts")
         return sts
     }

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherWebView.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/CipherWebView.kt
@@ -20,15 +20,8 @@ import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
-/**
- * WebView-based cipher executor for YouTube stream URL deobfuscation
- *
- * Executes signature decipher and n-transform functions extracted from player.js.
- * Supports both regex-extracted functions and hardcoded fallback for Q-array obfuscated players.
- */
 class CipherWebView private constructor(
     context: Context,
-    private val playerJs: String,
     private val sigInfo: FunctionNameExtractor.SigFunctionInfo?,
     private val nFuncInfo: FunctionNameExtractor.NFunctionInfo?,
     initContinuation: Continuation<CipherWebView>,
@@ -37,10 +30,39 @@ class CipherWebView private constructor(
 
     // Single-shot continuation slots. All resumes go through takeAndNull-style helpers so a late
     // or duplicate JS-bridge callback (or a renderer-gone racing a normal resume) can never
-    // double-resume and crash inside a @JavascriptInterface method.
+    // double-resume and crash inside a @JavascriptInterface method. The sig/n slots additionally
+    // carry a per-request id, echoed back by the JS bridge: a late result from a cancelled/
+    // abandoned request must never resume the NEXT request's continuation with the wrong value.
     private var initContinuation: Continuation<CipherWebView>? = initContinuation
-    private var sigContinuation: Continuation<String>? = null
-    private var nContinuation: Continuation<String>? = null
+    private val sigSlot = RequestSlot<String>()
+    private val nSlot = RequestSlot<String>()
+
+    /**
+     * Single-shot continuation slot with an id-checked take. arm() returns the request id the
+     * JS call must echo back; takeIfCurrent(id) ignores late callbacks from superseded
+     * requests (the stale-result guard); takeAny() is for renderer-gone/timeout paths, which
+     * must clear whatever is pending. Synchronized because JS-bridge callbacks arrive on a
+     * WebView-internal thread while onRenderProcessGone/timeouts run on the main thread.
+     * The distinct method names are deliberate: same-name overloads made dropping the id a
+     * silent, compile-clean way to reintroduce the race.
+     */
+    private class RequestSlot<T> {
+        private var continuation: Continuation<T>? = null
+        private var requestId = 0
+
+        @Synchronized
+        fun arm(cont: Continuation<T>): Int {
+            continuation = cont
+            return ++requestId
+        }
+
+        @Synchronized
+        fun takeIfCurrent(id: Int): Continuation<T>? =
+            if (id == requestId) continuation.also { continuation = null } else null
+
+        @Synchronized
+        fun takeAny(): Continuation<T>? = continuation.also { continuation = null }
+    }
 
     /**
      * Set once the WebView's renderer process has died (or an evaluate timed out, which on a
@@ -90,7 +112,6 @@ class CipherWebView private constructor(
                 val msg = m.message()
                 val src = "${m.sourceId()}:${m.lineNumber()}"
 
-                // Log all console messages for debugging
                 when (m.messageLevel()) {
                     ConsoleMessage.MessageLevel.ERROR -> {
                         if (!msg.contains("is not defined")) {
@@ -136,24 +157,16 @@ class CipherWebView private constructor(
         isDead = true
         val e = CipherRendererGoneException(reason)
         takeInitContinuation()?.resumeSafely { it.resumeWithException(e) }
-        takeSigContinuation()?.resumeSafely { it.resumeWithException(e) }
-        takeNContinuation()?.resumeSafely { it.resumeWithException(e) }
+        sigSlot.takeAny()?.resumeSafely { it.resumeWithException(e) }
+        nSlot.takeAny()?.resumeSafely { it.resumeWithException(e) }
         destroyWebView()
     }
 
-    // Single-shot takes — synchronized because JS-bridge callbacks arrive on a WebView-internal
+    // Single-shot take — synchronized because JS-bridge callbacks arrive on a WebView-internal
     // thread while onRenderProcessGone/timeouts run on the main thread.
     @Synchronized
     private fun takeInitContinuation(): Continuation<CipherWebView>? =
         initContinuation.also { initContinuation = null }
-
-    @Synchronized
-    private fun takeSigContinuation(): Continuation<String>? =
-        sigContinuation.also { sigContinuation = null }
-
-    @Synchronized
-    private fun takeNContinuation(): Continuation<String>? =
-        nContinuation.also { nContinuation = null }
 
     private inline fun <T> T.resumeSafely(block: (T) -> Unit) {
         // A continuation cancelled by withTimeout may already be completed; never let that
@@ -161,97 +174,14 @@ class CipherWebView private constructor(
         runCatching { block(this) }
     }
 
-    private fun loadPlayerJsFromFile() {
-        val sigFuncName = sigInfo?.name
-        val nFuncName = nFuncInfo?.name
-        val nArrayIdx = nFuncInfo?.arrayIndex
-        val isHardcoded = sigInfo?.isHardcoded == true || nFuncInfo?.isHardcoded == true
+    /**
+     * Loads the already-prepared player.js (written by create() on an IO dispatcher via
+     * [buildModifiedPlayerJsImpl]) into the WebView. Only the cheap WebView work happens here
+     * on Main.
+     */
+    private fun loadPreparedPlayerJs(cacheDir: File) {
+        usingHardcodedMode = sigInfo?.isHardcoded == true || nFuncInfo?.isHardcoded == true
 
-        Timber.tag(TAG).d("=== LOADING PLAYER.JS INTO WEBVIEW ===")
-        Timber.tag(TAG).d("Player.js size: ${playerJs.length} chars")
-        Timber.tag(TAG).d("Export mode: ${if (isHardcoded) "HARDCODED" else "EXTRACTED"}")
-        Timber.tag(TAG).d("Sig function: $sigFuncName (constantArg=${sigInfo?.constantArg})")
-        Timber.tag(TAG).d("N function: $nFuncName (arrayIdx=$nArrayIdx)")
-
-        usingHardcodedMode = isHardcoded
-
-        val exports = buildList {
-            val sigJsExpr = sigInfo?.jsExpression
-            if (sigJsExpr != null) {
-                val expr = sigJsExpr.replace("INPUT", "sig")
-                Timber.tag(TAG).d("Sig: expression-based export: $expr")
-                add("window._cipherSigFunc = function(sig) { try { return $expr; } catch(e) { return null; } };")
-            } else if (sigFuncName != null) {
-                val sigConstArgs = sigInfo?.constantArgs
-                val preprocessFunc = sigInfo?.preprocessFunc
-                val preprocessArgs = sigInfo?.preprocessArgs
-
-                if (!sigConstArgs.isNullOrEmpty() && preprocessFunc != null && !preprocessArgs.isNullOrEmpty()) {
-                    val mainArgsStr = sigConstArgs.joinToString(", ")
-                    val prepArgsStr = preprocessArgs.joinToString(", ")
-                    Timber.tag(TAG).d("Sig function needs full wrapper:")
-                    Timber.tag(TAG).d("  $sigFuncName($mainArgsStr, $preprocessFunc($prepArgsStr, sig))")
-                    add("window._cipherSigFunc = function(sig) { return $sigFuncName($mainArgsStr, $preprocessFunc($prepArgsStr, sig)); };")
-                } else if (!sigConstArgs.isNullOrEmpty()) {
-                    val argsStr = sigConstArgs.joinToString(", ")
-                    Timber.tag(TAG).d("Sig function needs wrapper with constant args: $argsStr")
-                    add("window._cipherSigFunc = function(sig) { return $sigFuncName($argsStr, sig); };")
-                } else if (isHardcoded) {
-                    Timber.tag(TAG).d("Will export sig function $sigFuncName in hardcoded mode (legacy)")
-                    add("window._cipherSigFunc = typeof $sigFuncName !== 'undefined' ? $sigFuncName : null;")
-                } else {
-                    add("window._cipherSigFunc = typeof $sigFuncName !== 'undefined' ? $sigFuncName : null;")
-                }
-            }
-            val nJsExpr = nFuncInfo?.jsExpression
-            if (nJsExpr != null) {
-                val expr = nJsExpr.replace("INPUT", "n")
-                Timber.tag(TAG).d("N: expression-based export: ${expr.take(80)}")
-                add("window._nTransformFunc = function(n) { try { return $expr; } catch(e) { return n; } };")
-            } else if (nFuncName != null) {
-                val nConstArgs = nFuncInfo?.constantArgs
-                if (!nConstArgs.isNullOrEmpty()) {
-                    val argsStr = nConstArgs.joinToString(", ")
-                    Timber.tag(TAG).d("N-function needs wrapper with constant args: $argsStr")
-                    add("window._nTransformFunc = function(n) { return $nFuncName($argsStr, n); };")
-                } else {
-                    val nExpr = if (nArrayIdx != null) {
-                        "$nFuncName[$nArrayIdx]"
-                    } else {
-                        nFuncName
-                    }
-                    add("window._nTransformFunc = typeof $nFuncName !== 'undefined' ? $nExpr : null;")
-                }
-            }
-        }
-
-        Timber.tag(TAG).d("Export statements: ${exports.size}")
-        exports.forEachIndexed { idx, stmt ->
-            Timber.tag(TAG).v("  Export[$idx]: ${stmt.take(80)}...")
-        }
-
-        val modifiedJs = if (exports.isNotEmpty()) {
-            val exportCode = "; " + exports.joinToString(" ")
-            val modified = playerJs.replace("})(_yt_player);", "$exportCode })(_yt_player);")
-            if (modified == playerJs) {
-                Timber.tag(TAG).w("Export injection point '})(_yt_player);' not found, appending exports")
-                playerJs + "\n" + exportCode
-            } else {
-                Timber.tag(TAG).d("Exports injected into IIFE closure")
-                modified
-            }
-        } else {
-            Timber.tag(TAG).w("No exports to inject")
-            playerJs
-        }
-
-        val cacheDir = File(webView.context.cacheDir, "cipher")
-        cacheDir.mkdirs()
-        val playerJsFile = File(cacheDir, "player.js")
-        playerJsFile.writeText(modifiedJs)
-        Timber.tag(TAG).d("Player.js written to cache: ${playerJsFile.absolutePath} (${modifiedJs.length} chars)")
-
-        // Build HTML with comprehensive discovery and validation
         val html = buildDiscoveryHtml()
         Timber.tag(TAG).d("Discovery HTML built (${html.length} chars)")
 
@@ -262,39 +192,25 @@ class CipherWebView private constructor(
         Timber.tag(TAG).d("WebView loading started...")
     }
 
-    /**
-     * Build HTML with JS discovery logic
-     *
-     * Key changes from original:
-     * 1. Removed outdated `_w8_` pattern check
-     * 2. Accept any valid alphanumeric transform result
-     * 3. More comprehensive logging to bridge
-     */
     private fun buildDiscoveryHtml(): String = """<!DOCTYPE html>
 <html><head><script>
-// ============================================================
-// SIGNATURE DEOBFUSCATION
-// ============================================================
-function deobfuscateSig(funcName, constantArg, obfuscatedSig) {
-    CipherBridge.logDebug("deobfuscateSig called: funcName=" + funcName + ", constantArg=" + constantArg + ", sigLen=" + obfuscatedSig.length);
+function deobfuscateSig(funcName, constantArg, obfuscatedSig, reqId) {
+    CipherBridge.logDebug("deobfuscateSig called: funcName=" + funcName + ", constantArg=" + constantArg + ", sigLen=" + obfuscatedSig.length + ", reqId=" + reqId);
 
     try {
         var func = window._cipherSigFunc;
         CipherBridge.logDebug("window._cipherSigFunc type: " + typeof func + ", length: " + (func ? func.length : "N/A"));
 
         if (typeof func !== 'function') {
-            CipherBridge.onSigError("Sig func not found on window (type: " + typeof func + ")");
+            CipherBridge.onSigError(reqId, "Sig func not found on window (type: " + typeof func + ")");
             return;
         }
 
         var result;
-        // Check if this is a wrapper function (takes 1 arg: sig) vs direct function (takes 2+ args)
         if (func.length === 1) {
-            // Wrapper function: window._cipherSigFunc = function(sig) { return JI(48, 1918, f1(1, 6528, sig)); }
             CipherBridge.logDebug("Calling wrapped sig func with just sig (func.length=1)");
             result = func(obfuscatedSig);
         } else if (constantArg !== null && constantArg !== undefined) {
-            // Direct function with constantArg
             CipherBridge.logDebug("Calling sig func with constantArg: " + constantArg);
             result = func(constantArg, obfuscatedSig);
         } else {
@@ -303,29 +219,26 @@ function deobfuscateSig(funcName, constantArg, obfuscatedSig) {
         }
 
         if (result === undefined || result === null) {
-            CipherBridge.onSigError("Function returned null/undefined");
+            CipherBridge.onSigError(reqId, "Function returned null/undefined");
             return;
         }
 
         CipherBridge.logDebug("Sig result type: " + typeof result + ", length: " + String(result).length);
-        CipherBridge.onSigResult(String(result));
+        CipherBridge.onSigResult(reqId, String(result));
     } catch (error) {
-        CipherBridge.onSigError(error + "\n" + (error.stack || ""));
+        CipherBridge.onSigError(reqId, error + "\n" + (error.stack || ""));
     }
 }
 
-// ============================================================
-// N-PARAMETER TRANSFORM
-// ============================================================
-function transformN(nValue) {
-    CipherBridge.logDebug("transformN called: nValue=" + nValue);
+function transformN(nValue, reqId) {
+    CipherBridge.logDebug("transformN called: nValue=" + nValue + ", reqId=" + reqId);
 
     try {
         var func = window._nTransformFunc;
         CipherBridge.logDebug("window._nTransformFunc type: " + typeof func);
 
         if (typeof func !== 'function') {
-            CipherBridge.onNError("N-transform func not available (type: " + typeof func + ")");
+            CipherBridge.onNError(reqId, "N-transform func not available (type: " + typeof func + ")");
             return;
         }
 
@@ -333,21 +246,18 @@ function transformN(nValue) {
         CipherBridge.logDebug("N-transform raw result: " + (result ? String(result).substring(0, 50) : "null/undefined"));
 
         if (result === undefined || result === null) {
-            CipherBridge.onNError("N-transform returned null/undefined");
+            CipherBridge.onNError(reqId, "N-transform returned null/undefined");
             return;
         }
 
         var resultStr = String(result);
         CipherBridge.logDebug("N-transform result: length=" + resultStr.length + ", value=" + resultStr.substring(0, 30));
-        CipherBridge.onNResult(resultStr);
+        CipherBridge.onNResult(reqId, resultStr);
     } catch (error) {
-        CipherBridge.onNError(error + "\n" + (error.stack || ""));
+        CipherBridge.onNError(reqId, error + "\n" + (error.stack || ""));
     }
 }
 
-// ============================================================
-// FUNCTION DISCOVERY AND INITIALIZATION
-// ============================================================
 function discoverAndInit() {
     CipherBridge.logDebug("========== DISCOVERY AND INIT ==========");
 
@@ -355,7 +265,6 @@ function discoverAndInit() {
     var sigFuncName = "";
     var info = "";
 
-    // Check if signature function was exported
     if (typeof window._cipherSigFunc === 'function') {
         sigFuncName = "exported_sig_func";
         CipherBridge.logDebug("Signature function found on window._cipherSigFunc");
@@ -363,7 +272,6 @@ function discoverAndInit() {
         CipherBridge.logDebug("WARNING: window._cipherSigFunc not available (type=" + typeof window._cipherSigFunc + ")");
     }
 
-    // Check if N-transform function was exported
     if (typeof window._nTransformFunc === 'function') {
         CipherBridge.logDebug("Testing exported window._nTransformFunc...");
         try {
@@ -374,7 +282,6 @@ function discoverAndInit() {
             CipherBridge.logDebug("N-func test result: " + (testResult ? String(testResult).substring(0, 50) : "null"));
 
             if (typeof testResult === 'string' && testResult !== testInput && testResult.length >= 5) {
-                // FIXED: Accept any valid alphanumeric result, not just _w8_ pattern
                 if (/^[a-zA-Z0-9_-]+$/.test(testResult)) {
                     nFuncName = "exported_n_func";
                     info = "export_valid,test=" + testResult.substring(0, 20);
@@ -398,7 +305,6 @@ function discoverAndInit() {
         CipherBridge.logDebug("window._nTransformFunc not exported, trying brute force discovery...");
     }
 
-    // Brute force discovery if export failed
     if (!nFuncName) {
         try {
             var testInput = "T2Xw3pWQ_Wk0xbOg";
@@ -412,7 +318,6 @@ function discoverAndInit() {
             for (var i = 0; i < keys.length; i++) {
                 try {
                     var key = keys[i];
-                    // Skip known non-candidates
                     if (key.startsWith("webkit") || key.startsWith("on") ||
                         key === "CipherBridge" || key === "_cipherSigFunc" ||
                         key === "_nTransformFunc" || key === "window" || key === "self") {
@@ -423,14 +328,12 @@ function discoverAndInit() {
                     var fn = window[key];
                     if (typeof fn !== 'function') continue;
 
-                    // N-transform functions typically take 1 argument
                     if (fn.length !== 1) continue;
 
                     tested++;
                     var result = fn(testInput);
 
                     if (typeof result === 'string' && result !== testInput && result.length >= 5) {
-                        // FIXED: Accept any valid alphanumeric transform
                         if (/^[a-zA-Z0-9_-]+$/.test(result)) {
                             candidates.push({
                                 name: key,
@@ -438,7 +341,6 @@ function discoverAndInit() {
                                 len: result.length
                             });
 
-                            // Accept the first valid candidate
                             if (!nFuncName) {
                                 window._nTransformFunc = fn;
                                 nFuncName = key;
@@ -447,7 +349,6 @@ function discoverAndInit() {
                         }
                     }
                 } catch(e) {
-                    // Expected - many window properties throw when called
                 }
             }
 
@@ -477,8 +378,6 @@ function discoverAndInit() {
 </script>
 </head><body></body></html>"""
 
-    // ==================== JAVASCRIPT INTERFACE ====================
-
     @JavascriptInterface
     fun logDebug(message: String) {
         Timber.tag(TAG).d("JS: $message")
@@ -504,7 +403,6 @@ function discoverAndInit() {
 
     @JavascriptInterface
     fun onNDiscoveryDone(funcName: String, info: String) {
-        // Legacy interface - redirects to new combined discovery
         Timber.tag(TAG).d("Legacy onNDiscoveryDone: funcName=$funcName, info=$info")
         if (funcName.isNotEmpty()) {
             discoveredNFuncName = funcName
@@ -532,8 +430,6 @@ function discoverAndInit() {
         }
     }
 
-    // ==================== SIGNATURE DEOBFUSCATION ====================
-
     suspend fun deobfuscateSignature(obfuscatedSig: String): String {
         Timber.tag(TAG).d("========== DEOBFUSCATE SIGNATURE ==========")
         Timber.tag(TAG).d("Input sig length: ${obfuscatedSig.length}")
@@ -550,9 +446,9 @@ function discoverAndInit() {
             withTimeout(EVAL_TIMEOUT_MS) {
                 withContext(Dispatchers.Main) {
                     suspendCancellableCoroutine { cont ->
-                        sigContinuation = cont
+                        val requestId = sigSlot.arm(cont)
                         val constArgJs = if (sigInfo.constantArg != null) "${sigInfo.constantArg}" else "null"
-                        val jsCall = "deobfuscateSig('${sigInfo.name}', $constArgJs, '${escapeJsString(obfuscatedSig)}')"
+                        val jsCall = "deobfuscateSig('${sigInfo.name}', $constArgJs, '${escapeJsString(obfuscatedSig)}', $requestId)"
                         Timber.tag(TAG).d("Evaluating JS: ${jsCall.take(100)}...")
                         webView.evaluateJavascript(jsCall, null)
                     }
@@ -567,23 +463,21 @@ function discoverAndInit() {
     }
 
     @JavascriptInterface
-    fun onSigResult(result: String) {
+    fun onSigResult(requestId: Int, result: String) {
         Timber.tag(TAG).d("========== SIGNATURE RESULT ==========")
-        Timber.tag(TAG).d("Result length: ${result.length}")
+        Timber.tag(TAG).d("Result length: ${result.length} (requestId=$requestId)")
         Timber.tag(TAG).d("Result preview: ${result.take(50)}...")
-        takeSigContinuation()?.resumeSafely { it.resume(result) }
+        sigSlot.takeIfCurrent(requestId)?.resumeSafely { it.resume(result) }
     }
 
     @JavascriptInterface
-    fun onSigError(error: String) {
+    fun onSigError(requestId: Int, error: String) {
         Timber.tag(TAG).e("========== SIGNATURE ERROR ==========")
-        Timber.tag(TAG).e("Error: $error")
-        takeSigContinuation()?.resumeSafely {
+        Timber.tag(TAG).e("Error: $error (requestId=$requestId)")
+        sigSlot.takeIfCurrent(requestId)?.resumeSafely {
             it.resumeWithException(CipherException("Sig deobfuscation failed: $error"))
         }
     }
-
-    // ==================== N-TRANSFORM ====================
 
     suspend fun transformN(nValue: String): String {
         Timber.tag(TAG).d("========== N-TRANSFORM ==========")
@@ -601,8 +495,8 @@ function discoverAndInit() {
             withTimeout(EVAL_TIMEOUT_MS) {
                 withContext(Dispatchers.Main) {
                     suspendCancellableCoroutine { cont ->
-                        nContinuation = cont
-                        val jsCall = "transformN('${escapeJsString(nValue)}')"
+                        val requestId = nSlot.arm(cont)
+                        val jsCall = "transformN('${escapeJsString(nValue)}', $requestId)"
                         Timber.tag(TAG).d("Evaluating JS: $jsCall")
                         webView.evaluateJavascript(jsCall, null)
                     }
@@ -615,18 +509,18 @@ function discoverAndInit() {
     }
 
     @JavascriptInterface
-    fun onNResult(result: String) {
+    fun onNResult(requestId: Int, result: String) {
         Timber.tag(TAG).d("========== N-TRANSFORM RESULT ==========")
-        Timber.tag(TAG).d("Result: $result")
+        Timber.tag(TAG).d("Result: $result (requestId=$requestId)")
         Timber.tag(TAG).d("Result length: ${result.length}")
-        takeNContinuation()?.resumeSafely { it.resume(result) }
+        nSlot.takeIfCurrent(requestId)?.resumeSafely { it.resume(result) }
     }
 
     @JavascriptInterface
-    fun onNError(error: String) {
+    fun onNError(requestId: Int, error: String) {
         Timber.tag(TAG).e("========== N-TRANSFORM ERROR ==========")
-        Timber.tag(TAG).e("Error: $error")
-        takeNContinuation()?.resumeSafely {
+        Timber.tag(TAG).e("Error: $error (requestId=$requestId)")
+        nSlot.takeIfCurrent(requestId)?.resumeSafely {
             it.resumeWithException(CipherException("N-transform failed: $error"))
         }
     }
@@ -640,12 +534,10 @@ function discoverAndInit() {
     /** Timeout path: mark this instance dead, clear pending slots, throw renderer-gone. */
     private fun failAsRendererGone(reason: String): Nothing {
         isDead = true
-        takeSigContinuation()
-        takeNContinuation()
+        sigSlot.takeAny()
+        nSlot.takeAny()
         throw CipherRendererGoneException(reason)
     }
-
-    // ==================== CLEANUP ====================
 
     fun close() {
         Timber.tag(TAG).d("Closing CipherWebView...")
@@ -666,8 +558,6 @@ function discoverAndInit() {
             webView.destroy()
         }.onFailure { Timber.tag(TAG).w("WebView teardown threw: $it") }
     }
-
-    // ==================== UTILITIES ====================
 
     private fun escapeJsString(s: String): String {
         return s.replace("\\", "\\\\")
@@ -690,6 +580,101 @@ function discoverAndInit() {
         // renderer died without onRenderProcessGone being delivered (old providers).
         private const val EVAL_TIMEOUT_MS = 15_000L
 
+        /**
+         * Builds the export-injected player.js. This scans and copies a ~2.8 MB string — it MUST run
+         * off the main thread (create() calls it on Dispatchers.IO before any WebView work), or every
+         * WebView (re)build would freeze the UI thread for the duration.
+         */
+        private fun buildModifiedPlayerJsImpl(
+            playerJs: String,
+            sigInfo: FunctionNameExtractor.SigFunctionInfo?,
+            nFuncInfo: FunctionNameExtractor.NFunctionInfo?,
+        ): String {
+            val sigFuncName = sigInfo?.name
+            val nFuncName = nFuncInfo?.name
+            val nArrayIdx = nFuncInfo?.arrayIndex
+            val isHardcoded = sigInfo?.isHardcoded == true || nFuncInfo?.isHardcoded == true
+
+            Timber.tag(TAG).d("=== PREPARING PLAYER.JS FOR WEBVIEW ===")
+            Timber.tag(TAG).d("Player.js size: ${playerJs.length} chars")
+            Timber.tag(TAG).d("Export mode: ${if (isHardcoded) "HARDCODED" else "EXTRACTED"}")
+            Timber.tag(TAG).d("Sig function: $sigFuncName (constantArg=${sigInfo?.constantArg})")
+            Timber.tag(TAG).d("N function: $nFuncName (arrayIdx=$nArrayIdx)")
+
+            val exports = buildList {
+                val sigJsExpr = sigInfo?.jsExpression
+                if (sigJsExpr != null) {
+                    // Expression-based sig decipher (VM-dispatch players like 9c249f6f).
+                    // INPUT is replaced with the sig argument.
+                    val expr = sigJsExpr.replace("INPUT", "sig")
+                    Timber.tag(TAG).d("Sig: expression-based export: $expr")
+                    add("window._cipherSigFunc = function(sig) { try { return $expr; } catch(e) { return null; } };")
+                } else if (sigFuncName != null) {
+                    val sigConstArgs = sigInfo?.constantArgs
+                    val preprocessFunc = sigInfo?.preprocessFunc
+                    val preprocessArgs = sigInfo?.preprocessArgs
+
+                    if (!sigConstArgs.isNullOrEmpty() && preprocessFunc != null && !preprocessArgs.isNullOrEmpty()) {
+                        val mainArgsStr = sigConstArgs.joinToString(", ")
+                        val prepArgsStr = preprocessArgs.joinToString(", ")
+                        Timber.tag(TAG).d("Sig function needs full wrapper:")
+                        Timber.tag(TAG).d("  $sigFuncName($mainArgsStr, $preprocessFunc($prepArgsStr, sig))")
+                        add("window._cipherSigFunc = function(sig) { return $sigFuncName($mainArgsStr, $preprocessFunc($prepArgsStr, sig)); };")
+                    } else if (!sigConstArgs.isNullOrEmpty()) {
+                        val argsStr = sigConstArgs.joinToString(", ")
+                        Timber.tag(TAG).d("Sig function needs wrapper with constant args: $argsStr")
+                        add("window._cipherSigFunc = function(sig) { return $sigFuncName($argsStr, sig); };")
+                    } else if (isHardcoded) {
+                        Timber.tag(TAG).d("Will export sig function $sigFuncName in hardcoded mode (legacy)")
+                        add("window._cipherSigFunc = typeof $sigFuncName !== 'undefined' ? $sigFuncName : null;")
+                    } else {
+                        add("window._cipherSigFunc = typeof $sigFuncName !== 'undefined' ? $sigFuncName : null;")
+                    }
+                }
+                val nJsExpr = nFuncInfo?.jsExpression
+                if (nJsExpr != null) {
+                    // Expression-based n-transform (VM-dispatch players).
+                    val expr = nJsExpr.replace("INPUT", "n")
+                    Timber.tag(TAG).d("N: expression-based export: ${expr.take(80)}")
+                    add("window._nTransformFunc = function(n) { try { return $expr; } catch(e) { return n; } };")
+                } else if (nFuncName != null) {
+                    val nConstArgs = nFuncInfo?.constantArgs
+                    if (!nConstArgs.isNullOrEmpty()) {
+                        val argsStr = nConstArgs.joinToString(", ")
+                        Timber.tag(TAG).d("N-function needs wrapper with constant args: $argsStr")
+                        add("window._nTransformFunc = function(n) { return $nFuncName($argsStr, n); };")
+                    } else {
+                        val nExpr = if (nArrayIdx != null) {
+                            "$nFuncName[$nArrayIdx]"
+                        } else {
+                            nFuncName
+                        }
+                        add("window._nTransformFunc = typeof $nFuncName !== 'undefined' ? $nExpr : null;")
+                    }
+                }
+            }
+
+            Timber.tag(TAG).d("Export statements: ${exports.size}")
+            exports.forEachIndexed { idx, stmt ->
+                Timber.tag(TAG).v("  Export[$idx]: ${stmt.take(80)}...")
+            }
+
+            return if (exports.isNotEmpty()) {
+                val exportCode = "; " + exports.joinToString(" ")
+                val modified = playerJs.replace("})(_yt_player);", "$exportCode })(_yt_player);")
+                if (modified == playerJs) {
+                    Timber.tag(TAG).w("Export injection point '})(_yt_player);' not found, appending exports")
+                    playerJs + "\n" + exportCode
+                } else {
+                    Timber.tag(TAG).d("Exports injected into IIFE closure")
+                    modified
+                }
+            } else {
+                Timber.tag(TAG).w("No exports to inject")
+                playerJs
+            }
+        }
+
         suspend fun create(
             context: Context,
             playerJs: String,
@@ -701,14 +686,26 @@ function discoverAndInit() {
             Timber.tag(TAG).d("sigInfo: $sigInfo")
             Timber.tag(TAG).d("nFuncInfo: $nFuncInfo")
 
+            // Heavy prep (multi-MB string transform + disk write) runs on IO; only WebView
+            // construction and the load call happen on the main thread below.
+            val cacheDir = withContext(Dispatchers.IO) {
+                val modifiedJs = buildModifiedPlayerJsImpl(playerJs, sigInfo, nFuncInfo)
+                val dir = File(context.cacheDir, "cipher")
+                dir.mkdirs()
+                val playerJsFile = File(dir, "player.js")
+                playerJsFile.writeText(modifiedJs)
+                Timber.tag(TAG).d("Player.js written to cache: ${playerJsFile.absolutePath} (${modifiedJs.length} chars)")
+                dir
+            }
+
             var created: CipherWebView? = null
             try {
                 return withTimeout(CREATE_TIMEOUT_MS) {
                     withContext(Dispatchers.Main) {
                         suspendCancellableCoroutine { cont ->
-                            val wv = CipherWebView(context, playerJs, sigInfo, nFuncInfo, cont)
+                            val wv = CipherWebView(context, sigInfo, nFuncInfo, cont)
                             created = wv
-                            wv.loadPlayerJsFromFile()
+                            wv.loadPreparedPlayerJs(cacheDir)
                         }
                     }
                 }
@@ -716,8 +713,11 @@ function discoverAndInit() {
                 Timber.tag(TAG).e("CipherWebView init timed out after ${CREATE_TIMEOUT_MS}ms — treating renderer as gone")
                 destroyQuietly(created)
                 throw CipherRendererGoneException("CipherWebView init timed out after ${CREATE_TIMEOUT_MS}ms")
-            } catch (e: CancellationException) {
-                // Caller cancelled — don't leak the half-initialized WebView.
+            } catch (e: Exception) {
+                // Covers both caller cancellation (CancellationException is rethrown, never
+                // swallowed) and init failure via an error resume (e.g. onPlayerJsError ->
+                // CipherException): destroy the half-initialized WebView either way, or every
+                // failed create() leaks a live renderer that the retry path then multiplies.
                 destroyQuietly(created)
                 throw e
             }

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/FunctionNameExtractor.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/FunctionNameExtractor.kt
@@ -52,6 +52,10 @@ object FunctionNameExtractor {
 
     // ==================== DETECTION PATTERNS ====================
 
+    // See extractSignatureTimestamp for why these two are tried in different precedence tiers.
+    private val ANCHORED_STS_PATTERN = Regex("""signatureTimestamp['":\s]+(\d+)""")
+    private val LOOSE_STS_PATTERN = Regex("""sts['":\s]+(\d+)""")
+
     // Detect Q-array obfuscation: var Q="...".split("}")
     private val Q_ARRAY_PATTERN = Regex("""var\s+Q\s*=\s*"[^"]+"\s*\.\s*split\s*\(\s*"\}"\s*\)""")
 
@@ -293,34 +297,34 @@ object FunctionNameExtractor {
     /**
      * Extract signatureTimestamp from player.js
      */
-    fun extractSignatureTimestamp(playerJs: String): Int? {
+    fun extractSignatureTimestamp(playerJs: String, knownHash: String? = null): Int? {
         Timber.tag(TAG).d("Extracting signatureTimestamp...")
 
-        val patterns = listOf(
-            Regex("""signatureTimestamp['":\s]+(\d+)"""),
-            Regex("""sts['":\s]+(\d+)"""),
-            Regex(""""signatureTimestamp"\s*:\s*(\d+)""")
-        )
-
-        for ((index, pattern) in patterns.withIndex()) {
-            val match = pattern.find(playerJs)
-            if (match != null) {
-                val sts = match.groupValues[1].toIntOrNull()
-                if (sts != null) {
-                    Timber.tag(TAG).d("signatureTimestamp found via pattern $index: $sts")
-                    return sts
-                }
-            }
+        // Precedence: (1) the anchored `signatureTimestamp` literal in the JS itself — it is
+        // the player's own embedded field and the source config sts values are copied from
+        // at authoring time, so it is immune to config typos, stale aliases, and bad remote
+        // pushes (configs' sts is NOT CDN-validated, unlike sig/n); (2) the config, for
+        // players lacking the literal; (3) the loose `sts` pattern, which can false-match
+        // anywhere in ~2 MB of JS and must never shadow the other two.
+        val anchored = ANCHORED_STS_PATTERN.find(playerJs)?.groupValues?.get(1)?.toIntOrNull()
+        if (anchored != null) {
+            Timber.tag(TAG).d("signatureTimestamp from player JS literal: $anchored")
+            return anchored
         }
 
-        // Fallback to hardcoded config
-        val playerHash = extractPlayerHash(playerJs)
+        val playerHash = knownHash ?: extractPlayerHash(playerJs)
         if (playerHash != null) {
             val config = getHardcodedConfig(playerHash)
             if (config != null) {
                 Timber.tag(TAG).d("Using hardcoded signatureTimestamp: ${config.signatureTimestamp}")
                 return config.signatureTimestamp
             }
+        }
+
+        val loose = LOOSE_STS_PATTERN.find(playerJs)?.groupValues?.get(1)?.toIntOrNull()
+        if (loose != null) {
+            Timber.tag(TAG).d("signatureTimestamp via loose sts pattern: $loose")
+            return loose
         }
 
         Timber.tag(TAG).w("Could not extract signatureTimestamp")
@@ -346,7 +350,7 @@ object FunctionNameExtractor {
         val hasQArray = hasQArrayObfuscation(playerJs)
         val sigInfo = extractSigFunctionInfo(playerJs, playerHash)
         val nFuncInfo = extractNFunctionInfo(playerJs, playerHash)
-        val signatureTimestamp = extractSignatureTimestamp(playerJs)
+        val signatureTimestamp = extractSignatureTimestamp(playerJs, playerHash)
 
         Timber.tag(TAG).d("=== ANALYSIS SUMMARY ===")
         Timber.tag(TAG).d("Player Hash:        ${playerHash ?: "unknown"}")

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/PlayerConfigStore.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/PlayerConfigStore.kt
@@ -77,9 +77,20 @@ object PlayerConfigStore {
     // The two cooldown gates read DIFFERENT stamps on purpose (see above). Routed through these
     // functions — which forceRefresh / refreshAfterStreamRejection actually call — so a unit test
     // can prove neither path is gated by the other's cooldown without touching the network.
-    internal fun forcedCooldownActive(now: Long) = now - lastForcedAttemptMs < FORCE_REFRESH_COOLDOWN_MS
+    /**
+     * True iff [stampMs] lies within [windowMs] of [now]. The in-range check (not a plain
+     * `now - stamp < window`) matters: these are wall-clock stamps, and a backward clock
+     * adjustment (NTP correction, manual change) makes the delta negative — a plain
+     * less-than would then hold the window for the entire skew duration, wedging
+     * cooldowns/TTLs exactly while playback is broken. Every wall-clock window check in
+     * this module MUST go through this helper.
+     */
+    internal fun withinWindow(now: Long, stampMs: Long, windowMs: Long) =
+        (now - stampMs) in 0 until windowMs
 
-    internal fun rejectionCooldownActive(now: Long) = now - lastRejectionAttemptMs < FORCE_REFRESH_COOLDOWN_MS
+    internal fun forcedCooldownActive(now: Long) = withinWindow(now, lastForcedAttemptMs, FORCE_REFRESH_COOLDOWN_MS)
+
+    internal fun rejectionCooldownActive(now: Long) = withinWindow(now, lastRejectionAttemptMs, FORCE_REFRESH_COOLDOWN_MS)
 
     // Test-only: arm a cooldown stamp without invoking the network refresh paths.
     internal fun armForcedCooldownForTest(ms: Long) { lastForcedAttemptMs = ms }
@@ -231,7 +242,9 @@ object PlayerConfigStore {
 
     private suspend fun refreshIfStale() {
         val lastFetchMs = readMeta()?.second ?: 0L
-        if (System.currentTimeMillis() - lastFetchMs < REFRESH_TTL_MS) {
+        // lastFetchMs is persisted, so a future stamp (wall clock stepped back after the
+        // write) must count as stale, not fresh — withinWindow handles that.
+        if (withinWindow(System.currentTimeMillis(), lastFetchMs, REFRESH_TTL_MS)) {
             Timber.tag(TAG).d("Remote configs fresh (fetched ${System.currentTimeMillis() - lastFetchMs} ms ago)")
             return
         }
@@ -391,9 +404,14 @@ object PlayerConfigStore {
         val tmp = File(file.parentFile, "${file.name}.tmp")
         tmp.writeText(content)
         if (!tmp.renameTo(file)) {
-            // renameTo can fail on some filesystems — fall back to a direct write.
-            file.writeText(content)
-            tmp.delete()
+            // renameTo won't overwrite an existing target on some filesystems — retry after
+            // deleting it (two cheap metadata ops, still atomic) before the last-resort direct
+            // write, which is both non-atomic and a second full write of the content.
+            file.delete()
+            if (!tmp.renameTo(file)) {
+                file.writeText(content)
+                tmp.delete()
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/metrolist/music/utils/cipher/PlayerJsFetcher.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/cipher/PlayerJsFetcher.kt
@@ -27,6 +27,11 @@ object PlayerJsFetcher {
     // Regex to extract player hash from iframe_api response
     private val PLAYER_HASH_REGEX = Regex("""\\?/s\\?/player\\?/([a-zA-Z0-9_-]+)\\?/""")
 
+    // Serializes cache mutations: getPlayerJs has unsynchronized concurrent callers, and an
+    // unlocked writeToCache purge racing another writer's writeAtomic tmp window would delete
+    // the tmp mid-write and silently degrade to a truncating non-atomic write.
+    private val cacheWriteLock = Any()
+
     private fun getCacheDir(): File = File(CipherDeobfuscator.appContext.filesDir, "cipher_cache")
 
     private fun getCacheFile(hash: String): File = File(getCacheDir(), "player_$hash.js")
@@ -99,7 +104,7 @@ object PlayerJsFetcher {
      */
     fun invalidateCache() {
         Timber.tag(TAG).d("Invalidating cache...")
-        try {
+        synchronized(cacheWriteLock) { try {
             val cacheDir = getCacheDir()
             if (cacheDir.exists()) {
                 // Only the player.js cache (player_*.js + current_hash.txt) belongs to this fetcher.
@@ -118,7 +123,7 @@ object PlayerJsFetcher {
             Timber.tag(TAG).d("Cache invalidated successfully")
         } catch (e: Exception) {
             Timber.tag(TAG).e(e, "Failed to invalidate cache: ${e.message}")
-        }
+        } }
     }
 
     private fun readFromCache(): Pair<String, String>? {
@@ -147,8 +152,9 @@ object PlayerJsFetcher {
             val ageHours = ageMs / (1000 * 60 * 60)
             Timber.tag(TAG).d("Cache age: ${ageHours}h (TTL: ${CACHE_TTL_MS / (1000 * 60 * 60)}h)")
 
-            // Check TTL
-            if (ageMs > CACHE_TTL_MS) {
+            // Check TTL (in-range: a future timestamp from a backward clock step counts as
+            // expired, not fresh — see PlayerConfigStore.withinWindow).
+            if (!PlayerConfigStore.withinWindow(System.currentTimeMillis(), timestamp, CACHE_TTL_MS)) {
                 Timber.tag(TAG).d("Cache expired (hash=$hash, age=${ageHours}h)")
                 return null
             }
@@ -175,20 +181,25 @@ object PlayerJsFetcher {
 
     private fun writeToCache(hash: String, playerJs: String) {
         Timber.tag(TAG).d("Writing to cache: hash=$hash, length=${playerJs.length}")
-        try {
-            val cacheDir = getCacheDir()
+        synchronized(cacheWriteLock) {
+            try {
+                val cacheDir = getCacheDir()
 
-            // Clean old cache files
-            val oldFiles = cacheDir.listFiles()?.filter { it.name.startsWith("player_") }
-            Timber.tag(TAG).d("Cleaning ${oldFiles?.size ?: 0} old cache files")
-            oldFiles?.forEach { it.delete() }
+                // Clean old cache files
+                val oldFiles = cacheDir.listFiles()?.filter { it.name.startsWith("player_") }
+                Timber.tag(TAG).d("Cleaning ${oldFiles?.size ?: 0} old cache files")
+                oldFiles?.forEach { it.delete() }
 
-            getCacheFile(hash).writeText(playerJs)
-            getHashFile().writeText("$hash\n${System.currentTimeMillis()}")
+                // Atomic (temp + rename): a plain writeText truncates first, so process death
+                // during a same-hash force-refresh rewrite would leave a truncated player.js
+                // that readFromCache happily serves until the TTL expires.
+                PlayerConfigStore.writeAtomic(getCacheFile(hash), playerJs)
+                PlayerConfigStore.writeAtomic(getHashFile(), "$hash\n${System.currentTimeMillis()}")
 
-            Timber.tag(TAG).d("Cache written successfully")
-        } catch (e: Exception) {
-            Timber.tag(TAG).e(e, "Error writing cache: ${e.message}")
+                Timber.tag(TAG).d("Cache written successfully")
+            } catch (e: Exception) {
+                Timber.tag(TAG).e(e, "Error writing cache: ${e.message}")
+            }
         }
     }
 
@@ -200,15 +211,16 @@ object PlayerJsFetcher {
             .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")
             .build()
 
-        val response = httpClient.newCall(request).execute()
-        Timber.tag(TAG).d("iframe_api response: HTTP ${response.code}")
-
-        if (!response.isSuccessful) {
-            Timber.tag(TAG).e("iframe_api HTTP ${response.code}")
-            return null
+        // .use{} so the response is closed on the error path too (an unread body would
+        // otherwise strand its connection).
+        val body = httpClient.newCall(request).execute().use { response ->
+            Timber.tag(TAG).d("iframe_api response: HTTP ${response.code}")
+            if (!response.isSuccessful) {
+                Timber.tag(TAG).e("iframe_api HTTP ${response.code}")
+                return null
+            }
+            response.body?.string()
         }
-
-        val body = response.body?.string()
         if (body == null) {
             Timber.tag(TAG).e("iframe_api response body is null")
             return null
@@ -238,15 +250,14 @@ object PlayerJsFetcher {
             .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")
             .build()
 
-        val response = httpClient.newCall(request).execute()
-        Timber.tag(TAG).d("player.js response: HTTP ${response.code}")
-
-        if (!response.isSuccessful) {
-            Timber.tag(TAG).e("player.js download HTTP ${response.code}")
-            return null
+        val body = httpClient.newCall(request).execute().use { response ->
+            Timber.tag(TAG).d("player.js response: HTTP ${response.code}")
+            if (!response.isSuccessful) {
+                Timber.tag(TAG).e("player.js download HTTP ${response.code}")
+                return null
+            }
+            response.body?.string()
         }
-
-        val body = response.body?.string()
         if (body == null) {
             Timber.tag(TAG).e("player.js response body is null")
             return null

--- a/app/src/main/kotlin/com/metrolist/music/utils/potoken/PoTokenGenerator.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/potoken/PoTokenGenerator.kt
@@ -97,19 +97,35 @@ class PoTokenGenerator {
 
                 if (shouldRecreate) {
                     Timber.tag(TAG).d("Creating new PoTokenWebView (forceRecreate=$forceRecreate)")
-                    webPoTokenSessionId = sessionId
 
                     withContext(Dispatchers.Main) {
                         webPoTokenGenerator?.close()
                     }
 
-                    // create a new webPoTokenGenerator
-                    webPoTokenGenerator = PoTokenWebView.getNewPoTokenGenerator(CipherDeobfuscator.appContext)
+                    // Clear the committed state BEFORE the fallible steps below: if creation or
+                    // the streaming-pot mint throws, the next call must compute
+                    // shouldRecreate=true instead of pairing the already-updated sessionId with
+                    // a null/stale streaming pot at the Triple below.
+                    webPoTokenGenerator = null
+                    webPoTokenStreamingPot = null
+                    webPoTokenSessionId = null
+
+                    val newGenerator = PoTokenWebView.getNewPoTokenGenerator(CipherDeobfuscator.appContext)
 
                     // The streaming poToken needs to be generated exactly once before generating
                     // any other (player) tokens.
-                    webPoTokenStreamingPot = webPoTokenGenerator!!.generatePoToken(webPoTokenSessionId!!)
-                    Timber.tag(TAG).d("Streaming poToken generated for sessionId=${webPoTokenSessionId?.take(20)}...")
+                    val newStreamingPot = try {
+                        newGenerator.generatePoToken(sessionId)
+                    } catch (t: Throwable) {
+                        // Don't leak the freshly created WebView (close() hops to Main itself).
+                        runCatching { newGenerator.close() }
+                        throw t
+                    }
+
+                    webPoTokenGenerator = newGenerator
+                    webPoTokenStreamingPot = newStreamingPot
+                    webPoTokenSessionId = sessionId
+                    Timber.tag(TAG).d("Streaming poToken generated for sessionId=${sessionId.take(20)}...")
                 }
 
                 Triple(webPoTokenGenerator!!, webPoTokenStreamingPot!!, shouldRecreate)

--- a/app/src/main/kotlin/com/metrolist/music/utils/potoken/PoTokenWebView.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/potoken/PoTokenWebView.kt
@@ -61,6 +61,8 @@ class PoTokenWebView private constructor(
         private set
     private val poTokenContinuations =
         Collections.synchronizedMap(ArrayMap<String, Continuation<String>>())
+    // Makes each generatePoToken call's continuation key unique (see generatePoToken).
+    private val requestCounter = java.util.concurrent.atomic.AtomicLong()
     private val exceptionHandler = CoroutineExceptionHandler { _, t ->
         onInitializationErrorCloseAndCancel(t)
     }
@@ -89,11 +91,27 @@ class PoTokenWebView private constructor(
 
                 if (msg.contains("Uncaught")) {
                     val fmt = "\"$msg\", source: ${m.sourceId()} (${m.lineNumber()})"
-                    val exception = BadWebViewException(fmt)
-                    Timber.tag(TAG).e("This WebView implementation is broken: $fmt")
+                    if (initResumed.get()) {
+                        // Post-init: our static HTML already executed fine, so an uncaught error
+                        // here comes from Google's remotely-served botguard/minter JS — transient,
+                        // NOT a BadWebViewException, which would permanently disable poTokens for
+                        // the session in PoTokenGenerator (same rationale as onRenderProcessGone).
+                        Timber.tag(TAG).e("Uncaught JS error after init (treating as transient): $fmt")
+                        isDead = true
+                        val exception = PoTokenException(fmt)
+                        close()
+                        popAllPoTokenContinuations().forEach { (_, cont) ->
+                            runCatching { cont.resumeWithException(exception) }
+                        }
+                    } else {
+                        val exception = BadWebViewException(fmt)
+                        Timber.tag(TAG).e("This WebView implementation is broken: $fmt")
 
-                    onInitializationErrorCloseAndCancel(exception)
-                    popAllPoTokenContinuations().forEach { (_, cont) -> cont.resumeWithException(exception) }
+                        onInitializationErrorCloseAndCancel(exception)
+                        popAllPoTokenContinuations().forEach { (_, cont) ->
+                            runCatching { cont.resumeWithException(exception) }
+                        }
+                    }
                 }
                 return super.onConsoleMessage(m)
             }
@@ -246,40 +264,47 @@ class PoTokenWebView private constructor(
             // WebView from scratch.
             throw PoTokenException("PoToken WebView is dead/closed — instance must be recreated")
         }
+        // Continuations are keyed by a per-call unique key, not the raw identifier: concurrent
+        // calls for the same videoId (player + prefetch/download) would otherwise silently
+        // overwrite each other's continuation and orphan one caller into the timeout.
+        val requestKey = "$identifier#${requestCounter.incrementAndGet()}"
         return try {
             withTimeout(GENERATE_TIMEOUT_MS) {
-                generatePoTokenInternal(identifier)
+                generatePoTokenInternal(identifier, requestKey)
             }
         } catch (e: TimeoutCancellationException) {
             // A renderer that never answers is wedged/dead (safety net for providers where
             // onRenderProcessGone doesn't fire) — drop the pending continuation and fail fast;
             // PoTokenGenerator's retry recreates the WebView from scratch.
             isDead = true
-            popPoTokenContinuation(identifier)
+            popPoTokenContinuation(requestKey)
             Timber.tag(TAG).e("generatePoToken($identifier) timed out after ${GENERATE_TIMEOUT_MS}ms")
             throw PoTokenException("poToken generation timed out after ${GENERATE_TIMEOUT_MS}ms")
         }
     }
 
-    private suspend fun generatePoTokenInternal(identifier: String): String {
+    private suspend fun generatePoTokenInternal(identifier: String, requestKey: String): String {
         return withContext(Dispatchers.Main) {
             suspendCancellableCoroutine { cont ->
                 Timber.tag(TAG).d("generatePoToken() called with identifier $identifier")
-                addPoTokenEmitter(identifier, cont)
-                // NOTE: obtainPoToken is now async, so we use .then()
+                addPoTokenEmitter(requestKey, cont)
+                // The IIFE keeps requestKey/u8Identifier lexically captured per call: bare globals
+                // here would let a concurrent call reassign them before this call's promise
+                // resolves, delivering this token to the other call's continuation.
                 webView.evaluateJavascript(
-                    """try {
-                        identifier = "$identifier"
-                        u8Identifier = ${stringToU8(identifier)}
-                        obtainPoToken(u8Identifier).then(function(poTokenU8) {
-                            poTokenU8String = poTokenU8.join(",")
-                            $JS_INTERFACE.onObtainPoTokenResult(identifier, poTokenU8String)
-                        }).catch(function(error) {
-                            $JS_INTERFACE.onObtainPoTokenError(identifier, error + "\n" + (error.stack || ''))
-                        })
-                    } catch (error) {
-                        $JS_INTERFACE.onObtainPoTokenError(identifier, error + "\n" + error.stack)
-                    }""",
+                    """(function() {
+                        var requestKey = "$requestKey"
+                        try {
+                            var u8Identifier = ${stringToU8(identifier)}
+                            obtainPoToken(u8Identifier).then(function(poTokenU8) {
+                                $JS_INTERFACE.onObtainPoTokenResult(requestKey, poTokenU8.join(","))
+                            }).catch(function(error) {
+                                $JS_INTERFACE.onObtainPoTokenError(requestKey, error + "\n" + (error.stack || ''))
+                            })
+                        } catch (error) {
+                            $JS_INTERFACE.onObtainPoTokenError(requestKey, error + "\n" + error.stack)
+                        }
+                    })()""",
                     null
                 )
             }
@@ -291,29 +316,33 @@ class PoTokenWebView private constructor(
      * JavaScript `obtainPoToken()` function.
      */
     @JavascriptInterface
-    fun onObtainPoTokenError(identifier: String, error: String) {
+    fun onObtainPoTokenError(requestKey: String, error: String) {
         if (BuildConfig.DEBUG) {
             Timber.tag(TAG).e("obtainPoToken error from JavaScript: $error")
         }
-        popPoTokenContinuation(identifier)?.resumeWithException(buildExceptionForJsError(error))
+        // Always transient here: the minter was already created successfully, so even a
+        // "SyntaxError" comes from Google's challenge/program data, not a broken WebView engine —
+        // buildExceptionForJsError's BadWebViewException mapping would permanently disable
+        // poTokens for the session in PoTokenGenerator.
+        popPoTokenContinuation(requestKey)?.resumeWithException(PoTokenException(error))
     }
 
     /**
-     * Called by the JavaScript snippet from [generatePoToken] with the original identifier and the
+     * Called by the JavaScript snippet from [generatePoToken] with the per-call request key and the
      * result of the JavaScript `obtainPoToken()` function.
      */
     @JavascriptInterface
-    fun onObtainPoTokenResult(identifier: String, poTokenU8: String) {
-        Timber.tag(TAG).d("Generated poToken (before decoding): identifier=$identifier poTokenU8=$poTokenU8")
+    fun onObtainPoTokenResult(requestKey: String, poTokenU8: String) {
+        Timber.tag(TAG).d("Generated poToken (before decoding): requestKey=$requestKey poTokenU8=$poTokenU8")
         val poToken = try {
             u8ToBase64(poTokenU8)
         } catch (t: Throwable) {
-            popPoTokenContinuation(identifier)?.resumeWithException(t)
+            popPoTokenContinuation(requestKey)?.resumeWithException(t)
             return
         }
 
-        Timber.tag(TAG).d("Generated poToken: identifier=$identifier poToken=$poToken")
-        popPoTokenContinuation(identifier)?.resume(poToken)
+        Timber.tag(TAG).d("Generated poToken: requestKey=$requestKey poToken=$poToken")
+        popPoTokenContinuation(requestKey)?.resume(poToken)
     }
 
     val isExpired: Boolean
@@ -353,16 +382,16 @@ class PoTokenWebView private constructor(
                     "x-user-agent" to "grpc-web-javascript/0.1",
                 ).toHeaders())
                 .url(url)
-            val response = withContext(Dispatchers.IO) {
-                httpClient.newCall(requestBuilder.build()).execute()
+            // .use{} so the response is closed on the non-200 path too (an unread body would
+            // otherwise strand its connection).
+            val (httpCode, body) = withContext(Dispatchers.IO) {
+                httpClient.newCall(requestBuilder.build()).execute().use { response ->
+                    response.code to if (response.code == 200) response.body!!.string() else null
+                }
             }
-            val httpCode = response.code
-            if (httpCode != 200) {
+            if (body == null) {
                 onInitializationErrorCloseAndCancel(PoTokenException("Invalid response code: $httpCode"))
             } else {
-                val body = withContext(Dispatchers.IO) {
-                    response.body!!.string()
-                }
                 handleResponseBody(body)
             }
         }

--- a/app/src/main/kotlin/com/metrolist/music/utils/potoken/PoTokenWebView.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/potoken/PoTokenWebView.kt
@@ -386,11 +386,13 @@ class PoTokenWebView private constructor(
             // otherwise strand its connection).
             val (httpCode, body) = withContext(Dispatchers.IO) {
                 httpClient.newCall(requestBuilder.build()).execute().use { response ->
-                    response.code to if (response.code == 200) response.body!!.string() else null
+                    response.code to if (response.code == 200) response.body?.string() else null
                 }
             }
-            if (body == null) {
-                onInitializationErrorCloseAndCancel(PoTokenException("Invalid response code: $httpCode"))
+            // Treat an empty 200 body as a failure too: handleResponseBody would otherwise pass
+            // "" to parseChallengeData/parseIntegrityTokenData and fail later with a murkier error.
+            if (body.isNullOrEmpty()) {
+                onInitializationErrorCloseAndCancel(PoTokenException("Invalid botguard response (code=$httpCode, empty body)"))
             } else {
                 handleResponseBody(body)
             }


### PR DESCRIPTION
## Problem
Several latent defects in the cipher/poToken pipeline degrade or break playback in ways that are hard to diagnose from the field:

- A single transient JS error in Google's remotely-served botguard code **permanently disables poTokens for the whole session** (streams degrade to the ~1 MiB cutoff / 403 pattern until app restart).
- Concurrent poToken mints (playback racing a prefetch/download) can deliver one video's token to another caller, or orphan a caller into a 15 s timeout that then destroys a perfectly healthy WebView.
- A failed session-pot mint leaves poisoned state behind: `KotlinNullPointerException` per song, or silently wrong-session tokens that 403.
- Skipping a song mid-decipher can deliver the **previous song's signature to the next request** (sporadic unexplainable 403s).
- Every cipher WebView build runs a ~2.8 MB string transform + disk write **on the main thread** — visible jank/ANR risk exactly at song start on slow devices.
- Failed WebView inits leak a live renderer process per retry; a backward clock step (NTP correction) wedges the player-config self-heal for the entire skew; process death mid-cache-write can serve a truncated player.js for 6 hours.

## Cause
- Error classification maps any console message containing "Uncaught" (and any "SyntaxError") to `BadWebViewException`, which sets a never-reset `webViewBadImpl` kill switch — even post-init, where such errors come from Google's own botguard program, not a broken WebView engine.
- The injected mint JS used bare page globals (`identifier`), read at promise-resolution time, and pending continuations were keyed by raw identifier (silent overwrite on same-key concurrency).
- `PoTokenGenerator` committed `sessionId`/generator state *before* the fallible session-pot mint.
- The sig/n JS bridge had no pairing between requests and results, so a late callback resumed whatever continuation was currently armed.
- `CipherWebView.create()` only destroyed the half-built WebView on timeout/cancellation, not on error resumes; `loadPlayerJsFromFile` ran entirely inside `withContext(Dispatchers.Main)`.
- Cooldown/TTL checks used signed wall-clock deltas (`now - stamp < window`), which stay true for negative deltas; cache writes were plain truncating `writeText` with no serialization against the purge in a concurrent writer.

## Solution
- `PoTokenWebView`: pending mints keyed by a **per-call unique request key**, captured lexically in an IIFE and echoed back by the JS bridge; post-init "Uncaught" and mint-time JS errors are **transient** (`PoTokenException` + recreate on next call) instead of the permanent `BadWebViewException` kill switch (init-phase broken-WebView detection unchanged); OkHttp responses closed on non-200 paths.
- `PoTokenGenerator`: session state committed **only after** the streaming-pot mint succeeds; the freshly created WebView is closed (not leaked) on mint failure.
- `CipherWebView`: sig/n requests carry an id validated on take (`RequestSlot`) so stale results are ignored; the ~2.8 MB player.js transform + write moved to `Dispatchers.IO` (only WebView construction/load stays on Main); the player JS string is no longer retained for the WebView's lifetime (~2.8 MB heap); the half-initialized WebView is destroyed on **any** init failure.
- `PlayerConfigStore`/`PlayerJsFetcher`: all wall-clock window checks go through one `withinWindow` helper that treats backward clock steps as expired/not-armed; player-JS cache writes are atomic (temp + rename, with delete-and-retry before the non-atomic last resort) and serialized behind a lock.
- `FunctionNameExtractor`: `signatureTimestamp` precedence is now anchored-JS-literal → config → loose pattern, so a bad `sts` in a config update can never shadow the player's own embedded value.
- `PoTokenWebView`: an empty botguard `200` response body is now treated as an init failure via the existing `PoTokenException` path — it previously fell through to `handleResponseBody("")` and failed deeper with a murkier error; the body is also read null-safely.

No changes to the remote config schema, parser, or fetch protocol — existing installs keep fetching configs unchanged.

These fixes were developed, reviewed, and hardened in [zemer-cipher](https://github.com/ZemerTeam/zemer-cipher) (a standalone library extracted from this same cipher/poToken lineage — see ZemerTeam/zemer-cipher#1 for the fully annotated changeset), then carefully ported here with each file diffed against this tree first and adapted to its local structure rather than copied blind.

## Testing
- Cipher unit tests pass (`:app:testFossDebugUnitTest --tests "com.metrolist.music.utils.cipher.*"`); the pre-existing `YouTubeUtilsTest` failures on `main` are unrelated and unchanged.
- On-device (foss debug build, real playback across two app sessions): 26 deciphered stream URLs, 13 n-transform successes, 15 uniquely-keyed poToken mints — every JS bridge callback id-matched, one WebView build per process with the 2.8 MB prep measured at ~50 ms on the IO thread, and **zero** crashes, renderer-gone events, Uncaught/BadWebView classifications, or timeouts in 20k+ captured log lines.
- The same changeset was additionally validated end-to-end against the live CDN in the zemer-cipher repo (real signatureCipher deciphered, n-probe changed, Range GET returned HTTP 206).

## Related Issues
- Related to #4092 (WebView renderer-death recovery — this extends that hardening to the token/decipher race and leak classes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when loading playback-related data, reducing failures caused by concurrent requests, stale cache entries, and interrupted refreshes.
  * Fixed issues where token generation could return the wrong result or fail during overlapping requests.
  * Made background loading and cache updates more resilient, helping prevent broken or partially written data from being used.
  * Improved handling of unexpected WebView errors so recovery is more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->