### PR TITLE
fix(ui): prevent BottomSheet drag cancel from forcing collapse

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/BottomSheet.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/BottomSheet.kt
@@ -97,8 +97,9 @@ fun BottomSheet(
                         state.dispatchRawDelta(dragAmount)
                     },
                     onDragCancel = {
+                        val velocity = -velocityTracker.calculateVelocity().y
                         velocityTracker.resetTracking()
-                        state.snapTo(state.collapsedBound)
+                        state.performFling(velocity, onDismiss)
                     },
                     onDragEnd = {
                         val velocity = -velocityTracker.calculateVelocity().y


### PR DESCRIPTION
## Problem
When lyrics are in fullscreen mode and the user enters the recent apps overview via gesture navigation, the player collapses back to the mini player. This only occurs with gesture navigation (not 3-button navigation).

<img width="240" height="528" alt="before_fix_1836" src="https://github.com/user-attachments/assets/b656d4b2-8470-4659-b03c-60ad31337e1c" />


## Cause
The `BottomSheet` drag gesture handler's `onDragCancel` callback unconditionally called `state.snapTo(state.collapsedBound)`. When the user performs a system recents gesture, the system briefly dispatches the touch event to the app as a drag on the bottom sheet before recognizing it as a system gesture. The system then cancels the drag, and `onDragCancel` forcibly collapses the player sheet — even though the user never intended to collapse it.

## Solution
- Replace `state.snapTo(state.collapsedBound)` with `state.performFling(velocity, onDismiss)` in `onDragCancel`, matching the existing `onDragEnd` behavior. This lets the Compose framework naturally settle the sheet to the appropriate anchor based on physics (velocity and position) rather than forcing a collapse.

## Testing
- Entered fullscreen lyrics mode with a scrolling song
- Swiped up to enter recent apps overview via gesture navigation
- Verified the player remains expanded in the recents preview
- Repeated multiple times at different lyrics scroll positions
- Also verified normal drag-to-collapse behavior still works correctly for user-initiated sheet drags

<img width="240" height="528" alt="after_fix_1832" src="https://github.com/user-attachments/assets/4671b6c4-fd27-46fb-a943-4f3008222d2d" />

## Related Issues
- Closes #
- Related to # 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bottom sheet drag cancellation behavior by applying the gesture’s fling velocity.
  * Bottom sheets now expand, collapse, or dismiss more naturally after interrupted drags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->