### PR TITLE
fix(lyrics): round exported image corners

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/utils/ComposeToImage.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/ComposeToImage.kt
@@ -67,6 +67,17 @@ object ComposeToImage {
 
             val bitmap = createBitmap(imageWidth, imageHeight)
             val canvas = Canvas(bitmap)
+            val backgroundRect = RectF(0f, 0f, imageWidth.toFloat(), imageHeight.toFloat())
+
+            // Base scale on width relative to the reference design (340dp)
+            // 2160 / 340 ≈ 6.35
+            val scale = imageWidth / 340f
+            val cornerRadius = 20f * scale
+            val exportPath =
+                Path().apply {
+                    addRoundRect(backgroundRect, cornerRadius, cornerRadius, Path.Direction.CW)
+                }
+            canvas.clipPath(exportPath)
 
             val defaultBackgroundColor = 0xFF121212.toInt()
             val defaultTextColor = 0xFFFFFFFF.toInt()
@@ -95,7 +106,6 @@ object ComposeToImage {
             }
 
             // Draw Background
-            val backgroundRect = RectF(0f, 0f, imageWidth.toFloat(), imageHeight.toFloat())
             val backgroundPaint =
                 Paint().apply {
                     isAntiAlias = true
@@ -164,12 +174,6 @@ object ComposeToImage {
                     }
                 }
             }
-
-            // Base scale on width relative to the reference design (340dp)
-            // 2160 / 340 ≈ 6.35
-            val scale = imageWidth / 340f
-
-            val cornerRadius = 20f * scale
 
             // Draw inner border
             val borderPaint =

--- a/app/src/test/kotlin/com/metrolist/music/utils/ComposeToImageTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/utils/ComposeToImageTest.kt
@@ -1,0 +1,70 @@
+package com.metrolist.music.utils
+
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.res.Resources
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
+import androidx.test.core.app.ApplicationProvider
+import com.metrolist.music.ui.component.LyricsBackgroundStyle
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = android.app.Application::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class ComposeToImageTest {
+    @Test
+    fun createLyricsImage_clipsOutputToRoundedCorners() =
+        runBlocking {
+            val context = TestContext(ApplicationProvider.getApplicationContext())
+            val bitmap =
+                ComposeToImage.createLyricsImage(
+                    context = context,
+                    coverArtUrl = null,
+                    songTitle = "",
+                    artistName = "",
+                    lyrics = "",
+                    width = 2160,
+                    height = 2160,
+                    backgroundColor = Color.BLACK,
+                    backgroundStyle = LyricsBackgroundStyle.SOLID,
+                )
+
+            val cornerPixels =
+                listOf(
+                    bitmap.getPixel(0, 0),
+                    bitmap.getPixel(bitmap.width - 1, 0),
+                    bitmap.getPixel(0, bitmap.height - 1),
+                    bitmap.getPixel(bitmap.width - 1, bitmap.height - 1),
+                )
+
+            cornerPixels.forEach { pixel ->
+                assertEquals(0, Color.alpha(pixel))
+            }
+            assertEquals(255, Color.alpha(bitmap.getPixel(bitmap.width / 2, bitmap.height / 2)))
+        }
+
+    private class TestContext(base: Context) : ContextWrapper(base) {
+        private val testResources = TestResources(base.resources)
+
+        override fun getResources(): Resources = testResources
+    }
+
+    @Suppress("DEPRECATION")
+    private class TestResources(base: Resources) : Resources(base.assets, base.displayMetrics, base.configuration) {
+        override fun getDrawable(
+            id: Int,
+            theme: Theme?,
+        ): Drawable = BitmapDrawable(this, Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888))
+
+        override fun getString(id: Int): String = "Metrolist"
+    }
+}


### PR DESCRIPTION
## Problem

Exported lyrics images have square opaque corners even though the card design and border are rounded.

## Cause

The exporter paints each background across the full bitmap. It then draws a rounded border, but never clips the bitmap content to that border's shape.

## Solution

- Clip the export canvas to the card's existing rounded shape before drawing any background or content.
- Preserve transparent PNG corners across solid, blur, and gradient backgrounds.
- Add a pixel-level regression test for transparent corners.

## Testing

- focused `ComposeToImageTest`
- `:app:assembleFossDebug`
- `:app:lintFossDebug`
- install and cold launch on an Android 16 emulator

## Related Issues

- Closes #4007
