### PR TITLE
fix(player): dim repeat button when off

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
@@ -1721,7 +1721,9 @@ fun BottomSheetPlayer(
                                             .size(32.dp)
                                             .padding(4.dp)
                                             .align(Alignment.Center)
-                                            .alpha(if (isListenTogetherGuest) 0.5f else 1f),
+                                            .alpha(
+                                                if (isListenTogetherGuest || repeatMode == Player.REPEAT_MODE_OFF) 0.5f else 1f,
+                                            ),
                                     enabled = !isListenTogetherGuest,
                                     onClick = {
                                         playerConnection.player.toggleRepeatMode()


### PR DESCRIPTION
## Problem

In the classic player, the repeat button remains fully highlighted when queue repeat is turned off, making the OFF and ALL states look identical.

## Cause

The classic player uses the same icon for OFF and ALL, while its opacity only accounts for Listen Together guest state and not the current repeat mode.

## Solution

- dim the classic repeat button to 50% opacity when repeat mode is OFF
- keep ALL and ONE fully emphasized
- preserve existing guest enablement and repeat-mode behavior

## Testing

- `./gradlew :app:assembleFossDebug :app:lintFossDebug`
- `./gradlew :app:testFossDebugUnitTest` (37/41 pass; four unrelated existing `YouTubeUtilsTest` expectations fail)
- installed and cold-launched the Foss debug APK on Android API 36

## Related Issues

- Closes #3038


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the repeat button’s visual state by dimming it when repeat mode is off or when listening as a guest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->