### PR TITLE
fix(discord): eliminate reconnect races that leave Rich Presence permanently disconnected

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/discord/DiscordGateway.kt
+++ b/app/src/main/kotlin/com/metrolist/music/discord/DiscordGateway.kt
@@ -72,8 +72,8 @@ sealed interface GatewayEvent {
 class DiscordGateway(
     private val appId: String,
     private val externalScope: CoroutineScope,
+    private val webSocketFactory: WebSocket.Factory? = null,
 ) {
-
     private val _events = MutableSharedFlow<GatewayEvent>(
         replay = 0,
         extraBufferCapacity = 64,
@@ -129,7 +129,7 @@ class DiscordGateway(
         val request = Request.Builder().url(gatewayUrl).build()
         val listener = createListener(openDeferred, myId)
         val ws = try {
-            httpClient.newWebSocket(request, listener)
+            (webSocketFactory ?: httpClient).newWebSocket(request, listener)
         } catch (e: Throwable) {
             invalidateAttempt(myId, null)
             throw GatewayConnectionException(4000, null, e)

--- a/app/src/main/kotlin/com/metrolist/music/discord/DiscordGateway.kt
+++ b/app/src/main/kotlin/com/metrolist/music/discord/DiscordGateway.kt
@@ -1,8 +1,11 @@
 package com.metrolist.music.discord
 
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -10,6 +13,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -18,26 +22,56 @@ import okhttp3.WebSocketListener
 import okio.ByteString
 import org.json.JSONObject
 import timber.log.Timber
+import java.io.IOException
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.math.abs
 import kotlin.random.Random
 
+/** Thrown when an in-flight connect is superseded by a newer connect/close before its handshake finished. */
+class GatewaySupersededException : IOException("connection superseded")
+
+class GatewayConnectionException(
+    val statusCode: Int,
+    val retryAfter: String?,
+    cause: Throwable,
+) : IOException("gateway connection failed (status=$statusCode): ${cause.message}", cause) {
+    val retryReason: String
+        get() = if (retryAfter != null) {
+            "${cause?.message ?: "failure"};retry_after=$retryAfter"
+        } else {
+            cause?.message ?: "failure"
+        }
+}
+
 sealed interface GatewayEvent {
-    data class Hello(val heartbeatIntervalMs: Long) : GatewayEvent
-    data class Ready(val sessionId: String, val resumeGatewayUrl: String?) : GatewayEvent
-    data class Resumed(val sessionId: String) : GatewayEvent
-    data class HeartbeatAck(val lastSeq: Int?) : GatewayEvent
-    data class InvalidSession(val resumable: Boolean) : GatewayEvent
-    data class Disconnected(val code: Int, val reason: String, val remote: Boolean) : GatewayEvent
-    data object RefreshToken : GatewayEvent
-    data class TextDispatch(val op: Int, val t: String?, val d: JSONObject) : GatewayEvent
+    data class Hello(val connectionId: Long, val heartbeatIntervalMs: Long) : GatewayEvent
+    data class Ready(
+        val connectionId: Long,
+        val sessionId: String,
+        val resumeGatewayUrl: String?,
+    ) : GatewayEvent
+    data class Resumed(val connectionId: Long, val sessionId: String) : GatewayEvent
+    data class HeartbeatAck(val connectionId: Long, val lastSeq: Int?) : GatewayEvent
+    data class InvalidSession(val connectionId: Long, val resumable: Boolean) : GatewayEvent
+    data class Disconnected(
+        val connectionId: Long,
+        val code: Int,
+        val reason: String,
+        val remote: Boolean,
+    ) : GatewayEvent
+    data class TextDispatch(
+        val connectionId: Long,
+        val op: Int,
+        val t: String?,
+        val d: JSONObject,
+    ) : GatewayEvent
 }
 
 class DiscordGateway(
     private val appId: String,
-    private val tokenProvider: suspend () -> String,
-    private val externalScope: kotlinx.coroutines.CoroutineScope,
+    private val externalScope: CoroutineScope,
 ) {
 
     private val _events = MutableSharedFlow<GatewayEvent>(
@@ -61,6 +95,7 @@ class DiscordGateway(
     @Volatile
     private var isOpen: Boolean = false
 
+    private val connectionLock = Any()
     private val webSocketIdCounter = AtomicLong(0L)
 
     @Volatile
@@ -68,9 +103,6 @@ class DiscordGateway(
 
     @Volatile
     private var gatewayUrl: String = DEFAULT_GATEWAY_URL
-
-    @Volatile
-    private var reconnectAttempts: Int = 0
 
     @Volatile
     private var heartbeatJob: Job? = null
@@ -83,33 +115,77 @@ class DiscordGateway(
         .pingInterval(0, TimeUnit.MILLISECONDS)
         .build()
 
-    suspend fun connect() {
-        val myId = webSocketIdCounter.incrementAndGet()
-        activeWebSocketId = myId
+    suspend fun connect(onConnectionCreated: (Long) -> Unit = {}): Long {
+        val myId = synchronized(connectionLock) {
+            webSocketIdCounter.incrementAndGet().also { activeWebSocketId = it }
+        }
+        try {
+            onConnectionCreated(myId)
+        } catch (e: Throwable) {
+            invalidateAttempt(myId, null)
+            throw e
+        }
         val openDeferred = CompletableDeferred<Unit>()
         val request = Request.Builder().url(gatewayUrl).build()
         val listener = createListener(openDeferred, myId)
-        val ws = httpClient.newWebSocket(request, listener)
-        webSocket = ws
+        val ws = try {
+            httpClient.newWebSocket(request, listener)
+        } catch (e: Throwable) {
+            invalidateAttempt(myId, null)
+            throw GatewayConnectionException(4000, null, e)
+        }
+        val accepted = synchronized(connectionLock) {
+            if (myId == activeWebSocketId) {
+                webSocket = ws
+                true
+            } else {
+                false
+            }
+        }
+        if (!accepted) {
+            runCatching { ws.cancel() }
+            throw GatewaySupersededException()
+        }
         try {
-            openDeferred.await()
+            withTimeout(HANDSHAKE_TIMEOUT_MS) { openDeferred.await() }
             Timber.tag(TAG).i("connect: WS opened (id=%d), gatewayUrl=%s", myId, gatewayUrl)
+            return myId
+        } catch (e: TimeoutCancellationException) {
+            Timber.tag(TAG).e("connect: handshake timed out after %dms (id=%d)", HANDSHAKE_TIMEOUT_MS, myId)
+            runCatching { ws.cancel() }
+            invalidateAttempt(myId, ws)
+            throw GatewayConnectionException(4000, null, e)
+        } catch (e: CancellationException) {
+            runCatching { ws.cancel() }
+            invalidateAttempt(myId, ws)
+            throw e
+        } catch (e: GatewaySupersededException) {
+            runCatching { ws.cancel() }
+            throw e
+        } catch (e: GatewayConnectionException) {
+            Timber.tag(TAG).e(e, "connect: failed to open WS (id=%d)", myId)
+            runCatching { ws.cancel() }
+            invalidateAttempt(myId, ws)
+            throw e
         } catch (e: Throwable) {
             Timber.tag(TAG).e(e, "connect: failed to open WS (id=%d)", myId)
             runCatching { ws.cancel() }
-            webSocket = null
-            throw e
+            invalidateAttempt(myId, ws)
+            throw GatewayConnectionException(4000, null, e)
         }
     }
 
     fun close(code: Int = 1000, reason: String? = null) {
         Timber.tag(TAG).i("close: code=%d, reason=%s", code, reason ?: "")
-        heartbeatJob?.cancel()
-        heartbeatJob = null
-        val ws = webSocket
-        webSocket = null
-        isOpen = false
-        activeWebSocketId = webSocketIdCounter.incrementAndGet()
+        val ws = synchronized(connectionLock) {
+            heartbeatJob?.cancel()
+            heartbeatJob = null
+            val current = webSocket
+            webSocket = null
+            isOpen = false
+            activeWebSocketId = webSocketIdCounter.incrementAndGet()
+            current
+        }
         if (ws != null) {
             runCatching {
                 if (reason != null) ws.close(code, reason) else ws.close(code, null)
@@ -117,12 +193,30 @@ class DiscordGateway(
         }
     }
 
-    fun send(frameJson: String) {
-        val ws = webSocket
-        if (ws == null || !isOpen) {
-            Timber.tag(TAG).w("send: WebSocket not open (ws=%s, isOpen=%s)", ws, isOpen)
+    private fun send(frameJson: String) {
+        val ws = synchronized(connectionLock) {
+            if (isOpen) webSocket else null
+        }
+        if (ws == null) {
+            Timber.tag(TAG).w("send: WebSocket not open")
             throw IllegalStateException("DiscordGateway: WebSocket is not open")
         }
+        send(frameJson, ws)
+    }
+
+    private fun send(frameJson: String, forConnectionId: Long) {
+        val ws = synchronized(connectionLock) {
+            if (forConnectionId != activeWebSocketId || !isOpen) {
+                null
+            } else {
+                webSocket
+            }
+        }
+        if (ws == null) throw GatewaySupersededException()
+        send(frameJson, ws)
+    }
+
+    private fun send(frameJson: String, ws: WebSocket) {
         Timber.tag(TAG).v("send: frame (length=%d)", frameJson.length)
         val ok = ws.send(frameJson)
         if (!ok) {
@@ -131,9 +225,9 @@ class DiscordGateway(
         }
     }
 
-    suspend fun identify(token: String) {
+    suspend fun identify(token: String, connectionId: Long) {
         val frame = buildIdentifyFrame(token)
-        send(frame)
+        send(frame, connectionId)
         Timber.tag(TAG).i("identify: IDENTIFY sent (token length=%d)", token.length)
     }
 
@@ -141,21 +235,24 @@ class DiscordGateway(
         send(presenceJson)
     }
 
-    suspend fun resume(sessionId: String, seq: Int, token: String) {
+    suspend fun resume(sessionId: String, seq: Int, token: String, connectionId: Long) {
         val frame = buildResumeFrame(sessionId, seq, token)
-        send(frame)
+        send(frame, connectionId)
         Timber.tag(TAG).i("resume: RESUME sent (sessionId prefix=%s, seq=%d)", sessionId.take(8), seq)
     }
 
-    fun heartbeat(seq: Int) {
+    private fun heartbeat(seq: Int, connectionId: Long) {
         Timber.tag(TAG).d("heartbeat: sending seq=%d", seq)
         val frame = buildHeartbeatFrame(seq)
-        send(frame)
+        send(frame, connectionId)
     }
 
-    fun setGatewayUrl(url: String) {
-        gatewayUrl = url
-        Timber.tag(TAG).i("setGatewayUrl: %s", url)
+    fun invalidateSession() {
+        synchronized(connectionLock) {
+            _sessionId = null
+            _currentSeq = 0
+            gatewayUrl = DEFAULT_GATEWAY_URL
+        }
     }
 
     fun closeHttp() {
@@ -167,13 +264,30 @@ class DiscordGateway(
 
     private fun createListener(openDeferred: CompletableDeferred<Unit>, wsId: Long): WebSocketListener =
         object : WebSocketListener() {
+            private val opened = AtomicBoolean(false)
 
             override fun onOpen(webSocket: WebSocket, response: Response) {
-                if (wsId != activeWebSocketId) return
+                val accepted = synchronized(connectionLock) {
+                    if (wsId != activeWebSocketId) {
+                        false
+                    } else {
+                        this@DiscordGateway.webSocket = webSocket
+                        isOpen = true
+                        lastAckAtMs.set(System.currentTimeMillis())
+                        opened.set(true)
+                        true
+                    }
+                }
+                if (!accepted) {
+                    Timber.tag(TAG).i(
+                        "onOpen: stale WS (wsId=%d, activeId=%d), cancelling superseded socket",
+                        wsId, activeWebSocketId,
+                    )
+                    runCatching { webSocket.cancel() }
+                    openDeferred.completeExceptionally(GatewaySupersededException())
+                    return
+                }
                 Timber.tag(TAG).i("onOpen: response.code=%d, wsId=%d", response.code, wsId)
-                this@DiscordGateway.webSocket = webSocket
-                isOpen = true
-                lastAckAtMs.set(System.currentTimeMillis())
                 openDeferred.complete(Unit)
             }
 
@@ -181,7 +295,7 @@ class DiscordGateway(
                 if (wsId != activeWebSocketId) return
                 externalScope.launch {
                     try {
-                        handleFrame(text)
+                        handleFrame(text, wsId)
                     } catch (e: Throwable) {
                         Timber.tag(TAG).e(e, "onMessage: failed to handle text frame")
                     }
@@ -199,17 +313,36 @@ class DiscordGateway(
 
             override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
                 Timber.tag(TAG).i("onClosed: code=%d, reason=%s, wsId=%d", code, reason, wsId)
+                if (!opened.get()) {
+                    val exception = if (!isActiveConnection(wsId)) {
+                        GatewaySupersededException()
+                    } else {
+                        GatewayConnectionException(code, null, IOException(reason.ifEmpty { "closed before open" }))
+                    }
+                    openDeferred.completeExceptionally(exception)
+                    return
+                }
                 externalScope.launch {
                     handleClose(code, reason, remote = true, closedWebSocketId = wsId)
                 }
             }
 
             override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
-                if (wsId != activeWebSocketId) return
-                Timber.tag(TAG).e(t, "onFailure: response=%s, wsId=%d", response?.code, wsId)
-                if (!openDeferred.isCompleted) {
-                    openDeferred.completeExceptionally(t)
+                if (!isActiveConnection(wsId)) {
+                    openDeferred.completeExceptionally(GatewaySupersededException())
+                    return
                 }
+                if (!opened.get()) {
+                    openDeferred.completeExceptionally(
+                        GatewayConnectionException(
+                            statusCode = response?.code ?: 4000,
+                            retryAfter = response?.header("Retry-After"),
+                            cause = t,
+                        ),
+                    )
+                    return
+                }
+                Timber.tag(TAG).e(t, "onFailure after open: response=%s, wsId=%d", response?.code, wsId)
                 externalScope.launch {
                     val code = response?.code ?: 4000
                     val retryAfter = response?.header("Retry-After")
@@ -223,13 +356,14 @@ class DiscordGateway(
             }
         }
 
-    private suspend fun handleFrame(text: String) {
+    private suspend fun handleFrame(text: String, connectionId: Long) {
         val json = try {
             JSONObject(text)
         } catch (e: Throwable) {
             Timber.tag(TAG).e(e, "handleFrame: invalid JSON")
             return
         }
+        if (!isOpenConnection(connectionId)) return
 
         val op = json.optInt("op", -1)
         val d: JSONObject? = json.optJSONObject("d")
@@ -240,20 +374,30 @@ class DiscordGateway(
 
         if (json.has("s") && !json.isNull("s")) {
             val seq = json.optInt("s", 0)
-            if (seq > 0) _currentSeq = seq
+            if (seq > 0) {
+                synchronized(connectionLock) {
+                    if (connectionId != activeWebSocketId || !isOpen) return
+                    _currentSeq = seq
+                }
+            }
         }
 
         when (op) {
             HELLO -> {
                 val interval = d?.optLong("heartbeat_interval", DEFAULT_HEARTBEAT_MS)
                     ?: DEFAULT_HEARTBEAT_MS
+                if (!isOpenConnection(connectionId)) return
                 Timber.tag(TAG).d("handleFrame: HELLO received, heartbeatInterval=%dms", interval)
-                startHeartbeat(interval)
-                _events.emit(GatewayEvent.Hello(interval))
+                startHeartbeat(interval, connectionId)
+                if (!isOpenConnection(connectionId)) return
+                _events.emit(GatewayEvent.Hello(connectionId, interval))
             }
             HEARTBEAT_ACK -> {
-                lastAckAtMs.set(System.currentTimeMillis())
-                _events.emit(GatewayEvent.HeartbeatAck(_currentSeq))
+                synchronized(connectionLock) {
+                    if (connectionId != activeWebSocketId || !isOpen) return
+                    lastAckAtMs.set(System.currentTimeMillis())
+                }
+                _events.emit(GatewayEvent.HeartbeatAck(connectionId, _currentSeq))
             }
             DISPATCH -> {
                 when (t) {
@@ -262,166 +406,146 @@ class DiscordGateway(
                         val sessionId = data.optString("session_id", "")
                         val resumeUrl: String? = data.optString("resume_gateway_url", "")
                             .takeIf { it.isNotEmpty() }
-                        _sessionId = sessionId
+                        synchronized(connectionLock) {
+                            if (connectionId != activeWebSocketId || !isOpen) return
+                            _sessionId = sessionId
+                            if (resumeUrl != null) gatewayUrl = resumeUrl
+                        }
                         Timber.tag(TAG).d(
                             "handleFrame: READY parsed (sessionId prefix=%s, resumeUrl=%s)",
                             sessionId.take(8), resumeUrl?.take(60),
                         )
-                        if (resumeUrl != null) setGatewayUrl(resumeUrl)
-                        reconnectAttempts = 0
-                        _events.emit(GatewayEvent.Ready(sessionId, resumeUrl))
+                        if (resumeUrl != null) {
+                            Timber.tag(TAG).i("setGatewayUrl: %s", resumeUrl)
+                        }
+                        if (!isOpenConnection(connectionId)) return
+                        _events.emit(GatewayEvent.Ready(connectionId, sessionId, resumeUrl))
                     }
                     "RESUMED" -> {
-                        reconnectAttempts = 0
+                        if (!isOpenConnection(connectionId)) return
                         Timber.tag(TAG).d("handleFrame: RESUMED parsed (sessionId prefix=%s)", _sessionId?.take(8))
-                        _events.emit(GatewayEvent.Resumed(_sessionId.orEmpty()))
+                        _events.emit(GatewayEvent.Resumed(connectionId, _sessionId.orEmpty()))
                     }
                     else -> {
-                        _events.emit(GatewayEvent.TextDispatch(op, t, d ?: JSONObject()))
+                        if (!isOpenConnection(connectionId)) return
+                        _events.emit(GatewayEvent.TextDispatch(connectionId, op, t, d ?: JSONObject()))
                     }
                 }
             }
             INVALID_SESSION -> {
                 val resumable = (json.opt("d") as? Boolean) ?: false
                 Timber.tag(TAG).w("INVALID_SESSION: resumable=%s", resumable)
-                if (!resumable) {
-                    _sessionId = null
+                synchronized(connectionLock) {
+                    if (connectionId != activeWebSocketId || !isOpen) return
+                    if (!resumable) {
+                        _sessionId = null
+                    }
                 }
-                _events.emit(GatewayEvent.InvalidSession(resumable))
-                webSocket?.close(4000, "invalid session")
+                _events.emit(GatewayEvent.InvalidSession(connectionId, resumable))
+                close(connectionId, 4000, "invalid session")
             }
             HEARTBEAT -> {
-                heartbeat(_currentSeq)
+                if (!isOpenConnection(connectionId)) return
+                heartbeat(_currentSeq, connectionId)
             }
             RECONNECT -> {
                 Timber.tag(TAG).w("RECONNECT requested by server, closing 4000")
-                webSocket?.close(4000, "reconnect requested")
+                close(connectionId, 4000, "reconnect requested")
             }
             else -> {
-                _events.emit(GatewayEvent.TextDispatch(op, t, d ?: JSONObject()))
+                if (!isOpenConnection(connectionId)) return
+                _events.emit(GatewayEvent.TextDispatch(connectionId, op, t, d ?: JSONObject()))
             }
         }
     }
 
     private suspend fun handleClose(code: Int, reason: String, remote: Boolean, closedWebSocketId: Long) {
-        if (closedWebSocketId != activeWebSocketId) {
+        val accepted = synchronized(connectionLock) {
+            if (closedWebSocketId != activeWebSocketId || (!isOpen && webSocket == null)) {
+                false
+            } else {
+                isOpen = false
+                heartbeatJob?.cancel()
+                heartbeatJob = null
+                webSocket = null
+                if (code == 1000 && remote) {
+                    _sessionId = null
+                    _currentSeq = 0
+                }
+                true
+            }
+        }
+        if (!accepted) {
             Timber.tag(TAG).i(
                 "handleClose: ignoring stale WS close (closedId=%d, activeId=%d, code=%d)",
                 closedWebSocketId, activeWebSocketId, code,
             )
             return
         }
-        if (!isOpen && webSocket == null) {
-            return
-        }
-        isOpen = false
-        heartbeatJob?.cancel()
-        heartbeatJob = null
-        webSocket = null
-
-        _events.emit(GatewayEvent.Disconnected(code, reason, remote))
 
         if (code == 1000 && remote) {
             Timber.tag(TAG).d("handleClose: clean remote close (code=1000), resetting session")
-            _sessionId = null
-            _currentSeq = 0
-            return
         }
-
-        val action = DiscordReconnectStrategy.decide(
-            closeCode = code,
-            hadSession = _sessionId != null,
-            seq = _currentSeq,
-            sessionId = _sessionId,
-        )
-        Timber.tag(TAG).i("handleClose: strategy=%s for closeCode=%d", action::class.simpleName, code)
-
-        when (action) {
-            is ReconnectAction.SurfaceFatal -> {
-                Timber.tag(TAG).w("SurfaceFatal for closeCode=%d, giving up", code)
-                _sessionId = null
-                _currentSeq = 0
-            }
-            is ReconnectAction.RefreshAndReIdentify -> {
-                Timber.tag(TAG).w("RefreshAndReIdentify for closeCode=%d, delegating to manager", code)
-                _events.emit(GatewayEvent.RefreshToken)
-            }
-            is ReconnectAction.Resume,
-            is ReconnectAction.ReIdentify -> {
-                if (reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
-                    Timber.tag(TAG).w("max reconnect attempts reached (%d), giving up", MAX_RECONNECT_ATTEMPTS)
-                    _events.emit(
-                        GatewayEvent.Disconnected(4000, "max reconnect attempts", remote = false),
-                    )
-                    return
-                }
-                reconnectAttempts++
-                val delay = if (code == 429) {
-                    val retryAfter = parseRetryAfter(reason)
-                    retryAfter.coerceAtLeast(60_000L)
-                } else {
-                    reconnectDelayMs(reconnectAttempts)
-                }
-                Timber.tag(TAG).i("handleClose: reconnecting in %dms (attempt %d, code=%d)", delay, reconnectAttempts, code)
-                delay(delay)
-                performReconnect(action)
-            }
-        }
+        _events.emit(GatewayEvent.Disconnected(closedWebSocketId, code, reason, remote))
     }
 
-    private suspend fun performReconnect(action: ReconnectAction) {
-        try {
-            connect()
-        } catch (e: Throwable) {
-            Timber.tag(TAG).e(e, "performReconnect: connect failed")
-            return
-        }
-
-        when (action) {
-            is ReconnectAction.Resume -> {
-                try {
-                    val token = tokenProvider()
-                    resume(action.sessionId, action.seq, token)
-                } catch (e: Throwable) {
-                    Timber.tag(TAG).e(e, "performReconnect: resume failed")
-                    webSocket?.close(1011, "resume failed")
-                }
-            }
-            is ReconnectAction.ReIdentify -> {
-                try {
-                    val token = tokenProvider()
-                    identify(token)
-                } catch (e: Throwable) {
-                    Timber.tag(TAG).e(e, "performReconnect: identify failed")
-                    webSocket?.close(1011, "identify failed")
-                }
-            }
-            is ReconnectAction.SurfaceFatal -> {}
-            is ReconnectAction.RefreshAndReIdentify -> {}
-        }
-    }
-
-    private fun startHeartbeat(intervalMs: Long) {
-        heartbeatJob?.cancel()
+    private fun startHeartbeat(intervalMs: Long, connectionId: Long) {
         val jittered = applyJitter(intervalMs, JITTER_RATIO)
         Timber.tag(TAG).i("startHeartbeat: interval=%dms, jittered=%dms", intervalMs, jittered)
-        lastAckAtMs.set(System.currentTimeMillis())
-        heartbeatJob = externalScope.launch {
+        val newJob = externalScope.launch(start = CoroutineStart.LAZY) {
             var lastSentAt = System.currentTimeMillis()
-            while (isActive && isOpen) {
+            while (isActive && isOpen && connectionId == activeWebSocketId) {
                 delay(jittered)
-                if (!isActive || !isOpen) break
+                if (!isActive || !isOpen || connectionId != activeWebSocketId) break
                 val lastAck = lastAckAtMs.get()
                 if (lastAck < lastSentAt) {
                     Timber.tag(TAG).w("heartbeat: no ACK in %d ms, closing with 4000", jittered)
-                    webSocket?.close(4000, "heartbeat timeout")
+                    close(connectionId, 4000, "heartbeat timeout")
                     break
                 }
                 lastSentAt = System.currentTimeMillis()
-                runCatching { heartbeat(_currentSeq) }
+                runCatching { heartbeat(_currentSeq, connectionId) }
                     .onFailure { Timber.tag(TAG).w(it, "heartbeat: send failed") }
             }
         }
+        synchronized(connectionLock) {
+            if (connectionId != activeWebSocketId || !isOpen) {
+                newJob.cancel()
+                return
+            }
+            heartbeatJob?.cancel()
+            lastAckAtMs.set(System.currentTimeMillis())
+            heartbeatJob = newJob
+            newJob.start()
+        }
+    }
+
+    private fun close(connectionId: Long, code: Int, reason: String) {
+        val ws = synchronized(connectionLock) {
+            if (connectionId == activeWebSocketId) webSocket else null
+        } ?: return
+        runCatching { ws.close(code, reason) }
+    }
+
+    private fun invalidateAttempt(connectionId: Long, ws: WebSocket?) {
+        synchronized(connectionLock) {
+            if (connectionId != activeWebSocketId) return
+            if (ws == null || webSocket === ws) {
+                webSocket = null
+            }
+            heartbeatJob?.cancel()
+            heartbeatJob = null
+            isOpen = false
+            activeWebSocketId = webSocketIdCounter.incrementAndGet()
+        }
+    }
+
+    private fun isActiveConnection(connectionId: Long): Boolean = synchronized(connectionLock) {
+        connectionId == activeWebSocketId
+    }
+
+    private fun isOpenConnection(connectionId: Long): Boolean = synchronized(connectionLock) {
+        connectionId == activeWebSocketId && isOpen
     }
 
     private fun buildIdentifyFrame(token: String): String {
@@ -463,21 +587,6 @@ class DiscordGateway(
         return root.toString()
     }
 
-    private fun reconnectDelayMs(attempt: Int): Long {
-        val base = (RECONNECT_BASE_DELAY_MS * (1L shl (attempt - 1)))
-            .coerceAtMost(RECONNECT_MAX_DELAY_MS)
-        return applyJitter(base, 0.25)
-    }
-
-    private fun parseRetryAfter(reason: String): Long {
-        val prefix = ";retry_after="
-        val idx = reason.indexOf(prefix)
-        if (idx < 0) return 60_000L
-        val value = reason.substring(idx + prefix.length).trim()
-        val seconds = value.substringBefore(';').substringBefore(',').toDoubleOrNull()
-        return if (seconds != null) (seconds * 1000.0).toLong().coerceAtLeast(60_000L) else 60_000L
-    }
-
     private fun applyJitter(intervalMs: Long, ratio: Double): Long {
         if (intervalMs <= 0L) return intervalMs
         val delta = (intervalMs * ratio).toLong()
@@ -493,9 +602,7 @@ class DiscordGateway(
         private const val DEFAULT_GATEWAY_URL = "wss://gateway.discord.gg/?v=10&encoding=json"
         private const val DEFAULT_HEARTBEAT_MS = 41250L
         private const val JITTER_RATIO = 0.05
-        private const val MAX_RECONNECT_ATTEMPTS = 7
-        private const val RECONNECT_BASE_DELAY_MS = 1000L
-        private const val RECONNECT_MAX_DELAY_MS = 64_000L
+        private const val HANDSHAKE_TIMEOUT_MS = 20_000L
 
         private const val DISPATCH = 0
         private const val HEARTBEAT = 1

--- a/app/src/main/kotlin/com/metrolist/music/discord/DiscordGateway.kt
+++ b/app/src/main/kotlin/com/metrolist/music/discord/DiscordGateway.kt
@@ -493,12 +493,15 @@ class DiscordGateway(
         val jittered = applyJitter(intervalMs, JITTER_RATIO)
         Timber.tag(TAG).i("startHeartbeat: interval=%dms, jittered=%dms", intervalMs, jittered)
         val newJob = externalScope.launch(start = CoroutineStart.LAZY) {
-            var lastSentAt = System.currentTimeMillis()
+            // Stays 0 until the first heartbeat is actually sent: the liveness check below
+            // compares against the last heartbeat we sent, and on the first tick we haven't
+            // sent one yet, so there is no ACK to wait for.
+            var lastSentAt = 0L
             while (isActive && isOpen && connectionId == activeWebSocketId) {
                 delay(jittered)
                 if (!isActive || !isOpen || connectionId != activeWebSocketId) break
                 val lastAck = lastAckAtMs.get()
-                if (lastAck < lastSentAt) {
+                if (lastSentAt > 0L && lastAck < lastSentAt) {
                     Timber.tag(TAG).w("heartbeat: no ACK in %d ms, closing with 4000", jittered)
                     close(connectionId, 4000, "heartbeat timeout")
                     break

--- a/app/src/main/kotlin/com/metrolist/music/discord/DiscordReconnectStrategy.kt
+++ b/app/src/main/kotlin/com/metrolist/music/discord/DiscordReconnectStrategy.kt
@@ -1,6 +1,8 @@
 package com.metrolist.music.discord
 
 import timber.log.Timber
+import kotlin.math.abs
+import kotlin.random.Random
 
 sealed interface ReconnectAction {
     data class Resume(val sessionId: String, val seq: Int) : ReconnectAction
@@ -11,6 +13,9 @@ sealed interface ReconnectAction {
 
 object DiscordReconnectStrategy {
     private const val TAG = "DiscordSvc"
+    private const val RECONNECT_BASE_DELAY_MS = 1000L
+    private const val RECONNECT_MAX_DELAY_MS = 64_000L
+    private const val MIN_RATE_LIMIT_DELAY_MS = 60_000L
 
     fun decide(
         closeCode: Int,
@@ -38,5 +43,36 @@ object DiscordReconnectStrategy {
             closeCode, hadSession, seq, action::class.simpleName,
         )
         return action
+    }
+
+    fun backoffDelayMs(attempt: Int, closeCode: Int, reason: String): Long {
+        if (closeCode == 429) {
+            return parseRetryAfter(reason).coerceAtLeast(MIN_RATE_LIMIT_DELAY_MS)
+        }
+        val base = (RECONNECT_BASE_DELAY_MS * (1L shl (attempt - 1)))
+            .coerceAtMost(RECONNECT_MAX_DELAY_MS)
+        return applyJitter(base, 0.25)
+    }
+
+    private fun parseRetryAfter(reason: String): Long {
+        val prefix = ";retry_after="
+        val index = reason.indexOf(prefix)
+        if (index < 0) return MIN_RATE_LIMIT_DELAY_MS
+        val value = reason.substring(index + prefix.length).trim()
+        val seconds = value.substringBefore(';').substringBefore(',').toDoubleOrNull()
+        return if (seconds != null) {
+            (seconds * 1000.0).toLong().coerceAtLeast(MIN_RATE_LIMIT_DELAY_MS)
+        } else {
+            MIN_RATE_LIMIT_DELAY_MS
+        }
+    }
+
+    private fun applyJitter(intervalMs: Long, ratio: Double): Long {
+        if (intervalMs <= 0L) return intervalMs
+        val delta = (intervalMs * ratio).toLong()
+        if (delta <= 0L) return intervalMs
+        val offset = abs(Random.nextLong(delta + 1))
+        val sign = if (Random.nextBoolean()) -1L else 1L
+        return intervalMs + sign * offset
     }
 }

--- a/app/src/main/kotlin/com/metrolist/music/discord/DiscordRpcManager.kt
+++ b/app/src/main/kotlin/com/metrolist/music/discord/DiscordRpcManager.kt
@@ -30,16 +30,26 @@ data class DiscordUser(
     val avatar: String?,
 )
 
+internal sealed interface ConnectionIntent {
+    data object EnsureConnected : ConnectionIntent
+    data class Resume(val sessionId: String, val sequence: Int) : ConnectionIntent
+    data object Identify : ConnectionIntent
+    data object ForceRefreshAndIdentify : ConnectionIntent
+}
+
+internal fun intentPriority(intent: ConnectionIntent): Int = when (intent) {
+    ConnectionIntent.EnsureConnected -> 0
+    is ConnectionIntent.Resume -> 1
+    ConnectionIntent.Identify -> 2
+    ConnectionIntent.ForceRefreshAndIdentify -> 3
+}
+
+internal fun mergeIntents(current: ConnectionIntent, incoming: ConnectionIntent): ConnectionIntent =
+    if (intentPriority(incoming) >= intentPriority(current)) incoming else current
+
 object DiscordRpcManager {
     private const val TAG = "DiscordSvc"
     private const val MAX_RECONNECT_ATTEMPTS = 7
-
-    private sealed interface ConnectionIntent {
-        data object EnsureConnected : ConnectionIntent
-        data class Resume(val sessionId: String, val sequence: Int) : ConnectionIntent
-        data object Identify : ConnectionIntent
-        data object ForceRefreshAndIdentify : ConnectionIntent
-    }
 
     private data class PendingConnectionRequest(
         var intent: ConnectionIntent,
@@ -937,16 +947,6 @@ object DiscordRpcManager {
             publishConnectionFailure(expectedEpoch, error)
         }
     }
-
-    private fun intentPriority(intent: ConnectionIntent): Int = when (intent) {
-        ConnectionIntent.EnsureConnected -> 0
-        is ConnectionIntent.Resume -> 1
-        ConnectionIntent.Identify -> 2
-        ConnectionIntent.ForceRefreshAndIdentify -> 3
-    }
-
-    private fun mergeIntents(current: ConnectionIntent, incoming: ConnectionIntent): ConnectionIntent =
-        if (intentPriority(incoming) >= intentPriority(current)) incoming else current
 
     fun disconnect() {
         Timber.tag(TAG).i("disconnect: closing gateway, clearing ready/authorized")

--- a/app/src/main/kotlin/com/metrolist/music/discord/DiscordRpcManager.kt
+++ b/app/src/main/kotlin/com/metrolist/music/discord/DiscordRpcManager.kt
@@ -2,17 +2,21 @@ package com.metrolist.music.discord
 
 import android.app.Activity
 import android.content.Context
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import org.json.JSONObject
 import timber.log.Timber
 import java.net.HttpURLConnection
@@ -28,6 +32,19 @@ data class DiscordUser(
 
 object DiscordRpcManager {
     private const val TAG = "DiscordSvc"
+    private const val MAX_RECONNECT_ATTEMPTS = 7
+
+    private sealed interface ConnectionIntent {
+        data object EnsureConnected : ConnectionIntent
+        data class Resume(val sessionId: String, val sequence: Int) : ConnectionIntent
+        data object Identify : ConnectionIntent
+        data object ForceRefreshAndIdentify : ConnectionIntent
+    }
+
+    private data class PendingConnectionRequest(
+        var intent: ConnectionIntent,
+        val completions: MutableList<CompletableDeferred<Boolean>> = mutableListOf(),
+    )
 
     @Volatile
     private var initialized: Boolean = false
@@ -52,10 +69,23 @@ object DiscordRpcManager {
 
     @Volatile private var currentSongId: String? = null
     @Volatile private var currentIsPlaying: Boolean = false
+    @Volatile private var lastForcedRefreshAtMs: Long = 0L
     private val currentActivityId = AtomicLong(0L)
     @Volatile private var imageResolutionJob: Job? = null
     @Volatile private var currentActivityHadImages: Boolean = false
-    private val reconnectMutex = Mutex()
+
+    // Every connection lifecycle mutation is serialized through this state and its single worker.
+    private val coordinatorLock = Any()
+    private var pendingConnectionRequest: PendingConnectionRequest? = null
+    private var activeConnectionIntent: ConnectionIntent? = null
+    private var coordinatorJob: Job? = null
+    private var retryJob: Job? = null
+    private var reconnectAttempts: Int = 0
+    private var retryExhausted: Boolean = false
+    private var connectionEpoch: Long = 0L
+    private var currentGatewayConnectionId: Long? = null
+    private var forceRefreshRequired: Boolean = false
+    private var terminalGatewayFailure: Boolean = false
 
     private val _accessTokenFlow = MutableStateFlow<String?>(null)
     val accessTokenFlow: StateFlow<String?> = _accessTokenFlow
@@ -122,7 +152,6 @@ object DiscordRpcManager {
     private fun createGateway(scope: CoroutineScope): DiscordGateway =
         DiscordGateway(
             appId = appId,
-            tokenProvider = { "Bearer ${accessToken ?: ""}" },
             externalScope = scope,
         )
 
@@ -152,7 +181,7 @@ object DiscordRpcManager {
             val saved = DiscordTokenStore.retrieveSuspend()
             if (!saved.isNullOrEmpty()) {
                 Timber.tag(TAG).i("init: found persisted token, reconnecting")
-                reconnectWithToken(saved)
+                reconnect()
             } else {
                 Timber.tag(TAG).i("init: no persisted token, waiting for explicit authorize")
             }
@@ -180,7 +209,7 @@ object DiscordRpcManager {
         if (_authorized) {
             Timber.tag(TAG).d("authorize: short-circuit — authorized but not ready, reconnecting")
             authorizeInProgress = false
-            reconnectWithToken(accessToken ?: "")
+            reconnect()
             scope.launch(Dispatchers.Main) { onComplete(true) }
             return
         }
@@ -191,28 +220,13 @@ object DiscordRpcManager {
         scope.launch {
             try {
                 val result = auth.authorize(activity)
-                DiscordTokenStore.storeFull(
-                    result.accessToken,
-                    result.refreshToken,
-                    result.expiresInSec,
+                val connected = requestConnectionAndAwait(
+                    intent = ConnectionIntent.Identify,
+                    newAuthorization = result,
                 )
-                accessToken = result.accessToken
-                _accessTokenFlow.value = result.accessToken
-                _authorized = true
-
-                try {
-                    reconnectMutex.withLock {
-                        runCatching { gateway.close(4000, "re-authorizing") }
-                        gateway.connect()
-                        gateway.identify("Bearer ${result.accessToken}")
-                    }
+                if (connected) {
                     completeWith(true)
-                } catch (e: Throwable) {
-                    Timber.tag(TAG).e(e, "authorize: gateway connect/identify failed")
-                    _lastError.value = "discord_error_loopback_timeout"
-                    _connectionStatus.value = Status.Disconnected
-                    _ready = false
-                    _authorized = false
+                } else {
                     completeWith(false)
                 }
             } catch (e: DiscordAuthException.UserCancelled) {
@@ -240,6 +254,8 @@ object DiscordRpcManager {
                 _lastError.value = "discord_error_token_refresh_failed"
                 _connectionStatus.value = Status.Disconnected
                 completeWith(false)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Throwable) {
                 Timber.tag(TAG).e(e, "authorize: unexpected failure")
                 _lastError.value = "discord_error_loopback_timeout"
@@ -456,118 +472,487 @@ object DiscordRpcManager {
         }
     }
 
-    fun reconnectWithToken(token: String) {
+    fun reconnect(forceRefresh: Boolean = false) {
         if (!initialized) {
-            Timber.tag(TAG).w("reconnectWithToken: not initialized, ignoring")
+            Timber.tag(TAG).w("reconnect: not initialized, ignoring")
             return
         }
+        val intent = if (forceRefresh) {
+            ConnectionIntent.ForceRefreshAndIdentify
+        } else {
+            ConnectionIntent.EnsureConnected
+        }
+        requestConnection(intent)
+    }
 
-        scope.launch {
-            reconnectMutex.withLock {
-                accessToken = token
-                _accessTokenFlow.value = token
-                DiscordTokenStore.storeAccessToken(token)
+    private suspend fun requestConnectionAndAwait(
+        intent: ConnectionIntent,
+        newAuthorization: DiscordAuthResult? = null,
+    ): Boolean {
+        val completion = CompletableDeferred<Boolean>()
+        if (!requestConnection(intent, completion, newAuthorization = newAuthorization)) {
+            return false
+        }
+        return completion.await()
+    }
+
+    private fun requestConnection(
+        requestedIntent: ConnectionIntent,
+        completion: CompletableDeferred<Boolean>? = null,
+        newAuthorization: DiscordAuthResult? = null,
+        fromRetry: Boolean = false,
+        requiredEpoch: Long? = null,
+    ): Boolean {
+        var delayedRetryToCancel: Job? = null
+        val accepted = synchronized(coordinatorLock) {
+            if (!initialized || !scope.isActive) {
+                completion?.complete(false)
+                return@synchronized false
+            }
+            if (requiredEpoch != null &&
+                (connectionEpoch != requiredEpoch || _ready)
+            ) {
+                return@synchronized false
+            }
+
+            val hasNewAuthorization = newAuthorization != null
+            if (newAuthorization != null) {
+                connectionEpoch++
+                currentGatewayConnectionId = null
+                gateway.close(4000, "new authorization")
+                pendingConnectionRequest?.intent = requestedIntent
+                reconnectAttempts = 0
+                retryExhausted = false
+                forceRefreshRequired = false
+                terminalGatewayFailure = false
+                lastForcedRefreshAtMs = 0L
+                accessToken = newAuthorization.accessToken
+                _accessTokenFlow.value = newAuthorization.accessToken
+                DiscordTokenStore.storeFull(
+                    newAuthorization.accessToken,
+                    newAuthorization.refreshToken,
+                    newAuthorization.expiresInSec,
+                )
+                _authorized = true
+                _ready = false
                 _connectionStatus.value = Status.Authorizing
-                try {
-                    val refreshToken = DiscordTokenStore.getRefreshToken()
-                    val expiresAt = DiscordTokenStore.getExpiresAt()
-                    val nowSec = System.currentTimeMillis() / 1000L
-                    val needsRefresh = !refreshToken.isNullOrEmpty() &&
-                        expiresAt > 0L &&
-                        (expiresAt - nowSec) < 3600L
+            }
 
-                    Timber.tag(TAG).i(
-                        "reconnectWithToken: hasRefreshToken=%s, expiresAt=%d, now=%d, needsRefresh=%s",
-                        !refreshToken.isNullOrEmpty(),
-                        expiresAt,
-                        nowSec,
-                        needsRefresh,
-                    )
+            var intent = requestedIntent
+            if (intent is ConnectionIntent.ForceRefreshAndIdentify) {
+                forceRefreshRequired = true
+            } else if (intent is ConnectionIntent.EnsureConnected && forceRefreshRequired) {
+                intent = ConnectionIntent.ForceRefreshAndIdentify
+            }
 
-                    if (needsRefresh) {
-                        Timber.tag(TAG).i("reconnectWithToken: proactive token refresh")
-                        val refreshed = try {
-                            auth.refresh(refreshToken)
-                        } catch (e: DiscordAuthException.InvalidGrant) {
-                            Timber.tag(TAG).w(e, "reconnectWithToken: refresh invalid_grant, logging out")
-                            _lastError.value = "discord_error_token_refresh_failed"
-                            logout()
-                            return@withLock
-                        } catch (e: Throwable) {
-                            Timber.tag(TAG).w(e, "reconnectWithToken: refresh failed, continuing with old token")
-                            null
-                        }
-                        if (refreshed != null) {
-                            Timber.tag(TAG).i(
-                                "reconnectWithToken: refresh succeeded (new token length=%d, expiresIn=%d)",
-                                refreshed.accessToken.length,
-                                refreshed.expiresInSec,
-                            )
-                            accessToken = refreshed.accessToken
-                            _accessTokenFlow.value = refreshed.accessToken
-                            DiscordTokenStore.storeFull(
-                                refreshed.accessToken,
-                                refreshed.refreshToken,
-                                refreshed.expiresInSec,
-                            )
-                        }
+            if (terminalGatewayFailure && !hasNewAuthorization) {
+                Timber.tag(TAG).w("requestConnection: ignoring reconnect after terminal close")
+                completion?.complete(false)
+                return@synchronized false
+            }
+            if (intent is ConnectionIntent.EnsureConnected && _ready) {
+                completion?.complete(true)
+                return@synchronized true
+            }
+            if (intent is ConnectionIntent.EnsureConnected &&
+                currentGatewayConnectionId != null &&
+                _connectionStatus.value == Status.Authorizing
+            ) {
+                Timber.tag(TAG).d("requestConnection: coalescing with gateway authentication")
+                completion?.complete(true)
+                return@synchronized true
+            }
+
+            val supersedesDelay = hasNewAuthorization ||
+                intent is ConnectionIntent.ForceRefreshAndIdentify
+            if (retryJob?.isActive == true) {
+                if (!supersedesDelay) {
+                    Timber.tag(TAG).d("requestConnection: coalescing with scheduled retry")
+                    completion?.complete(false)
+                    return@synchronized true
+                }
+                delayedRetryToCancel = retryJob
+                retryJob = null
+            }
+
+            if (intent is ConnectionIntent.EnsureConnected &&
+                retryExhausted &&
+                !fromRetry &&
+                activeConnectionIntent == null &&
+                pendingConnectionRequest == null
+            ) {
+                Timber.tag(TAG).i("requestConnection: re-arming exhausted reconnect ladder")
+                reconnectAttempts = 0
+                retryExhausted = false
+            }
+
+            if (!hasNewAuthorization &&
+                completion == null &&
+                activeConnectionIntent != null &&
+                intentPriority(activeConnectionIntent!!) >= intentPriority(intent)
+            ) {
+                Timber.tag(TAG).d("requestConnection: coalescing with active %s", activeConnectionIntent)
+                return@synchronized true
+            }
+
+            val pending = pendingConnectionRequest
+            if (pending == null) {
+                pendingConnectionRequest = PendingConnectionRequest(
+                    intent = intent,
+                    completions = completion?.let { mutableListOf(it) } ?: mutableListOf(),
+                )
+            } else {
+                pending.intent = mergeIntents(pending.intent, intent)
+                if (completion != null) pending.completions += completion
+            }
+            startCoordinatorLocked()
+            true
+        }
+        delayedRetryToCancel?.cancel()
+        return accepted
+    }
+
+    private fun startCoordinatorLocked() {
+        if (pendingConnectionRequest == null || coordinatorJob?.isActive == true) return
+        val job = scope.launch(start = CoroutineStart.LAZY) {
+            runConnectionCoordinator()
+        }
+        coordinatorJob = job
+        job.start()
+    }
+
+    private suspend fun runConnectionCoordinator() {
+        val workerJob = currentCoroutineContext()[Job] ?: return
+        try {
+            while (currentCoroutineContext().isActive) {
+                val request = synchronized(coordinatorLock) {
+                    if (coordinatorJob !== workerJob) return
+                    val next = pendingConnectionRequest
+                    if (next == null) {
+                        activeConnectionIntent = null
+                        coordinatorJob = null
+                        return
                     }
+                    pendingConnectionRequest = null
+                    activeConnectionIntent = next.intent
+                    next
+                }
 
-                    runCatching { gateway.close(4000, "reconnecting") }
-                    gateway.connect()
-                    gateway.identify("Bearer ${accessToken ?: token}")
+                val success = try {
+                    processConnectionIntent(request.intent)
+                } catch (e: CancellationException) {
+                    request.completions.forEach { it.complete(false) }
+                    throw e
                 } catch (e: Throwable) {
-                    Timber.tag(TAG).e(e, "reconnectWithToken: connect/identify failed")
-                    _lastError.value = "discord_error_loopback_timeout"
-                    _connectionStatus.value = Status.Disconnected
+                    Timber.tag(TAG).e(e, "connection coordinator: unexpected failure")
+                    false
+                }
+                val currentSuccess = synchronized(coordinatorLock) {
+                    success &&
+                        coordinatorJob === workerJob &&
+                        currentGatewayConnectionId != null
+                }
+                request.completions.forEach { it.complete(currentSuccess) }
+                synchronized(coordinatorLock) {
+                    if (coordinatorJob === workerJob) {
+                        activeConnectionIntent = null
+                    }
+                }
+            }
+        } finally {
+            synchronized(coordinatorLock) {
+                if (coordinatorJob === workerJob) {
+                    coordinatorJob = null
+                    activeConnectionIntent = null
+                    startCoordinatorLocked()
                 }
             }
         }
     }
 
-    private suspend fun refreshAndReconnect() {
+    private suspend fun processConnectionIntent(intent: ConnectionIntent): Boolean {
+        val initialEpoch = synchronized(coordinatorLock) {
+            if (terminalGatewayFailure) return false
+            connectionEpoch
+        }
+        val forceRefresh = intent is ConnectionIntent.ForceRefreshAndIdentify
+        val token = resolveConnectionToken(forceRefresh, initialEpoch) ?: return false
+        currentCoroutineContext().ensureActive()
+
+        val establishIntent = when (intent) {
+            is ConnectionIntent.Resume -> intent
+            ConnectionIntent.EnsureConnected,
+            ConnectionIntent.Identify,
+            ConnectionIntent.ForceRefreshAndIdentify -> ConnectionIntent.Identify
+        }
+
+        var attemptEpoch: Long? = null
+        return try {
+            val currentAttemptEpoch = beginEstablish(initialEpoch) ?: throw GatewaySupersededException()
+            attemptEpoch = currentAttemptEpoch
+            if (establishIntent is ConnectionIntent.Identify) {
+                gateway.invalidateSession()
+            }
+            gateway.close(4000, "reconnecting")
+            ensureCurrentEpoch(currentAttemptEpoch)
+
+            val connectionId = gateway.connect { createdConnectionId ->
+                // Register before opening so an immediate close cannot outrun connect()'s return.
+                synchronized(coordinatorLock) {
+                    if (connectionEpoch != currentAttemptEpoch) throw GatewaySupersededException()
+                    currentGatewayConnectionId = createdConnectionId
+                }
+            }
+            ensureCurrentEpoch(currentAttemptEpoch)
+            synchronized(coordinatorLock) {
+                if (connectionEpoch != currentAttemptEpoch ||
+                    currentGatewayConnectionId != connectionId
+                ) {
+                    throw GatewaySupersededException()
+                }
+            }
+
+            when (establishIntent) {
+                is ConnectionIntent.Resume -> gateway.resume(
+                    sessionId = establishIntent.sessionId,
+                    seq = establishIntent.sequence,
+                    token = "Bearer $token",
+                    connectionId = connectionId,
+                )
+                ConnectionIntent.Identify -> gateway.identify(
+                    token = "Bearer $token",
+                    connectionId = connectionId,
+                )
+                else -> error("Unsupported establish intent: $establishIntent")
+            }
+            ensureCurrentEpoch(currentAttemptEpoch)
+            true
+        } catch (e: GatewaySupersededException) {
+            Timber.tag(TAG).i("connection attempt superseded")
+            false
+        } catch (e: GatewayConnectionException) {
+            Timber.tag(TAG).w(e, "gateway connection failed before open")
+            val epoch = attemptEpoch
+            if (epoch != null && publishConnectionFailure(epoch, "discord_error_loopback_timeout")) {
+                scheduleRetry(establishIntent, e.statusCode, e.retryReason, epoch)
+            }
+            false
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            Timber.tag(TAG).e(e, "gateway connect/authenticate failed")
+            val epoch = attemptEpoch
+            if (epoch != null && publishConnectionFailure(epoch, "discord_error_loopback_timeout")) {
+                gateway.close(1011, "authentication send failed")
+                scheduleRetry(establishIntent, 4000, e.message ?: "failure", epoch)
+            }
+            false
+        }
+    }
+
+    private suspend fun resolveConnectionToken(forceRefresh: Boolean, expectedEpoch: Long): String? {
+        val storedToken = accessToken ?: DiscordTokenStore.retrieveSuspend()
+        if (!isCurrentEpoch(expectedEpoch)) return null
+        if (storedToken.isNullOrEmpty()) {
+            Timber.tag(TAG).w("resolveConnectionToken: no token available")
+            return null
+        }
+        synchronized(coordinatorLock) {
+            if (connectionEpoch != expectedEpoch) return null
+            accessToken = storedToken
+            _accessTokenFlow.value = storedToken
+        }
+
         val refreshToken = DiscordTokenStore.getRefreshToken()
+        val expiresAt = DiscordTokenStore.getExpiresAt()
+        val nowSec = System.currentTimeMillis() / 1000L
+        val needsRefresh = forceRefresh ||
+            (!refreshToken.isNullOrEmpty() && expiresAt > 0L && (expiresAt - nowSec) < 3600L)
+
+        Timber.tag(TAG).i(
+            "resolveConnectionToken: hasRefreshToken=%s, expiresAt=%d, now=%d, needsRefresh=%s, forced=%s",
+            !refreshToken.isNullOrEmpty(),
+            expiresAt,
+            nowSec,
+            needsRefresh,
+            forceRefresh,
+        )
+        if (!needsRefresh) return storedToken
+
         if (refreshToken.isNullOrEmpty()) {
-            Timber.tag(TAG).w("refreshAndReconnect: no refresh token available, logging out")
-            _lastError.value = "discord_error_token_refresh_failed"
-            logout()
-            return
+            Timber.tag(TAG).w("resolveConnectionToken: refresh needed but no refresh token")
+            performLogout("discord_error_token_refresh_failed")
+            return null
+        }
+
+        val now = System.currentTimeMillis()
+        synchronized(coordinatorLock) {
+            if (connectionEpoch != expectedEpoch) return null
+            if (forceRefresh && (now - lastForcedRefreshAtMs) < 60_000L) {
+                Timber.tag(TAG).w("resolveConnectionToken: forced refresh throttled")
+                _lastError.value = "discord_error_token_refresh_failed"
+                _connectionStatus.value = Status.Disconnected
+                return null
+            }
+            if (forceRefresh) lastForcedRefreshAtMs = now
         }
 
         val refreshed = try {
             auth.refresh(refreshToken)
         } catch (e: DiscordAuthException.InvalidGrant) {
-            Timber.tag(TAG).w(e, "refreshAndReconnect: refresh token rejected, logging out")
-            _lastError.value = "discord_error_token_refresh_failed"
-            logout()
-            return
+            if (isCurrentEpoch(expectedEpoch)) {
+                Timber.tag(TAG).w(e, "resolveConnectionToken: refresh token rejected")
+                performLogout("discord_error_token_refresh_failed")
+            }
+            return null
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Throwable) {
-            Timber.tag(TAG).e(e, "refreshAndReconnect: token refresh failed")
-            _lastError.value = "discord_error_token_refresh_failed"
-            return
+            Timber.tag(TAG).w(e, "resolveConnectionToken: token refresh failed")
+            null
         }
 
-        Timber.tag(TAG).i(
-            "refreshAndReconnect: refresh succeeded (token length=%d, expiresIn=%d), reconnecting",
-            refreshed.accessToken.length,
-            refreshed.expiresInSec,
-        )
-        DiscordTokenStore.storeFull(
-            refreshed.accessToken,
-            refreshed.refreshToken,
-            refreshed.expiresInSec,
-        )
-        reconnectWithToken(refreshed.accessToken)
+        if (!isCurrentEpoch(expectedEpoch)) return null
+        if (refreshed == null) {
+            if (forceRefresh) {
+                synchronized(coordinatorLock) {
+                    if (connectionEpoch != expectedEpoch) return null
+                    _lastError.value = "discord_error_token_refresh_failed"
+                    _connectionStatus.value = Status.Disconnected
+                }
+                return null
+            }
+            return storedToken
+        }
+
+        synchronized(coordinatorLock) {
+            if (connectionEpoch != expectedEpoch) return null
+            accessToken = refreshed.accessToken
+            _accessTokenFlow.value = refreshed.accessToken
+            DiscordTokenStore.storeFull(
+                refreshed.accessToken,
+                refreshed.refreshToken,
+                refreshed.expiresInSec,
+            )
+            if (forceRefresh) forceRefreshRequired = false
+        }
+        return refreshed.accessToken
     }
+
+    private fun beginEstablish(expectedEpoch: Long): Long? = synchronized(coordinatorLock) {
+        if (!initialized || connectionEpoch != expectedEpoch) return@synchronized null
+        connectionEpoch++
+        currentGatewayConnectionId = null
+        _ready = false
+        _connectionStatus.value = Status.Authorizing
+        connectionEpoch
+    }
+
+    private suspend fun ensureCurrentEpoch(expectedEpoch: Long) {
+        currentCoroutineContext().ensureActive()
+        if (!isCurrentEpoch(expectedEpoch)) throw GatewaySupersededException()
+    }
+
+    private fun isCurrentEpoch(expectedEpoch: Long): Boolean = synchronized(coordinatorLock) {
+        initialized && connectionEpoch == expectedEpoch
+    }
+
+    private fun publishConnectionFailure(expectedEpoch: Long, error: String): Boolean =
+        synchronized(coordinatorLock) {
+            if (!initialized || connectionEpoch != expectedEpoch) return@synchronized false
+            currentGatewayConnectionId = null
+            _ready = false
+            _authorized = false
+            _lastError.value = error
+            _connectionStatus.value = Status.Disconnected
+            true
+        }
+
+    private fun scheduleRetry(
+        intent: ConnectionIntent,
+        closeCode: Int,
+        reason: String,
+        expectedEpoch: Long,
+    ) {
+        var exhausted = false
+        synchronized(coordinatorLock) {
+            if (!initialized || connectionEpoch != expectedEpoch || _ready || retryJob?.isActive == true) {
+                return
+            }
+            if (reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+                retryExhausted = true
+                exhausted = true
+                return@synchronized
+            }
+
+            reconnectAttempts++
+            val attempt = reconnectAttempts
+            val delayMs = DiscordReconnectStrategy.backoffDelayMs(attempt, closeCode, reason)
+            lateinit var scheduledJob: Job
+            scheduledJob = scope.launch(start = CoroutineStart.LAZY) {
+                try {
+                    delay(delayMs)
+                    val shouldRun = synchronized(coordinatorLock) {
+                        if (retryJob !== scheduledJob ||
+                            connectionEpoch != expectedEpoch ||
+                            _ready ||
+                            !initialized
+                        ) {
+                            false
+                        } else {
+                            retryJob = null
+                            true
+                        }
+                    }
+                    if (shouldRun) {
+                        requestConnection(
+                            requestedIntent = intent,
+                            fromRetry = true,
+                            requiredEpoch = expectedEpoch,
+                        )
+                    }
+                } finally {
+                    synchronized(coordinatorLock) {
+                        if (retryJob === scheduledJob) retryJob = null
+                    }
+                }
+            }
+            retryJob = scheduledJob
+            Timber.tag(TAG).i(
+                "scheduleRetry: retrying in %dms (attempt %d, code=%d, intent=%s)",
+                delayMs,
+                attempt,
+                closeCode,
+                intent,
+            )
+            scheduledJob.start()
+        }
+        if (exhausted) {
+            Timber.tag(TAG).w("scheduleRetry: max reconnect attempts reached")
+            val error = when (closeCode) {
+                4001, 4014 -> "discord_error_invalid_scope"
+                4004 -> "discord_error_token_refresh_failed"
+                else -> "discord_error_loopback_timeout"
+            }
+            publishConnectionFailure(expectedEpoch, error)
+        }
+    }
+
+    private fun intentPriority(intent: ConnectionIntent): Int = when (intent) {
+        ConnectionIntent.EnsureConnected -> 0
+        is ConnectionIntent.Resume -> 1
+        ConnectionIntent.Identify -> 2
+        ConnectionIntent.ForceRefreshAndIdentify -> 3
+    }
+
+    private fun mergeIntents(current: ConnectionIntent, incoming: ConnectionIntent): ConnectionIntent =
+        if (intentPriority(incoming) >= intentPriority(current)) incoming else current
 
     fun disconnect() {
         Timber.tag(TAG).i("disconnect: closing gateway, clearing ready/authorized")
+        cancelConnectionWork(closeReason = "user disconnect")
         currentActivityId.incrementAndGet()
         imageResolutionJob?.cancel()
-        runCatching { gateway.close(1000, "user disconnect") }
-        _connectionStatus.value = Status.Disconnected
-        _ready = false
-        _authorized = false
         currentSongId = null
         currentIsPlaying = false
         currentActivityHadImages = false
@@ -575,15 +960,15 @@ object DiscordRpcManager {
 
     fun destroy() {
         Timber.tag(TAG).i("destroy: cancelling scope and tearing down (initialized=%s)", initialized)
+        cancelConnectionWork(
+            closeReason = "destroy",
+            clearTerminalState = true,
+            deactivate = true,
+        )
         currentActivityId.incrementAndGet()
         imageResolutionJob?.cancel()
-        runCatching { gateway.close(1000, "destroy") }
         runCatching { gateway.closeHttp() }
         scope.cancel()
-        _ready = false
-        _authorized = false
-        initialized = false
-        _connectionStatus.value = Status.Disconnected
         lastActivity = null
         currentSongId = null
         currentIsPlaying = false
@@ -592,72 +977,214 @@ object DiscordRpcManager {
 
     fun logout() {
         Timber.tag(TAG).i("logout: clearing tokens and disconnecting")
-        disconnect()
-        accessToken = null
-        _accessTokenFlow.value = null
+        performLogout(null)
+    }
+
+    private fun performLogout(error: String?) {
+        cancelConnectionWork(
+            closeReason = "logout",
+            clearTerminalState = true,
+            clearCredentials = true,
+            connectionError = error,
+        )
+        currentActivityId.incrementAndGet()
+        imageResolutionJob?.cancel()
         _currentUser.value = null
-        DiscordTokenStore.clear()
-        DiscordSuperProperties.reset()
-        _lastError.value = null
         lastActivity = null
+        currentSongId = null
+        currentIsPlaying = false
         currentActivityHadImages = false
+    }
+
+    private fun cancelConnectionWork(
+        closeReason: String,
+        clearTerminalState: Boolean = false,
+        deactivate: Boolean = false,
+        clearCredentials: Boolean = false,
+        connectionError: String? = null,
+    ) {
+        val pendingCompletions: List<CompletableDeferred<Boolean>>
+        val worker: Job?
+        val delayedRetry: Job?
+        synchronized(coordinatorLock) {
+            connectionEpoch++
+            currentGatewayConnectionId = null
+            pendingCompletions = pendingConnectionRequest?.completions?.toList().orEmpty()
+            pendingConnectionRequest = null
+            activeConnectionIntent = null
+            worker = coordinatorJob
+            delayedRetry = retryJob
+            coordinatorJob = null
+            retryJob = null
+            _ready = false
+            _authorized = false
+            _connectionStatus.value = Status.Disconnected
+            if (deactivate) initialized = false
+            gateway.close(1000, closeReason)
+            if (clearTerminalState) {
+                terminalGatewayFailure = false
+                forceRefreshRequired = false
+                reconnectAttempts = 0
+                retryExhausted = false
+                lastForcedRefreshAtMs = 0L
+            }
+            if (clearCredentials) {
+                accessToken = null
+                _accessTokenFlow.value = null
+                DiscordTokenStore.clear()
+                DiscordSuperProperties.reset()
+                _lastError.value = connectionError
+            }
+        }
+        pendingCompletions.forEach { it.complete(false) }
+        delayedRetry?.cancel()
+        worker?.cancel()
     }
 
     private suspend fun handleGatewayEvent(event: GatewayEvent) {
         when (event) {
             is GatewayEvent.Ready -> {
+                var obsoleteRetry: Job? = null
+                val eventEpoch = synchronized(coordinatorLock) {
+                    if (event.connectionId != currentGatewayConnectionId) return
+                    reconnectAttempts = 0
+                    retryExhausted = false
+                    obsoleteRetry = retryJob
+                    retryJob = null
+                    _ready = true
+                    _authorized = true
+                    _connectionStatus.value = Status.Connected
+                    _lastError.value = null
+                    connectionEpoch
+                }
+                obsoleteRetry?.cancel()
                 Timber.tag(TAG).i("gateway: READY (sessionId prefix=%s)", event.sessionId.take(8))
-                _ready = true
-                _authorized = true
-                _connectionStatus.value = Status.Connected
-                _lastError.value = null
                 val token = accessToken ?: return
                 scope.launch {
                     val user = fetchCurrentUser(token)
-                    _currentUser.value = user
-                    if (user != null) {
+                    val current = synchronized(coordinatorLock) {
+                        connectionEpoch == eventEpoch &&
+                            currentGatewayConnectionId == event.connectionId &&
+                            _ready
+                    }
+                    if (current) {
+                        _currentUser.value = user
+                    }
+                    if (current && user != null) {
                         Timber.tag(TAG).i("gateway READY: fetched user %s", user.username)
                     }
                 }
             }
             is GatewayEvent.Resumed -> {
+                var obsoleteRetry: Job? = null
+                synchronized(coordinatorLock) {
+                    if (event.connectionId != currentGatewayConnectionId) return
+                    reconnectAttempts = 0
+                    retryExhausted = false
+                    obsoleteRetry = retryJob
+                    retryJob = null
+                    _ready = true
+                    _authorized = true
+                    _connectionStatus.value = Status.Connected
+                    _lastError.value = null
+                }
+                obsoleteRetry?.cancel()
                 Timber.tag(TAG).i("gateway: RESUMED")
-                _ready = true
-                _authorized = true
-                _connectionStatus.value = Status.Connected
-                _lastError.value = null
             }
             is GatewayEvent.Disconnected -> {
+                val action = if (event.code == 1000 && event.remote) {
+                    null
+                } else {
+                    DiscordReconnectStrategy.decide(
+                        closeCode = event.code,
+                        hadSession = gateway.sessionId != null,
+                        seq = gateway.currentSeq,
+                        sessionId = gateway.sessionId,
+                    )
+                }
+                val eventEpoch = synchronized(coordinatorLock) {
+                    if (event.connectionId != currentGatewayConnectionId) return
+                    currentGatewayConnectionId = null
+                    _ready = false
+                    _authorized = false
+                    _connectionStatus.value = Status.Disconnected
+                    when (action) {
+                        ReconnectAction.RefreshAndReIdentify -> forceRefreshRequired = true
+                        ReconnectAction.SurfaceFatal -> {
+                            terminalGatewayFailure = true
+                            _lastError.value = "discord_error_invalid_scope"
+                        }
+                        else -> Unit
+                    }
+                    connectionEpoch
+                }
                 Timber.tag(TAG).i("gateway: Disconnected (code=%d, remote=%s, reason=%s)",
                     event.code, event.remote, event.reason)
-                _ready = false
-                _authorized = false
-                _connectionStatus.value = Status.Disconnected
                 currentSongId = null
                 currentIsPlaying = false
                 imageResolutionJob?.cancel()
                 imageResolutionJob = null
-                if (event.code in setOf(4001, 4004) && event.reason.contains("max reconnect", ignoreCase = true)) {
-                    _lastError.value = when (event.code) {
-                        4004 -> "discord_error_token_refresh_failed"
-                        4001 -> "discord_error_invalid_scope"
-                        else -> _lastError.value
+
+                if (event.code == 1000 && event.remote) {
+                    invalidateGatewaySession(eventEpoch)
+                    return
+                }
+
+                val reconnectAction = checkNotNull(action)
+                Timber.tag(TAG).i(
+                    "gateway: reconnect strategy=%s for closeCode=%d",
+                    reconnectAction::class.simpleName,
+                    event.code,
+                )
+                when (reconnectAction) {
+                    is ReconnectAction.Resume -> scheduleRetry(
+                        intent = ConnectionIntent.Resume(reconnectAction.sessionId, reconnectAction.seq),
+                        closeCode = event.code,
+                        reason = event.reason,
+                        expectedEpoch = eventEpoch,
+                    )
+                    ReconnectAction.ReIdentify -> {
+                        invalidateGatewaySession(eventEpoch)
+                        scheduleRetry(
+                            intent = ConnectionIntent.Identify,
+                            closeCode = event.code,
+                            reason = event.reason,
+                            expectedEpoch = eventEpoch,
+                        )
+                    }
+                    ReconnectAction.RefreshAndReIdentify -> {
+                        invalidateGatewaySession(eventEpoch)
+                        requestConnection(
+                            requestedIntent = ConnectionIntent.ForceRefreshAndIdentify,
+                            requiredEpoch = eventEpoch,
+                        )
+                    }
+                    ReconnectAction.SurfaceFatal -> {
+                        invalidateGatewaySession(eventEpoch)
                     }
                 }
             }
             is GatewayEvent.InvalidSession -> {
+                val current = synchronized(coordinatorLock) {
+                    event.connectionId == currentGatewayConnectionId
+                }
+                if (!current) return
                 Timber.tag(TAG).w("gateway: InvalidSession (resumable=%s), closing WS to trigger reconnect", event.resumable)
                 imageResolutionJob?.cancel()
                 imageResolutionJob = null
-            }
-            is GatewayEvent.RefreshToken -> {
-                Timber.tag(TAG).w("gateway: RefreshToken requested, refreshing and reconnecting")
-                scope.launch { refreshAndReconnect() }
             }
             is GatewayEvent.Hello -> Unit
             is GatewayEvent.HeartbeatAck -> Unit
             is GatewayEvent.TextDispatch -> {
                 Timber.tag(TAG).v("gateway: TextDispatch op=%d t=%s", event.op, event.t)
+            }
+        }
+    }
+
+    private fun invalidateGatewaySession(expectedEpoch: Long) {
+        synchronized(coordinatorLock) {
+            if (connectionEpoch == expectedEpoch) {
+                gateway.invalidateSession()
             }
         }
     }

--- a/app/src/main/kotlin/com/metrolist/music/discord/DiscordTokenStore.kt
+++ b/app/src/main/kotlin/com/metrolist/music/discord/DiscordTokenStore.kt
@@ -106,17 +106,6 @@ object DiscordTokenStore {
         )
     }
 
-    fun storeAccessToken(accessToken: String) {
-        val encryptedToken = encrypt(accessToken) ?: run {
-            Timber.tag(TAG).w("tokenStore: encryption failed, not persisting access token")
-            return
-        }
-        prefs?.edit {
-            putString(TOKEN_KEY, encryptedToken)
-        }
-        Timber.tag(TAG).d("tokenStore: access token updated (length=%d)", accessToken.length)
-    }
-
     fun retrieve(): String? {
         val encrypted = prefs?.getString(TOKEN_KEY, null)
         val token = decrypt(encrypted)

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -1016,7 +1016,7 @@ class MusicService :
                                 Timber.tag("DiscordSvc").i("RPC toggle: initializing")
                                 DiscordRpcManager.init(this@MusicService)
                             }
-                            DiscordRpcManager.reconnectWithToken(DiscordRpcManager.getAccessToken()!!)
+                            DiscordRpcManager.reconnect()
                         }
                     } else {
                         Timber.tag("DiscordSvc").w("RPC toggle: enabled but no token and not ready")
@@ -1040,18 +1040,16 @@ class MusicService :
                     return@collectLatest
                 }
                 if (!discordRpcEnabled) {
-                    Timber.tag("DiscordSvc").i("Token change: RPC disabled, skipping reconnect")
+                    Timber.tag("DiscordSvc").i("Token change: RPC disabled, skipping")
                     return@collectLatest
                 }
+                // Never reconnect from here: every write to accessTokenFlow happens inside a flow
+                // that already establishes the connection itself (init/reconnect/refresh/authorize).
+                // Reacting with another reconnect created a feedback loop that killed each fresh
+                // connection before READY could arrive.
                 if (!DiscordRpcManager.isInitialized()) {
                     Timber.tag("DiscordSvc").i("Token change: initializing")
                     DiscordRpcManager.init(this@MusicService)
-                }
-                if (!DiscordRpcManager.isAuthorized()) {
-                    Timber.tag("DiscordSvc").i("Token change: reconnecting with token")
-                    DiscordRpcManager.reconnectWithToken(token)
-                } else {
-                    Timber.tag("DiscordSvc").i("Token change: already authorized, skipping reconnect")
                 }
             }
 
@@ -3432,7 +3430,7 @@ class MusicService :
                     if (!DiscordRpcManager.isInitialized()) {
                         DiscordRpcManager.init(this@MusicService)
                     }
-                    DiscordRpcManager.reconnectWithToken(token)
+                    DiscordRpcManager.reconnect()
                 }
             }
             return

--- a/app/src/test/kotlin/com/metrolist/music/discord/DiscordConnectionIntentTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/discord/DiscordConnectionIntentTest.kt
@@ -1,0 +1,55 @@
+package com.metrolist.music.discord
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DiscordConnectionIntentTest {
+
+    @Test
+    fun merge_forceRefreshCannotBeDowngradedByOrdinaryReconnect() {
+        assertEquals(
+            ConnectionIntent.ForceRefreshAndIdentify,
+            mergeIntents(
+                current = ConnectionIntent.ForceRefreshAndIdentify,
+                incoming = ConnectionIntent.EnsureConnected,
+            ),
+        )
+        assertEquals(
+            ConnectionIntent.ForceRefreshAndIdentify,
+            mergeIntents(
+                current = ConnectionIntent.EnsureConnected,
+                incoming = ConnectionIntent.ForceRefreshAndIdentify,
+            ),
+        )
+    }
+
+    @Test
+    fun merge_preservesHighestPriorityIntentRegardlessOfArrivalOrder() {
+        val intentsByPriority = listOf(
+            ConnectionIntent.EnsureConnected,
+            ConnectionIntent.Resume("session", 42),
+            ConnectionIntent.Identify,
+            ConnectionIntent.ForceRefreshAndIdentify,
+        )
+
+        intentsByPriority.forEachIndexed { lowerIndex, lower ->
+            intentsByPriority.drop(lowerIndex + 1).forEach { higher ->
+                assertEquals(higher, mergeIntents(lower, higher))
+                assertEquals(higher, mergeIntents(higher, lower))
+            }
+        }
+    }
+
+    @Test
+    fun merge_replacesResumeWithLatestSessionState() {
+        val latest = ConnectionIntent.Resume("new-session", 84)
+
+        assertEquals(
+            latest,
+            mergeIntents(
+                current = ConnectionIntent.Resume("old-session", 42),
+                incoming = latest,
+            ),
+        )
+    }
+}

--- a/app/src/test/kotlin/com/metrolist/music/discord/DiscordGatewayTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/discord/DiscordGatewayTest.kt
@@ -1,0 +1,398 @@
+package com.metrolist.music.discord
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.yield
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import okio.ByteString
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.IOException
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = android.app.Application::class)
+class DiscordGatewayTest {
+
+    private lateinit var scope: CoroutineScope
+    private lateinit var webSocketFactory: FakeWebSocketFactory
+    private lateinit var gateway: DiscordGateway
+
+    @Before
+    fun setUp() {
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        webSocketFactory = FakeWebSocketFactory()
+        gateway = DiscordGateway(
+            appId = "test-app",
+            externalScope = scope,
+            webSocketFactory = webSocketFactory,
+        )
+    }
+
+    @After
+    fun tearDown() {
+        gateway.closeHttp()
+        scope.cancel()
+    }
+
+    @Test
+    fun identifyAndResume_rejectSupersededConnection() = runBlocking {
+        val firstConnectionId = connectGateway()
+        val secondConnectionId = connectGateway()
+
+        try {
+            gateway.identify("Bearer stale", firstConnectionId)
+            fail("Expected the superseded connection to reject Identify")
+        } catch (_: GatewaySupersededException) {
+            // Expected.
+        }
+
+        gateway.resume(
+            sessionId = "session-abc",
+            seq = 42,
+            token = "Bearer current",
+            connectionId = secondConnectionId,
+        )
+
+        assertTrue(webSocketFactory.connection(0).webSocket.sentTextFrames.isEmpty())
+        val resumeFrame = JSONObject(webSocketFactory.connection(1).webSocket.sentTextFrames.single())
+        assertEquals(6, resumeFrame.getInt("op"))
+        assertEquals("session-abc", resumeFrame.getJSONObject("d").getString("session_id"))
+        assertEquals(42, resumeFrame.getJSONObject("d").getInt("seq"))
+    }
+
+    @Test
+    fun readyFromSupersededConnection_doesNotMutateSession() = runBlocking {
+        connectGateway()
+        val activeConnectionId = connectGateway()
+        val readyEvents = mutableListOf<GatewayEvent.Ready>()
+        val collection = launch(start = CoroutineStart.UNDISPATCHED) {
+            gateway.events.filterIsInstance<GatewayEvent.Ready>().collect {
+                readyEvents += it
+            }
+        }
+
+        webSocketFactory.message(
+            index = 0,
+            text = readyFrame("stale-session", "wss://stale.example"),
+        )
+        yield()
+        assertNull(gateway.sessionId)
+        assertTrue(readyEvents.isEmpty())
+
+        webSocketFactory.message(
+            index = 1,
+            text = readyFrame("active-session", "wss://active.example"),
+        )
+        yield()
+
+        assertEquals("active-session", gateway.sessionId)
+        assertEquals(
+            listOf(
+                GatewayEvent.Ready(
+                    connectionId = activeConnectionId,
+                    sessionId = "active-session",
+                    resumeGatewayUrl = "wss://active.example",
+                ),
+            ),
+            readyEvents,
+        )
+        collection.cancel()
+    }
+
+    @Test
+    fun stalePreOpenFailure_isReportedAsSuperseded() = runBlocking {
+        supervisorScope {
+            val firstConnect = async(start = CoroutineStart.UNDISPATCHED) { gateway.connect() }
+            val secondConnect = async(start = CoroutineStart.UNDISPATCHED) { gateway.connect() }
+
+            webSocketFactory.fail(
+                index = 0,
+                throwable = IOException("old socket failed"),
+            )
+            try {
+                firstConnect.await()
+                fail("Expected the stale attempt to be superseded")
+            } catch (_: GatewaySupersededException) {
+                // Expected.
+            }
+
+            webSocketFactory.open(1)
+            assertEquals(2L, secondConnect.await())
+        }
+    }
+
+    @Test
+    fun activePreOpenFailure_preservesRateLimitMetadata() = runBlocking {
+        supervisorScope {
+            val connect = async(start = CoroutineStart.UNDISPATCHED) { gateway.connect() }
+
+            webSocketFactory.fail(
+                index = 0,
+                throwable = IOException("rate limited"),
+                statusCode = 429,
+                retryAfter = "75.5",
+            )
+
+            try {
+                connect.await()
+                fail("Expected the connection attempt to fail")
+            } catch (e: GatewayConnectionException) {
+                assertEquals(429, e.statusCode)
+                assertEquals("75.5", e.retryAfter)
+                assertTrue(e.retryReason.contains("retry_after=75.5"))
+            }
+        }
+    }
+
+    @Test
+    fun activeUnexpectedClose_emitsSingleDisconnectedEvent() = runBlocking {
+        val connectionId = connectGateway()
+        val disconnected = mutableListOf<GatewayEvent.Disconnected>()
+        val collection = launch(start = CoroutineStart.UNDISPATCHED) {
+            gateway.events.filterIsInstance<GatewayEvent.Disconnected>().collect {
+                disconnected += it
+            }
+        }
+
+        webSocketFactory.closeFromServer(0, 4000, "gateway restart")
+        webSocketFactory.closeFromServer(0, 4000, "duplicate callback")
+        yield()
+
+        assertEquals(
+            listOf(
+                GatewayEvent.Disconnected(
+                    connectionId = connectionId,
+                    code = 4000,
+                    reason = "gateway restart",
+                    remote = true,
+                ),
+            ),
+            disconnected,
+        )
+        assertEquals(1, webSocketFactory.connectionCount)
+        collection.cancel()
+    }
+
+    @Test
+    fun postOpenFailureFromSupersededConnection_doesNotEmitDisconnected() = runBlocking {
+        connectGateway()
+        val activeConnectionId = connectGateway()
+        val disconnected = mutableListOf<GatewayEvent.Disconnected>()
+        val collection = launch(start = CoroutineStart.UNDISPATCHED) {
+            gateway.events.filterIsInstance<GatewayEvent.Disconnected>().collect {
+                disconnected += it
+            }
+        }
+
+        webSocketFactory.fail(
+            index = 0,
+            throwable = IOException("old socket failed"),
+        )
+        yield()
+        assertTrue(disconnected.isEmpty())
+
+        webSocketFactory.closeFromServer(1, 4000, "active socket failed")
+        yield()
+        assertEquals(
+            listOf(
+                GatewayEvent.Disconnected(
+                    connectionId = activeConnectionId,
+                    code = 4000,
+                    reason = "active socket failed",
+                    remote = true,
+                ),
+            ),
+            disconnected,
+        )
+        collection.cancel()
+    }
+
+    @Test
+    fun cleanRemoteClose_resetsSessionAndEmitsDisconnected() = runBlocking {
+        val connectionId = connectGateway()
+        webSocketFactory.message(
+            index = 0,
+            text = readyFrame("session-abc", "wss://resume.example"),
+        )
+        val disconnected = mutableListOf<GatewayEvent.Disconnected>()
+        val collection = launch(start = CoroutineStart.UNDISPATCHED) {
+            gateway.events.filterIsInstance<GatewayEvent.Disconnected>().collect {
+                disconnected += it
+            }
+        }
+
+        webSocketFactory.closeFromServer(0, 1000, "normal closure")
+        yield()
+
+        assertNull(gateway.sessionId)
+        assertEquals(0, gateway.currentSeq)
+        assertEquals(
+            listOf(
+                GatewayEvent.Disconnected(
+                    connectionId = connectionId,
+                    code = 1000,
+                    reason = "normal closure",
+                    remote = true,
+                ),
+            ),
+            disconnected,
+        )
+        assertEquals(1, webSocketFactory.connectionCount)
+        collection.cancel()
+    }
+
+    @Test
+    fun intentionalClose_invalidatesCallbackWithoutEmittingDisconnected() = runBlocking {
+        connectGateway()
+        val disconnected = mutableListOf<GatewayEvent.Disconnected>()
+        val collection = launch(start = CoroutineStart.UNDISPATCHED) {
+            gateway.events.filterIsInstance<GatewayEvent.Disconnected>().collect {
+                disconnected += it
+            }
+        }
+
+        gateway.close(1000, "manager disconnect")
+        webSocketFactory.closeFromServer(0, 1000, "manager disconnect")
+        yield()
+
+        assertTrue(webSocketFactory.connection(0).webSocket.closeRequested)
+        assertTrue(disconnected.isEmpty())
+        collection.cancel()
+    }
+
+    private suspend fun connectGateway(): Long = coroutineScope {
+        val connectionIndex = webSocketFactory.connectionCount
+        val connect = async(start = CoroutineStart.UNDISPATCHED) { gateway.connect() }
+        webSocketFactory.open(connectionIndex)
+        connect.await()
+    }
+
+    private fun readyFrame(sessionId: String, resumeUrl: String): String = JSONObject()
+        .put("op", 0)
+        .put("s", 1)
+        .put("t", "READY")
+        .put(
+            "d",
+            JSONObject()
+                .put("session_id", sessionId)
+                .put("resume_gateway_url", resumeUrl),
+        )
+        .toString()
+
+    private class FakeWebSocketFactory : WebSocket.Factory {
+        private val connections = mutableListOf<Connection>()
+
+        val connectionCount: Int
+            get() = connections.size
+
+        override fun newWebSocket(request: Request, listener: WebSocketListener): WebSocket {
+            val webSocket = FakeWebSocket(request)
+            connections += Connection(
+                webSocket = webSocket,
+                listener = listener,
+            )
+            return webSocket
+        }
+
+        fun connection(index: Int): Connection = connections[index]
+
+        fun open(index: Int) {
+            val connection = connection(index)
+            connection.listener.onOpen(
+                connection.webSocket,
+                response(connection.webSocket.request()),
+            )
+        }
+
+        fun message(index: Int, text: String) {
+            val connection = connection(index)
+            connection.listener.onMessage(connection.webSocket, text)
+        }
+
+        fun fail(
+            index: Int,
+            throwable: Throwable,
+            statusCode: Int? = null,
+            retryAfter: String? = null,
+        ) {
+            val connection = connection(index)
+            val response = statusCode?.let {
+                response(connection.webSocket.request(), it, retryAfter)
+            }
+            connection.listener.onFailure(connection.webSocket, throwable, response)
+        }
+
+        fun closeFromServer(index: Int, code: Int, reason: String) {
+            val connection = connection(index)
+            connection.listener.onClosed(connection.webSocket, code, reason)
+        }
+
+        private fun response(
+            request: Request,
+            code: Int = 101,
+            retryAfter: String? = null,
+        ): Response = Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(code)
+            .message(if (code == 101) "Switching Protocols" else "Failure")
+            .apply {
+                if (retryAfter != null) header("Retry-After", retryAfter)
+            }
+            .build()
+
+        data class Connection(
+            val webSocket: FakeWebSocket,
+            val listener: WebSocketListener,
+        )
+    }
+
+    private class FakeWebSocket(
+        private val request: Request,
+    ) : WebSocket {
+        val sentTextFrames = mutableListOf<String>()
+        var closeRequested: Boolean = false
+            private set
+
+        override fun request(): Request = request
+
+        override fun queueSize(): Long = 0L
+
+        override fun send(text: String): Boolean {
+            sentTextFrames += text
+            return true
+        }
+
+        override fun send(bytes: ByteString): Boolean = true
+
+        override fun close(code: Int, reason: String?): Boolean {
+            closeRequested = true
+            return true
+        }
+
+        override fun cancel() = Unit
+    }
+}

--- a/app/src/test/kotlin/com/metrolist/music/discord/DiscordReconnectStrategyTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/discord/DiscordReconnectStrategyTest.kt
@@ -81,4 +81,64 @@ class DiscordReconnectStrategyTest {
         )
         assertEquals(ReconnectAction.SurfaceFatal, action)
     }
+
+    @Test
+    fun backoffDelay_followsExponentialScheduleAndCapsAt64Seconds() {
+        val expectedBaseDelays = listOf(
+            1_000L,
+            2_000L,
+            4_000L,
+            8_000L,
+            16_000L,
+            32_000L,
+            64_000L,
+            64_000L,
+        )
+
+        expectedBaseDelays.forEachIndexed { index, baseDelay ->
+            val actual = DiscordReconnectStrategy.backoffDelayMs(
+                attempt = index + 1,
+                closeCode = 4000,
+                reason = "transient failure",
+            )
+            val jitter = baseDelay / 4L
+            assertTrue(
+                "attempt ${index + 1}: expected $actual within ${baseDelay - jitter}..${baseDelay + jitter}",
+                actual in (baseDelay - jitter)..(baseDelay + jitter),
+            )
+        }
+    }
+
+    @Test
+    fun backoffDelay_usesRetryAfterForRateLimits() {
+        assertEquals(
+            75_500L,
+            DiscordReconnectStrategy.backoffDelayMs(
+                attempt = 1,
+                closeCode = 429,
+                reason = "rate limited;retry_after=75.5",
+            ),
+        )
+    }
+
+    @Test
+    fun backoffDelay_enforcesMinimumForMissingMalformedOrShortRetryAfter() {
+        val reasons = listOf(
+            "rate limited",
+            "rate limited;retry_after=invalid",
+            "rate limited;retry_after=0.5",
+        )
+
+        reasons.forEach { reason ->
+            assertEquals(
+                reason,
+                60_000L,
+                DiscordReconnectStrategy.backoffDelayMs(
+                    attempt = 1,
+                    closeCode = 429,
+                    reason = reason,
+                ),
+            )
+        }
+    }
 }

--- a/app/src/test/kotlin/com/metrolist/music/discord/DiscordTokenStoreTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/discord/DiscordTokenStoreTest.kt
@@ -58,14 +58,6 @@ class DiscordTokenStoreTest {
     }
 
     @Test
-    fun storeAccessToken_updatesAccessWithoutChangingRefresh() {
-        DiscordTokenStore.storeFull("access1", "refresh1", expiresInSec = 3600L)
-        DiscordTokenStore.storeAccessToken("access2")
-        assertEquals("access2", DiscordTokenStore.retrieve())
-        assertEquals("refresh1", DiscordTokenStore.getRefreshToken())
-    }
-
-    @Test
     fun clear_removesAllTokens() {
         DiscordTokenStore.storeFull("access", "refresh", expiresInSec = 3600L)
         DiscordTokenStore.clear()


### PR DESCRIPTION
## Problem

Discord Rich Presence either never shows up after the app starts, or works for a while and then silently stops. It never recovers, except after force-stopping the app. 
The 30s reconnect poll in `MusicService` keeps firing and does nothing, and logging out and back in doesn't help either, because `authorize()` waits on the same mutex that's already stuck.

I hit this constantly.

## Cause

Three related things:

1. **The token write-back loop.** `reconnectWithToken()` publishes whatever token it was handed (`DiscordRpcManager.kt:468`), and `MusicService` collects that same flow and calls `reconnectWithToken(token)` straight back (`MusicService.kt:1052`). You'd expect `collectLatest` on a conflated `StateFlow` to throw away superseded values, but nothing in the collector body suspends - `isInitialized`, `isAuthorized` and `reconnectWithToken` are all plain functions, and `reconnectWithToken` just does `scope.launch` and returns. A block that never suspends can't be cancelled, so the body always finishes and hands its captured token back.

That's fine until the token changes. On startup with a nearly-expired token:

- `init()` calls `reconnectWithToken(T_old)` -> coroutine **A** takes the mutex, then publishes `T_old`.
-> The collector wakes on that write and, without suspending, calls `reconnectWithToken(T_old)` again -> coroutine **B** captures `T_old` and blocks on the mutex.
-> Still holding the lock, **A** sees the near expiry, refreshes to `T_new`, publishes it, IDENTIFYs, releases the lock. At this point the connection is up and using the correct token.
-> **B** takes the lock and publishes its captured `T_old`. That's a real `T_new` -> `T_old` change, so it closes the working connection (`gateway.close(4000, "reconnecting")`) and IDENTIFYs with the superseded token, which Discord rejects with `4004`.

So a healthy connection on the right token gets torn down and replaced with a dead one, purely because a stale value was echoed back.

It's a race, so it doesn't hit on every boot - if the collector is slow enough that the `StateFlow` conflates `T_old` away and only ever delivers `T_new`, nothing bad happens. When it does hit, the logs show it cycling at roughly 3 times a second, `4004` alternating with self-inflicted `4000` closes, and `READY` never arriving - which is exactly why `_authorized` stays false and the collector's `!isAuthorized()` guard never stops anything. One thing that plausibly keeps it going: a failed proactive refresh logs `refresh failed, continuing with old token` and leaves `expiresAt` untouched, so the next call retries the refresh and can publish yet another new token. I haven't traced every iteration of that churn to the line, but the step above is what starts it.

2. **The 4004 recovery path can't run.** `handleClose` drops stale closes before emitting `Disconnected` (`DiscordGateway.kt:307`), which is what would let `DiscordReconnectStrategy` decide `RefreshAndReIdentify`. During the churn above every close is stale, so the one mechanism designed to fix a bad token never fires. The check itself is fine - it only hurts because of the loop.

3. **Then it deadlocks for good.** `connect()` awaits `openDeferred` with no timeout (`DiscordGateway.kt:95`), but `onOpen` and `onFailure` both bail out early when `wsId != activeWebSocketId` *without completing it* (`:172`, `:208`), and `onClosing`/`onClosed` never touch it. Any `close()` bumps `activeWebSocketId` (`:112`) and any `connect()` overwrites it, so it only takes one collision to orphan a handshake forever. Both call sites await `connect()` while holding `reconnectMutex` (`DiscordRpcManager.kt:204`, `:466`), and the gateway's own retry ladder calls `connect()` outside it. When they collide, the mutex holder parks permanently and every reconnect afterwards queues silently behind it.

I caught one of these on my phone: process up 1d 7h, `syncDiscordState: not ready, attempting reconnect` logged every 30s, **and not a single line from inside `reconnectWithToken` - not even the first statement after the lock.** No OkHttp threads, no TCP connections to Discord. Nothing was happening at all.

So the lived experience is: boot → token storm → deadlock → restart → repeat.

## Solution (disclosure at the bottom of the PR)

`DiscordGateway` - `connect()` now always terminates. Every terminal callback completes `openDeferred`; the stale-id check gates state changes only, never completion. Superseded attempts fail with `GatewaySupersededException` and cancel their socket instead of leaking, and there's a 20s timeout on the handshake as a backstop. Connection state (`webSocket`, `isOpen`, `sessionId`, `seq`, `gatewayUrl`) now lives behind one `connectionLock`, and events carry a `connectionId` so staleness is decided in one place rather than in scattered per-callback guards.

`DiscordRpcManager` - `reconnectMutex` is gone, replaced by an epoch-based coordinator: one worker drains a `ConnectionIntent` queue and an epoch bump invalidates superseded work. Nothing holds a lock across a socket handshake anymore, so that whole class of deadlock is structurally gone rather than patched around. `reconnectWithToken(token)` becomes `reconnect()` - the manager resolves the canonical token itself instead of trusting whatever a caller passes in, which is what kills the loop. Reconnect backoff moves into the existing `DiscordReconnectStrategy` (heartbeat jitter stays in the gateway).

`MusicService` - the token collector no longer reconnects. Every write to `accessTokenFlow` already comes from a path that establishes the connection itself, so reacting to it was pure feedback. That's 7 insertions and 9 deletions; the `discordRpcEnabled` guard and init behaviour are untouched.

I deliberately kept the staleness check in `handleClose`. It was never the bug - with a single owner there's only ever one attempt in flight, so closes arrive fresh and the existing `4004` → refresh path works again on its own. Special-casing auth closes would have treated the symptom.

Two other things worth mentioning, so they don't look odd in review:

- `DiscordTokenStore.storeAccessToken()` is deleted along with its test. Its only caller was the write-back at `DiscordRpcManager.kt:469`; with that gone it's dead code. Mentioning it explicitly so the removed test doesn't read as silencing a failure - the remaining `DiscordTokenStore` tests still cover persistence.
- Two small seams exist purely for testing, both in the second commit: `DiscordGateway` takes an optional `webSocketFactory: WebSocket.Factory? = null` (OkHttp's own interface, defaulted, no production call site changes), and `ConnectionIntent`/`intentPriority`/`mergeIntents` move out of the singleton to `internal` top-level declarations in the same file so tests don't need reflection.

## Testing

On a OnePlus Nord 4 (Android 16), debug build, logcat captured throughout:

- Signed in, played a song, presence showed up. I kept using this for 1 day in various circumstances - no weird logs.
- Killed Wi-Fi mid-playback for a minute and restored it. This is the case the fix is really about, and the logs show one clean recovery: `closeCode=4000 → Resume`, backoff growing 948ms → 2.2s → 4.2s → 7.1s → 12.4s with each attempt failing honestly on DNS, the 30s poll correctly declining to start a competing attempt, then a single reconnect when the network came back. No storm, no competing sockets.

I never managed to catch a cold-start-with-expired-token handshake in the buffer (it had already rotated), so that path rests on the unit tests and the reasoning above rather than a device trace. I also didn't do a long soak or hammer the RPC toggle.

Unit tests: `DiscordGatewayTest` (Robolectric + a fake `WebSocket.Factory`) covers handshake completion, superseded attempts, the handshake timeout and stale-event rejection; `DiscordConnectionIntentTest` covers intent merging; `DiscordReconnectStrategyTest` is extended for the relocated backoff. Same conventions as the existing `discord` tests and **no new test dependencies** - Robolectric is already used by `DiscordAuthTest`, `DiscordPresenceTest` and `DiscordTokenStoreTest`.

`:app:testFossDebugUnitTest --tests "com.metrolist.music.discord.*"` → 38 tests, 0 failures across all six suites. `:app:lintFossDebug` is green with no new findings (nothing in `discord/`; the few in `MusicService.kt` are pre-existing and nowhere near the touched lines).

One caveat for completeness: since `DISCORD_APP_ID` is hardcoded, I tested with my own registered application ID. That changes which app the presence is attributed to, not how the gateway behaves.

## Related Issues

- Maybe #3918, but I don't want to claim it. That report says opening the integration screen *restores* presence, which this deadlock doesn't explain - `authorize()` blocks on the same mutex. Could be a separate startup issue, so I'm not marking this as closing it.

---

Happy to split this up, cut the test commit, or rework any of it if you'd rather review it in smaller pieces - it's a bigger diff than I'd like, but the manager and the gateway were racing each other and I didn't want to fix one without the other.

**Disclosure from me: The diagnosis and the fixes were fully done with an AI, with several rounds of guided verification, with my sanity check + verification.** The diagnosis came from on-device logcat, thread dumps and socket inspection. The body of this PR was co-written by an AI as well - specifically the technical parts. I left it on the more comprehensive side in order to provide you with more information so it's easier for you to make a call. If you're uncomfortable with this, I fully understand; I just wanted to take the care to verify+polish this and to share it as a PR in order to fix a bug for us all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Discord Gateway RPC stability with connection-id–scoped handshakes, heartbeat handling, and event routing.
  * Added intent-based connection coordination and a new `reconnect(forceRefresh)` flow.
  * Updated public gateway event contract to include a connection identifier (and removed the refresh-token event).

* **Bug Fixes**
  * Prevented stale/overlapped connections from mutating session state or emitting extra disconnects.
  * Rate-limit aware reconnect backoff now honors Discord `retry_after` (with sensible minimums).

* **Tests**
  * Expanded coverage for gateway supersession, backoff timing, intent merging, and token expiry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->