### PR TITLE
fix(sync): prevent playlist duplication by querying browseId directly

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
@@ -78,6 +78,10 @@ import java.util.Locale
  */
 @Dao
 interface DatabaseDao {
+    companion object {
+        private const val SQL_IN_CLAUSE_CHUNK_SIZE = 900
+    }
+
     @Transaction
     @Query("SELECT * FROM song WHERE inLibrary IS NOT NULL ORDER BY rowId")
     fun songsByRowIdAsc(): Flow<List<Song>>
@@ -660,7 +664,7 @@ interface DatabaseDao {
 
     @Transaction
     suspend fun getSongsByIds(songIds: List<String>): List<Song> {
-        return songIds.chunked(900).flatMap { getSongsByIdsInternal(it) }
+        return songIds.chunked(SQL_IN_CLAUSE_CHUNK_SIZE).flatMap { getSongsByIdsInternal(it) }
     }
 
 
@@ -1097,7 +1101,7 @@ interface DatabaseDao {
         playlistId: String,
         songIds: List<String>,
     ): List<String> {
-        return songIds.chunked(900).flatMap { playlistDuplicatesInternal(playlistId, it) }
+        return songIds.chunked(SQL_IN_CLAUSE_CHUNK_SIZE).flatMap { playlistDuplicatesInternal(playlistId, it) }
     }
 
     @Query("UPDATE playlist SET lastUpdateTime = :now WHERE id = :playlistId")

--- a/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
@@ -655,9 +655,13 @@ interface DatabaseDao {
     @Query("SELECT * FROM song WHERE id = :songId LIMIT 1")
     fun getSongByIdBlocking(songId: String): Song?
 
-    @Transaction
     @Query("SELECT * FROM song WHERE id IN (:songIds)")
-    suspend fun getSongsByIds(songIds: List<String>): List<Song>
+    suspend fun getSongsByIdsInternal(songIds: List<String>): List<Song>
+
+    @Transaction
+    suspend fun getSongsByIds(songIds: List<String>): List<Song> {
+        return songIds.chunked(900).flatMap { getSongsByIdsInternal(it) }
+    }
 
 
     @Transaction
@@ -1083,10 +1087,18 @@ interface DatabaseDao {
     ): Int
 
     @Query("SELECT songId from playlist_song_map WHERE playlistId = :playlistId AND songId IN (:songIds)")
-    fun playlistDuplicates(
+    fun playlistDuplicatesInternal(
         playlistId: String,
         songIds: List<String>,
     ): List<String>
+
+    @Transaction
+    fun playlistDuplicates(
+        playlistId: String,
+        songIds: List<String>,
+    ): List<String> {
+        return songIds.chunked(900).flatMap { playlistDuplicatesInternal(playlistId, it) }
+    }
 
     @Query("UPDATE playlist SET lastUpdateTime = :now WHERE id = :playlistId")
     fun updatePlaylistLastUpdated(

--- a/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
@@ -659,6 +659,7 @@ interface DatabaseDao {
     @Query("SELECT * FROM song WHERE id = :songId LIMIT 1")
     fun getSongByIdBlocking(songId: String): Song?
 
+    @Transaction
     @Query("SELECT * FROM song WHERE id IN (:songIds)")
     suspend fun getSongsByIdsInternal(songIds: List<String>): List<Song>
 

--- a/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
@@ -1418,6 +1418,9 @@ class SyncUtils @Inject constructor(
                                 database.insert(playlistEntity)
                                 Timber.d("syncSavedPlaylists: Created new playlist ${playlist.title} (${playlist.id})")
                             } else {
+                                if (playlistEntity.bookmarkedAt == null) {
+                                    playlistEntity = playlistEntity.copy(bookmarkedAt = LocalDateTime.now())
+                                }
                                 database.update(playlistEntity, playlist)
                                 Timber.d("syncSavedPlaylists: Updated existing playlist ${playlist.title} (${playlist.id})")
                             }

--- a/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
@@ -1399,7 +1399,7 @@ class SyncUtils @Inject constructor(
 
                     for (playlist in remotePlaylists) {
                         try {
-                            var playlistEntity = localPlaylists.find { it.playlist.browseId == playlist.id }?.playlist
+                            var playlistEntity = database.playlistByBrowseId(playlist.id).firstOrNull()?.playlist
 
                             if (playlistEntity == null) {
                                 playlistEntity = PlaylistEntity(


### PR DESCRIPTION
Closes #4101

### What was the issue?
When syncing saved playlists from YouTube, the app would sometimes create duplicate copies of the same playlist in the local database. This resulted in two identical playlists appearing in the Library screen.

### Why did it happen?
In `SyncUtils.kt`, the sync logic checked if a remote playlist already existed locally by looking it up in a list fetched via `database.playlistsByNameAsc()`. However, that specific query is designed to *only* return playlists that the user currently has **bookmarked** (`WHERE bookmarkedAt IS NOT NULL`). 

If a playlist existed in the database but wasn't currently bookmarked (e.g. if it was previously cached or unbookmarked locally), it wouldn't show up in that filtered list. The sync logic would then mistakenly assume it was a brand-new playlist, generate a new internal ID for it, and insert a duplicate row with the same `browseId`.

### How was it fixed?
I replaced the filtered list lookup with a direct database query by `browseId`:
```kotlin
var playlistEntity = database.playlistByBrowseId(playlist.id).firstOrNull()?.playlist


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved syncing for saved playlists: existing playlists are now matched more reliably, and bookmark timestamps are automatically set when missing.
  * Prevented potential failures/performance issues with very large song selections by batching large `IN (...)` lookups and duplicate checks into smaller chunks during database queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->