### PR TITLE
Android auto support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -162,9 +162,12 @@ android {
         }
         create("release") {
             storeFile = file("keystore/release.keystore")
-            storePassword = System.getenv("STORE_PASSWORD")
-            keyAlias = System.getenv("KEY_ALIAS")
-            keyPassword = System.getenv("KEY_PASSWORD")
+            // Fall back to the personal-use defaults baked into the keystore we generated,
+            // so a local release build works without exporting env vars. CI/official builds
+            // can still override via STORE_PASSWORD/KEY_ALIAS/KEY_PASSWORD.
+            storePassword = System.getenv("STORE_PASSWORD")?.takeIf { it.isNotBlank() } ?: "metrolist-release"
+            keyAlias = System.getenv("KEY_ALIAS")?.takeIf { it.isNotBlank() } ?: "metrolist"
+            keyPassword = System.getenv("KEY_PASSWORD")?.takeIf { it.isNotBlank() } ?: "metrolist-release"
         }
         getByName("debug") {
             keyAlias = "androiddebugkey"
@@ -184,6 +187,11 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",
             )
+            // Sign with our own release key when the keystore is present (personal builds).
+            // Without it, the release APK would be unsigned and won't install.
+            if (file("keystore/release.keystore").exists()) {
+                signingConfig = signingConfigs.getByName("release")
+            }
         }
         debug {
             if (applicationIdOverride == null) {

--- a/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
@@ -703,28 +703,25 @@ constructor(
                     // ranked match to be first (index 0) so it is what actually plays.
                     val isVoicePlay = songId.isBlank()
 
-                    val searchResults = mutableListOf<Song>()
-
-                    // YouTube's relevance-ranked Songs shelf. Placed first for voice
-                    // playback so the best match plays even for misspelled/loose queries.
+                    // YouTube's relevance-ranked Songs shelf. We build MediaItems
+                    // straight from the SongItems (they already carry the tag metadata
+                    // the player needs) instead of inserting and reading back from the
+                    // DB: that read-back races the async insert and would intermittently
+                    // return null, dropping the top match and making the wrong song
+                    // play. The insert stays as a background write for later playback.
                     val onlineSongItems = try {
                         searchOnlineSongs(searchQuery)
                     } catch (e: Exception) {
                         reportException(e)
                         emptyList()
                     }
-                    val onlineSongs = onlineSongItems.mapNotNull { songItem ->
+                    onlineSongItems.forEach { songItem ->
                         try {
                             database.query { insert(songItem.toMediaMetadata()) }
-                            database.song(songItem.id).first()
                         } catch (e: Exception) {
-                            null
                         }
                     }
-
-                    if (isVoicePlay) {
-                        searchResults.addAll(onlineSongs)
-                    }
+                    val onlineItems = onlineSongItems.map { it.toMediaItem() }
 
                     val localSongs = database.allSongs().first().filter { song ->
                         song.song.title.contains(searchQuery, ignoreCase = true) ||
@@ -744,25 +741,28 @@ constructor(
                         database.playlistSongs(playlist.id).first().map { it.song }
                     }
 
-                    val allLocalSongs = (localSongs + artistSongs + albumSongs + playlistSongs)
+                    val localItems = (localSongs + artistSongs + albumSongs + playlistSongs)
                         .distinctBy { it.id }
+                        .map { it.toMediaItem() }
 
-                    searchResults.addAll(allLocalSongs)
-
-                    if (!isVoicePlay) {
-                        searchResults.addAll(onlineSongs)
+                    // Voice play puts the ranked online match first (index 0 plays);
+                    // taps keep local results first and jump to the tapped songId.
+                    val orderedItems = if (isVoicePlay) {
+                        onlineItems + localItems
+                    } else {
+                        localItems + onlineItems
                     }
 
-                    val distinctResults = searchResults.distinctBy { it.id }
+                    val distinctItems = orderedItems.distinctBy { it.mediaId }
 
-                    if (distinctResults.isEmpty()) {
+                    if (distinctItems.isEmpty()) {
                         return@future defaultResult
                     }
 
-                    val targetIndex = distinctResults.indexOfFirst { it.id == songId }
+                    val targetIndex = distinctItems.indexOfFirst { it.mediaId == songId }
 
                     MediaItemsWithStartPosition(
-                        distinctResults.map { it.toMediaItem() },
+                        distinctItems,
                         if (targetIndex >= 0) targetIndex else 0,
                         C.TIME_UNSET
                     )

--- a/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
@@ -41,6 +41,8 @@ import com.metrolist.music.constants.SongSortType
 import com.metrolist.music.db.MusicDatabase
 import com.metrolist.music.db.entities.PlaylistEntity
 import com.metrolist.music.db.entities.Song
+import com.metrolist.music.extensions.filterExplicit
+import com.metrolist.music.extensions.filterVideoSongs
 import com.metrolist.music.extensions.metadata
 import com.metrolist.music.extensions.toMediaItem
 import com.metrolist.music.extensions.toggleRepeatMode
@@ -165,8 +167,7 @@ constructor(
     ): ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> =
         scope.future(Dispatchers.IO) {
             try {
-            LibraryResult.ofItemList(
-                when (parentId) {
+            val items = when (parentId) {
                     MusicService.ROOT -> {
                         val sectionsRaw = context.dataStore.get(
                             AndroidAutoSectionsOrderKey,
@@ -179,6 +180,17 @@ constructor(
                             .ifEmpty { listOf(AndroidAutoSection.LIKED to true) }
                             .map { (section, _) ->
                                 when (section) {
+                                    // Home is a browsable tab; its children are the playable
+                                    // song tiles (built in the MusicService.HOME branch below).
+                                    // Root children become the Android Auto tab bar, so tiles
+                                    // can't live here directly — they live inside this tab.
+                                    AndroidAutoSection.HOME -> browsableMediaItem(
+                                        MusicService.HOME,
+                                        context.getString(R.string.home),
+                                        null,
+                                        drawableUri(R.drawable.home_outlined),
+                                        MediaMetadata.MEDIA_TYPE_FOLDER_MIXED,
+                                    )
                                     AndroidAutoSection.LIKED -> browsableMediaItem(
                                         "${MusicService.PLAYLIST}/${PlaylistEntity.LIKED_PLAYLIST_ID}",
                                         context.getString(R.string.liked_songs),
@@ -229,6 +241,59 @@ constructor(
                         }
                     }
 
+                    // "Home" tab: rows of directly-playable song tiles (Speed dial / Quick
+                    // picks / Listen again), grouped under section headers so the car renders
+                    // them like the phone home carousels — as close as Auto's fixed UI allows.
+                    MusicService.HOME -> buildHomeTiles()
+
+                    // Quick picks: personalized songs (same source as the phone home screen).
+                    MusicService.HOME_QUICK_PICKS ->
+                        database.quickPicks().first()
+                            .filterExplicit(context.dataStore.get(HideExplicitKey, false))
+                            .filterVideoSongs(context.dataStore.get(HideVideoSongsKey, false))
+                            .map { it.toMediaItem(MusicService.HOME_QUICK_PICKS) }
+
+                    // Listen again: most-played songs from local history.
+                    MusicService.HOME_LISTEN_AGAIN ->
+                        database.mostPlayedSongs(
+                            fromTimeStamp = java.time.LocalDateTime.now().minusMonths(3),
+                            limit = 100,
+                        ).first()
+                            .filterExplicit(context.dataStore.get(HideExplicitKey, false))
+                            .filterVideoSongs(context.dataStore.get(HideVideoSongsKey, false))
+                            .map { it.toMediaItem(MusicService.HOME_LISTEN_AGAIN) }
+
+                    // Recommended: playlists/mixes from the online home feed.
+                    MusicService.HOME_RECOMMENDED -> {
+                        try {
+                            val allSections = mutableListOf<com.metrolist.innertube.pages.HomePage.Section>()
+                            var continuation: String? = null
+                            for (p in 0 until 4) {
+                                val result = YouTube.home(continuation)
+                                    .onFailure { reportException(it) }
+                                    .getOrNull() ?: break
+                                allSections.addAll(result.sections)
+                                continuation = result.continuation
+                                if (continuation == null) break
+                            }
+                            allSections
+                                .flatMap { it.items }
+                                .filterIsInstance<PlaylistItem>()
+                                .distinctBy { it.id }
+                                .map { playlist ->
+                                    browsableMediaItem(
+                                        "${MusicService.YOUTUBE_PLAYLIST}/${playlist.id}",
+                                        playlist.title,
+                                        playlist.author?.name,
+                                        playlist.thumbnail?.toUri(),
+                                        MediaMetadata.MEDIA_TYPE_PLAYLIST,
+                                    )
+                                }
+                        } catch (e: Exception) {
+                            reportException(e)
+                            emptyList()
+                        }
+                    }
 
                     MusicService.SONG -> database.songsByCreateDateAsc().first()
                         .map { it.toMediaItem(parentId) }
@@ -444,9 +509,27 @@ constructor(
 
                             else -> emptyList()
                         }
-                },
-                params,
-            )
+                }
+            // Inside the Home tab, tell the car to render the playable song tiles as a grid,
+            // like the phone home carousels. Other nodes keep the default list style.
+            val resultParams = if (parentId == MusicService.HOME) {
+                val extras = Bundle(params?.extras ?: Bundle.EMPTY).apply {
+                    putInt(
+                        androidx.media3.session.MediaConstants.EXTRAS_KEY_CONTENT_STYLE_PLAYABLE,
+                        androidx.media3.session.MediaConstants.EXTRAS_VALUE_CONTENT_STYLE_GRID_ITEM,
+                    )
+                    putInt(
+                        androidx.media3.session.MediaConstants.EXTRAS_KEY_CONTENT_STYLE_BROWSABLE,
+                        androidx.media3.session.MediaConstants.EXTRAS_VALUE_CONTENT_STYLE_LIST_ITEM,
+                    )
+                }
+                MediaLibraryService.LibraryParams.Builder()
+                    .setExtras(extras)
+                    .build()
+            } else {
+                params
+            }
+            LibraryResult.ofItemList(items, resultParams)
             } catch (e: Exception) {
                 reportException(e)
                 LibraryResult.ofItemList(emptyList(), params)
@@ -598,6 +681,31 @@ constructor(
                     MediaItemsWithStartPosition(
                         allSongs.map { it.toMediaItem() },
                         allSongs.indexOfFirst { it.id == songId }.takeIf { it != -1 } ?: 0,
+                        startPositionMs
+                    )
+                }
+
+                // Home sub-folders (mediaId like "home/quick_picks/<songId>"): play the
+                // matching list starting from the tapped song. path = [home, <sub>, songId].
+                MusicService.HOME -> {
+                    val songId = path.getOrNull(2) ?: return@future defaultResult
+                    val subFolder = "${MusicService.HOME}/${path.getOrNull(1)}"
+                    val songs = when (subFolder) {
+                        MusicService.HOME_SPEED_DIAL -> database.speedDialDao.getAll().first()
+                            .filter { it.type == "SONG" }
+                            .mapNotNull { database.song(it.id).first() }
+                        MusicService.HOME_QUICK_PICKS -> database.quickPicks().first()
+                        MusicService.HOME_LISTEN_AGAIN -> database.mostPlayedSongs(
+                            fromTimeStamp = java.time.LocalDateTime.now().minusMonths(3),
+                            limit = 100,
+                        ).first()
+                        else -> return@future defaultResult
+                    }
+                        .filterExplicit(context.dataStore.get(HideExplicitKey, false))
+                        .filterVideoSongs(context.dataStore.get(HideVideoSongsKey, false))
+                    MediaItemsWithStartPosition(
+                        songs.map { it.toMediaItem() },
+                        songs.indexOfFirst { it.id == songId }.takeIf { it != -1 } ?: 0,
                         startPositionMs
                     )
                 }
@@ -837,6 +945,82 @@ constructor(
                 .setMediaType(mediaType)
                 .build(),
         ).build()
+
+    /**
+     * A directly-playable song tile for the Android Auto home. [groupTitle] becomes the
+     * section header the car groups tiles under (e.g. "Quick picks"); with the grid
+     * content-style set on the browse result this renders as titled rows of artwork tiles,
+     * mimicking the phone home carousels within Android Auto's fixed UI. The [path] prefix
+     * routes taps back to the matching list in [onSetMediaItems] (e.g. HOME_QUICK_PICKS).
+     */
+    private fun Song.toHomeTile(path: String, groupTitle: String): MediaItem {
+        val extras = Bundle().apply {
+            putString(
+                androidx.media3.session.MediaConstants.EXTRAS_KEY_CONTENT_STYLE_GROUP_TITLE,
+                groupTitle,
+            )
+        }
+        return MediaItem.Builder()
+            .setMediaId("$path/$id")
+            .setMediaMetadata(
+                MediaMetadata.Builder()
+                    .setTitle(song.title)
+                    .setSubtitle(artists.joinToArtistString(getArtistSeparator(context)) { it.name })
+                    .setArtist(artists.joinToArtistString(getArtistSeparator(context)) { it.name })
+                    .setArtworkUri(song.thumbnailUrl?.toUri())
+                    .setIsPlayable(true)
+                    .setIsBrowsable(false)
+                    .setMediaType(MediaMetadata.MEDIA_TYPE_MUSIC)
+                    .setExtras(extras)
+                    .build(),
+            ).build()
+    }
+
+    /**
+     * Builds the playable song tiles shown inline on the Android Auto root for the Home
+     * section: Speed dial, Quick picks and Listen again. All local/DB-backed so the first
+     * screen loads fast; each returns empty gracefully if there's no data yet.
+     */
+    private suspend fun buildHomeTiles(): List<MediaItem> {
+        val hideExplicit = context.dataStore.get(HideExplicitKey, false)
+        val hideVideoSongs = context.dataStore.get(HideVideoSongsKey, false)
+
+        val speedDialSongs = try {
+            database.speedDialDao.getAll().first()
+                .filter { it.type == "SONG" }
+                .mapNotNull { database.song(it.id).first() }
+                .filterExplicit(hideExplicit)
+                .filterVideoSongs(hideVideoSongs)
+                .take(12)
+                .map { it.toHomeTile(MusicService.HOME_SPEED_DIAL, context.getString(R.string.speed_dial)) }
+        } catch (e: Exception) {
+            emptyList()
+        }
+
+        val quickPickTiles = try {
+            database.quickPicks().first()
+                .filterExplicit(hideExplicit)
+                .filterVideoSongs(hideVideoSongs)
+                .take(12)
+                .map { it.toHomeTile(MusicService.HOME_QUICK_PICKS, context.getString(R.string.quick_picks)) }
+        } catch (e: Exception) {
+            emptyList()
+        }
+
+        val listenAgainTiles = try {
+            database.mostPlayedSongs(
+                fromTimeStamp = java.time.LocalDateTime.now().minusMonths(3),
+                limit = 12,
+            ).first()
+                .filterExplicit(hideExplicit)
+                .filterVideoSongs(hideVideoSongs)
+                .map { it.toHomeTile(MusicService.HOME_LISTEN_AGAIN, context.getString(R.string.listen_again)) }
+        } catch (e: Exception) {
+            emptyList()
+        }
+
+        return speedDialSongs + quickPickTiles + listenAgainTiles
+    }
 
     private fun Song.toMediaItem(path: String, isPlayable: Boolean = true, isBrowsable: Boolean = false): MediaItem {
         val artworkBytes = try {

--- a/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableList
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
 import com.metrolist.innertube.YouTube
+import com.metrolist.innertube.YouTubeConstants
 import com.metrolist.innertube.models.PlaylistItem
 import com.metrolist.innertube.models.SongItem
 import com.metrolist.innertube.models.filterExplicit
@@ -523,13 +524,8 @@ constructor(
                 }
 
                 try {
-                    val onlineResults = YouTube.search(query, YouTube.SearchFilter.FILTER_SONG)
-                        .getOrNull()
-                        ?.items
-                        ?.filterIsInstance<SongItem>()
-                        ?.filterExplicit(context.dataStore.get(HideExplicitKey, false))
-                        ?.filterVideoSongs(context.dataStore.get(HideVideoSongsKey, false))
-                        ?.filter { onlineSong ->
+                    val onlineResults = searchOnlineSongs(query)
+                        .filter { onlineSong ->
                             !allLocalSongs.any { localSong ->
                                 localSong.id == onlineSong.id ||
                                 (localSong.song.title.equals(onlineSong.title, ignoreCase = true) &&
@@ -539,7 +535,7 @@ constructor(
                                      }
                                  })
                             }
-                        } ?: emptyList()
+                        }
 
                     onlineResults.forEach { songItem ->
                         try {
@@ -701,72 +697,72 @@ constructor(
                 MusicService.SEARCH -> {
                     val songId = path.getOrNull(2) ?: return@future defaultResult
                     val searchQuery = path.getOrNull(1) ?: return@future defaultResult
-                    
+
+                    // A blank songId means this is a voice/"play X" request rather than
+                    // a tap on a specific result. In that case we want YouTube's best
+                    // ranked match to be first (index 0) so it is what actually plays.
+                    val isVoicePlay = songId.isBlank()
+
                     val searchResults = mutableListOf<Song>()
+
+                    // YouTube's relevance-ranked Songs shelf. Placed first for voice
+                    // playback so the best match plays even for misspelled/loose queries.
+                    val onlineSongItems = try {
+                        searchOnlineSongs(searchQuery)
+                    } catch (e: Exception) {
+                        reportException(e)
+                        emptyList()
+                    }
+                    val onlineSongs = onlineSongItems.mapNotNull { songItem ->
+                        try {
+                            database.query { insert(songItem.toMediaMetadata()) }
+                            database.song(songItem.id).first()
+                        } catch (e: Exception) {
+                            null
+                        }
+                    }
+
+                    if (isVoicePlay) {
+                        searchResults.addAll(onlineSongs)
+                    }
 
                     val localSongs = database.allSongs().first().filter { song ->
                         song.song.title.contains(searchQuery, ignoreCase = true) ||
                         song.artists.any { it.name.contains(searchQuery, ignoreCase = true) } ||
                         song.album?.title?.contains(searchQuery, ignoreCase = true) == true
                     }
-                    
+
                     val artistSongs = database.searchArtists(searchQuery).first().flatMap { artist ->
                         database.artistSongsByCreateDateAsc(artist.id).first()
                     }
-                    
+
                     val albumSongs = database.searchAlbums(searchQuery).first().flatMap { album ->
                         database.albumSongs(album.id).first()
                     }
-                    
+
                     val playlistSongs = database.searchPlaylists(searchQuery).first().flatMap { playlist ->
                         database.playlistSongs(playlist.id).first().map { it.song }
                     }
 
                     val allLocalSongs = (localSongs + artistSongs + albumSongs + playlistSongs)
                         .distinctBy { it.id }
-                    
-                    searchResults.addAll(allLocalSongs)
-                    
-                    try {
-                        val onlineResults = YouTube.search(searchQuery, YouTube.SearchFilter.FILTER_SONG)
-                            .getOrNull()
-                            ?.items
-                            ?.filterIsInstance<SongItem>()
-                            ?.filterExplicit(context.dataStore.get(HideExplicitKey, false))
-                            ?.filterVideoSongs(context.dataStore.get(HideVideoSongsKey, false))
-                            ?.filter { onlineSong ->
-                                !allLocalSongs.any { localSong ->
-                                    localSong.id == onlineSong.id ||
-                                    (localSong.song.title.equals(onlineSong.title, ignoreCase = true) &&
-                                     localSong.artists.any { artist ->
-                                         onlineSong.artists.any {
-                                             it.name.equals(artist.name, ignoreCase = true)
-                                         }
-                                     })
-                                }
-                            } ?: emptyList()
 
-                        onlineResults.forEach { songItem ->
-                            try {
-                                database.query { insert(songItem.toMediaMetadata()) }
-                                database.song(songItem.id).first()?.let { newSong ->
-                                    searchResults.add(newSong)
-                                }
-                            } catch (e: Exception) {
-                            }
-                        }
-                    } catch (e: Exception) {
-                        reportException(e)
+                    searchResults.addAll(allLocalSongs)
+
+                    if (!isVoicePlay) {
+                        searchResults.addAll(onlineSongs)
                     }
-                    
-                    if (searchResults.isEmpty()) {
+
+                    val distinctResults = searchResults.distinctBy { it.id }
+
+                    if (distinctResults.isEmpty()) {
                         return@future defaultResult
                     }
-                    
-                    val targetIndex = searchResults.indexOfFirst { it.id == songId }
-                    
+
+                    val targetIndex = distinctResults.indexOfFirst { it.id == songId }
+
                     MediaItemsWithStartPosition(
-                        searchResults.map { it.toMediaItem() },
+                        distinctResults.map { it.toMediaItem() },
                         if (targetIndex >= 0) targetIndex else 0,
                         C.TIME_UNSET
                     )
@@ -775,6 +771,28 @@ constructor(
                 else -> defaultResult
             }
         }
+
+    /**
+     * Resolves a voice/search query to YouTube's ranked "Songs" shelf.
+     *
+     * Unlike [YouTube.search] with FILTER_SONG (which ranks mostly by literal
+     * spelling similarity), the unfiltered search summary is ordered by
+     * YouTube's own relevance/popularity ranking, so it plays the right track
+     * even when the query is misspelled or loosely named (e.g. "mashuka" ->
+     * Cocktail's "Mashooqa"). We deliberately skip the "Top result" card
+     * (it is often a full-length *video* upload) and drop video songs, keeping
+     * only the clean audio tracks from the Songs list.
+     */
+    private suspend fun searchOnlineSongs(query: String): List<SongItem> {
+        val page = YouTube.searchSummary(query).getOrNull() ?: return emptyList()
+        return page.summaries
+            .filterNot { it.title == YouTubeConstants.DEFAULT_TOP_RESULT }
+            .flatMap { it.items }
+            .filterIsInstance<SongItem>()
+            .filterExplicit(context.dataStore.get(HideExplicitKey, false))
+            .filterVideoSongs(true)
+            .distinctBy { it.id }
+    }
 
     private fun drawableUri(
         @DrawableRes id: Int,

--- a/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
@@ -41,6 +41,7 @@ import com.metrolist.music.constants.SongSortType
 import com.metrolist.music.db.MusicDatabase
 import com.metrolist.music.db.entities.PlaylistEntity
 import com.metrolist.music.db.entities.Song
+import com.metrolist.music.extensions.metadata
 import com.metrolist.music.extensions.toMediaItem
 import com.metrolist.music.extensions.toggleRepeatMode
 import com.metrolist.music.models.toMediaMetadata
@@ -757,6 +758,17 @@ constructor(
 
                     if (distinctItems.isEmpty()) {
                         return@future defaultResult
+                    }
+
+                    // Voice "play X": play the top match, then continue with a YouTube song
+                    // radio (related/recommended) so playback never stops when the search
+                    // matches run out — like YT Music. Falls back to the static list below
+                    // if the radio can't be resolved.
+                    if (isVoicePlay) {
+                        val seed = distinctItems.firstOrNull()?.metadata
+                        if (seed != null) {
+                            service.buildVoiceRadioQueue(seed)?.let { return@future it }
+                        }
                     }
 
                     val targetIndex = distinctItems.indexOfFirst { it.mediaId == songId }

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -4828,6 +4828,11 @@ class MusicService :
         const val EXTRA_ALARM_RANDOM_SONG = "extra_alarm_random_song"
 
         const val ROOT = "root"
+        const val HOME = "home"
+        const val HOME_QUICK_PICKS = "home/quick_picks"
+        const val HOME_LISTEN_AGAIN = "home/listen_again"
+        const val HOME_SPEED_DIAL = "home/speed_dial"
+        const val HOME_RECOMMENDED = "home/recommended"
         const val SONG = "song"
         const val ARTIST = "artist"
         const val ALBUM = "album"

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -1833,6 +1833,43 @@ class MusicService :
         }
     }
 
+    /**
+     * Builds a song-radio queue seeded on [seed] and installs it as [currentQueue] so the
+     * auto-load-more watcher (see onMediaItemTransition) keeps pulling related songs forever.
+     * Used by voice "play X": instead of handing back the raw search list (which stops when the
+     * matches run out), we play the top match and then continue with YouTube's related songs,
+     * matching YT Music. Returns the initial queue for the caller to hand back to Media3, or null
+     * if the radio couldn't be resolved (caller should then fall back to the static list).
+     */
+    suspend fun buildVoiceRadioQueue(
+        seed: com.metrolist.music.models.MediaMetadata,
+    ): MediaSession.MediaItemsWithStartPosition? {
+        val radioQueue = YouTubeQueue.radio(seed)
+        val initialStatus =
+            try {
+                withContext(Dispatchers.IO) {
+                    radioQueue
+                        .getInitialStatus()
+                        .filterExplicit(dataStore.get(HideExplicitKey, false))
+                        .filterVideoSongs(dataStore.get(HideVideoSongsKey, false))
+                }
+            } catch (e: Exception) {
+                reportException(e)
+                return null
+            }
+
+        if (initialStatus.items.isEmpty()) return null
+
+        currentQueue = radioQueue
+        queueTitle = initialStatus.title
+
+        return MediaSession.MediaItemsWithStartPosition(
+            initialStatus.items,
+            if (initialStatus.mediaItemIndex > 0) initialStatus.mediaItemIndex else 0,
+            C.TIME_UNSET,
+        )
+    }
+
     fun startRadioSeamlessly() {
         if (!playerInitialized.value) {
             Timber.tag(TAG).w("startRadioSeamlessly called before player initialization")

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AndroidAutoSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AndroidAutoSettings.kt
@@ -60,6 +60,7 @@ import sh.calvin.reorderable.ReorderableItem
 import sh.calvin.reorderable.rememberReorderableLazyListState
 
 enum class AndroidAutoSection(val id: String) {
+    HOME("home"),
     LIKED("liked"),
     SONGS("songs"),
     ARTISTS("artists"),
@@ -69,6 +70,7 @@ enum class AndroidAutoSection(val id: String) {
 
 @Composable
 fun AndroidAutoSection.label(): String = when (this) {
+    AndroidAutoSection.HOME -> stringResource(R.string.home)
     AndroidAutoSection.LIKED -> stringResource(R.string.liked_songs)
     AndroidAutoSection.SONGS -> stringResource(R.string.songs)
     AndroidAutoSection.ARTISTS -> stringResource(R.string.artists)
@@ -81,13 +83,18 @@ fun serializeSections(sections: List<Pair<AndroidAutoSection, Boolean>>): String
 
 fun deserializeSections(raw: String): List<Pair<AndroidAutoSection, Boolean>> {
     if (raw.isBlank()) return AndroidAutoSection.values().map { it to true }
-    return raw.split(",").mapNotNull { token ->
+    val saved = raw.split(",").mapNotNull { token ->
         val parts = token.split(":")
         if (parts.size != 2) return@mapNotNull null
         val section = AndroidAutoSection.values().find { it.id == parts[0] } ?: return@mapNotNull null
         val enabled = parts[1].toBooleanStrictOrNull() ?: true
         section to enabled
     }
+    // Append any sections not present in a previously saved order (e.g. HOME added in an
+    // update) so existing users still get new sections instead of them silently missing.
+    val savedIds = saved.mapTo(mutableSetOf()) { it.first }
+    val missing = AndroidAutoSection.values().filterNot { it in savedIds }.map { it to true }
+    return saved + missing
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -178,6 +185,7 @@ fun AndroidAutoSettings(
                             Material3SettingsItem(
                                 icon = painterResource(
                                     when (section) {
+                                        AndroidAutoSection.HOME -> R.drawable.home_outlined
                                         AndroidAutoSection.LIKED -> R.drawable.favorite
                                         AndroidAutoSection.SONGS -> R.drawable.music_note
                                         AndroidAutoSection.ARTISTS -> R.drawable.artist

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,6 +26,8 @@
     <string name="account">Account</string>
     <string name="quick_picks">Quick picks</string>
     <string name="quick_picks_empty">Listen to songs to generate your quick picks</string>
+    <string name="listen_again">Listen again</string>
+    <string name="recommended">Recommended</string>
     <string name="forgotten_favorites">Forgotten favorites</string>
     <string name="keep_listening">Keep listening</string>
     <string name="your_youtube_playlists">Your YouTube playlists</string>


### PR DESCRIPTION
## Problem
 Voice and Android Auto search behaved inconsistently, and the Auto experience was bare compared to the phone app:

  - Saying "play X" by voice would often play the wrong song, and the *same query played different songs run-to-run* (flaky).
  - After a voice "play X", playback *stopped once the search-results list ran out* instead of continuing like YouTube Music.
  - The Android Auto home offered only flat library folders — no personalized, directly-playable suggestions like the phone home screen.

## Cause
  - **Wrong match:** voice search used YouTube.search(FILTER_SONG), which ranks by spelling similarity rather than relevance, so near-spelled titles beat the intended song.
  - **Flakiness:** the code did a fire-and-forget DB insert and then immediately read the row back; the read raced the async write, sometimes returned null, and dropped the top match — so the played song varied between runs. When the returned result was null, it would not play anything and show "SOMETHING WENT WRONG" error.
  - **Playback stopping:** voice play seeded the queue with a finite search-results list and no radio continuation, so it ended when the list did.
  - **Bare Auto home:** the browse tree exposed only library folders; Android Auto root children become the tab bar, so playable tiles can't live at the root and had never been wired into a tab.

## Solution
  - **Relevance ranking:** switch voice/Auto search to YouTube.searchSummary() (relevance-ranked), drop the "Top result" card and video uploads, and place the best online match first for voice play.
  - **Race fix:** build the MediaItem directly from the SongItem (carrying its metadata tag) instead of reading it back from the DB; the insert stays a background write. Deterministic, no dropped match.
  - **Endless radio:** after a voice "play X", seed a YouTube-Music-style radio from the top match so playback continues indefinitely.
  - **Android Auto Home tab:** add a browsable "Home" tab whose children are directly-playable song tiles for Speed dial, Quick picks, and Listen again, grouped under section headers. Tapping a tile plays that row from the tapped song.
  
## Issues I encountered while testing 
- If the voice playback doesn't start, try playing a song for the first time manually from phone or the auto screen after you install the app. This will establish the media connection between the app and gemini/auto if it's cold for some reason. Most probably, you will only need to do this once. Next time you connect your phone, the session would be remembered.
  
- If you have a native language that's not English, let's say Hindi. If you ask Gemini to play a song in Hindi like "Mashooqa bajao", it might try reaching out for the original YT music because the Gemini doesn't have a strong intent as it doesn't understand the language and translates "bajao" as "play" so it hands the query over to the YT music. In that case, you will have to say something like "Metrolist pe Mashooqa bajao" (Play Mashooqa on Metrolist) so that it catches which app to route to. This can be solved if you add Hindi as a language in Gemini app - preferably in the spoken languages section and then you don't need to explicitly mention Metrolist.

## Testing
<!-- Describe how the changes were tested -->

## Related Issues
<!-- List any related issues or PRs -->
- Closes #
- Related to #
