### PR TITLE
fix: resolve IO_UNSPECIFIED for podcasts

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -2985,10 +2985,8 @@ class MusicService :
             }
         }
 
-        // For IO_UNSPECIFIED and IO_BAD_HTTP_STATUS, try recovery first
-        if (error.errorCode == PlaybackException.ERROR_CODE_IO_UNSPECIFIED ||
-            error.errorCode == PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS
-        ) {
+        // For IO_BAD_HTTP_STATUS, try recovery first
+        if (error.errorCode == PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS) {
             Timber.tag(TAG).d("IO error detected (${error.errorCode}), attempting recovery")
             handleGenericIOError(mediaId)
             return

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -413,7 +413,6 @@ object YTPlayerUtils {
                 // try directly, UNLESS this videoId already 403'd on GET (markWebRemixFailed) — then
                 // fall through to the fallback clients. Saves a validateStatus round-trip per resolve.
                 
-                val musicVideoType = streamPlayerResponse?.videoDetails?.musicVideoType
                 val isUgcOrPodcast = musicVideoType == "MUSIC_VIDEO_TYPE_UGC" ||
                                      musicVideoType?.contains("PODCAST") == true ||
                                      musicVideoType == null
@@ -640,10 +639,11 @@ object YTPlayerUtils {
                 println("[PLAYBACK_DEBUG] Added cookie to validation request")
             }
 
-            val response = httpClient.newCall(requestBuilder.build()).execute()
-            val isSuccessful = response.isSuccessful
-            Timber.tag(logTag).d("Stream URL validation result: ${if (isSuccessful) "Success" else "Failed"} (${response.code})")
-            return isSuccessful
+            httpClient.newCall(requestBuilder.build()).execute().use { response ->
+                val isSuccessful = response.isSuccessful
+                Timber.tag(logTag).d("Stream URL validation result: ${if (isSuccessful) "Success" else "Failed"} (${response.code})")
+                return isSuccessful
+            }
         } catch (e: Exception) {
             Timber.tag(logTag).e(e, "Stream URL validation failed with exception")
             reportException(e)

--- a/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YTPlayerUtils.kt
@@ -412,8 +412,15 @@ object YTPlayerUtils {
                 // GET that ExoPlayer makes. Skip HEAD validation for the main client and let ExoPlayer
                 // try directly, UNLESS this videoId already 403'd on GET (markWebRemixFailed) — then
                 // fall through to the fallback clients. Saves a validateStatus round-trip per resolve.
+                
+                val musicVideoType = streamPlayerResponse?.videoDetails?.musicVideoType
+                val isUgcOrPodcast = musicVideoType == "MUSIC_VIDEO_TYPE_UGC" ||
+                                     musicVideoType?.contains("PODCAST") == true ||
+                                     musicVideoType == null
+
                 if (currentClient.clientName == "WEB_REMIX" &&
-                    !webRemixFailedIds.contains(videoId)
+                    !webRemixFailedIds.contains(videoId) &&
+                    !isUgcOrPodcast
                 ) {
                     Timber.tag(logTag).d("WEB_REMIX — skipping HEAD validation, letting ExoPlayer try directly")
                     Timber.tag(TAG).i("Playback: client=${currentClient.clientName}, videoId=$videoId")


### PR DESCRIPTION
## Problem
The app fails to play podcasts and certain UGC videos, resulting in an IO_UNSPECIFIED error which previously triggered an infinite retry loop workaround.

## Cause
The WEB_REMIX client skips HEAD validation to avoid 403s on music tracks. However, for non-music videos like podcasts, this causes the app to pass an invalid URL directly to ExoPlayer, leading to an IO exception rather than a fallback to a working client.

## Solution
Modified the playback resolution logic to avoid skipping HEAD validation on WEB_REMIX if the video is classified as a podcast or UGC content, allowing the app to naturally fall back to TVHTML5. Also removed the infinite retry workaround for IO_UNSPECIFIED in MusicService since the root cause is resolved.

## Testing
Verified that podcast URLs now properly validate and fall back to the appropriate client, enabling successful playback without regressions on standard music tracks.

## Related Issues
Closes #4152


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined playback error handling so certain HTTP-status-related recovery is attempted only for the appropriate I/O error type; unspecified I/O errors now follow the safer auto-skip/stop flow.
  * Tightened remix stream validation to avoid skipping status checks for UGC/podcast or previously failed-unknown cases.
  * Improved HTTP HEAD handling by ensuring response resources are properly closed after validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->