### PR TITLE
fix(sync): resolve playlist duplication and prevent OOM crashes

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
@@ -1415,6 +1415,8 @@ class SyncUtils @Inject constructor(
                         .distinctBy { it.id }
                     val remoteIds = remotePlaylists.map { it.id }.toSet()
 
+                    executeCleanupDuplicatePlaylists()
+
                     val localPlaylists = database.playlistEntitiesByNameAsc().toMutableList()
                     localPlaylists.filterNot { it.browseId in remoteIds }
                         .filterNot { it.browseId == null }
@@ -1466,7 +1468,6 @@ class SyncUtils @Inject constructor(
                     }
 
                     updateState { copy(playlists = SyncStatus.Completed) }
-                    executeCleanupDuplicatePlaylists()
                     Timber.d("Synced ${remotePlaylists.size} saved playlists")
                 } catch (e: Exception) {
                     Timber.e(e, "Error processing saved playlists")

--- a/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
@@ -1412,9 +1412,10 @@ class SyncUtils @Inject constructor(
                     val remotePlaylists = page.items.filterIsInstance<PlaylistItem>()
                         .filterNot { it.id == "LM" || it.id == "SE" }
                         .reversed()
+                        .distinctBy { it.id }
                     val remoteIds = remotePlaylists.map { it.id }.toSet()
 
-                    val localPlaylists = database.playlistEntitiesByNameAsc()
+                    val localPlaylists = database.playlistEntitiesByNameAsc().toMutableList()
                     localPlaylists.filterNot { it.browseId in remoteIds }
                         .filterNot { it.browseId == null }
                         .forEach { playlist ->
@@ -1445,6 +1446,7 @@ class SyncUtils @Inject constructor(
                                     radioEndpointParams = playlist.radioEndpoint?.params
                                 )
                                 database.insert(playlistEntity)
+                                localPlaylists.add(playlistEntity)
                                 Timber.d("syncSavedPlaylists: Created new playlist ${playlist.title} (${playlist.id})")
                             } else {
                                 database.update(playlistEntity, playlist)
@@ -1464,6 +1466,7 @@ class SyncUtils @Inject constructor(
                     }
 
                     updateState { copy(playlists = SyncStatus.Completed) }
+                    executeCleanupDuplicatePlaylists()
                     Timber.d("Synced ${remotePlaylists.size} saved playlists")
                 } catch (e: Exception) {
                     Timber.e(e, "Error processing saved playlists")
@@ -1589,21 +1592,21 @@ class SyncUtils @Inject constructor(
 
     private suspend fun executeCleanupDuplicatePlaylists() = withContext(Dispatchers.IO) {
         try {
-            val allPlaylists = database.playlistsByNameAsc().first()
+            val allPlaylists = database.playlistEntitiesByNameAsc()
             val browseIdGroups = allPlaylists
-                .filter { it.playlist.browseId != null }
-                .groupBy { it.playlist.browseId }
+                .filter { it.browseId != null }
+                .groupBy { it.browseId }
 
             for ((browseId, playlists) in browseIdGroups) {
                 if (playlists.size > 1) {
                     Timber.w("Found ${playlists.size} duplicate playlists for browseId: $browseId")
-                    val toKeep = playlists.maxByOrNull { it.songCount } ?: playlists.first()
+                    val toKeep = playlists.maxByOrNull { it.remoteSongCount ?: 0 } ?: playlists.first()
 
                     playlists.filter { it.id != toKeep.id }.forEach { duplicate ->
                         try {
-                            Timber.d("Removing duplicate playlist: ${duplicate.playlist.name} (${duplicate.id})")
+                            Timber.d("Removing duplicate playlist: ${duplicate.name} (${duplicate.id})")
                             database.clearPlaylist(duplicate.id)
-                            database.delete(duplicate.playlist)
+                            database.delete(duplicate)
                             delay(DB_OPERATION_DELAY_MS)
                         } catch (e: Exception) {
                             Timber.e(e, "Failed to remove duplicate playlist: ${duplicate.id}")


### PR DESCRIPTION
## Problem
The app experiences duplicate playlists and out of memory errors causing constant crashes and playback freezes.

## Cause
The sync engine duplicates playlists during background synchronization, and the cleanup routine loads the entire database into memory, crashing the app.

## Solution
Implemented strict checking before creating new playlists and modified the sync cleanup logic to use memory-efficient entity queries.

## Testing
Built the app and verified the sync function prevents duplicates and does not allocate excessive memory.

## Related Issues
Closes #4114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved saved-playlist synchronization by de-duplicating remote playlist items before computing matches.
  * Updated duplicate-playlist cleanup to keep the most complete playlist while removing redundant duplicates.
  * Ensured playlists created during the same sync run are included for subsequent lookups, keeping results consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->