### PR TITLE
fix: Fix UI layout for long localized text in GridMenu

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/GridMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/GridMenu.kt
@@ -31,10 +31,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.media3.exoplayer.offline.Download
 import com.metrolist.music.R
@@ -107,12 +107,11 @@ fun LazyGridScope.GridMenuItem(
                 text = stringResource(title),
                 style = MaterialTheme.typography.labelLarge,
                 textAlign = TextAlign.Center,
+                minLines = 2,
                 maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(with(LocalDensity.current) {
-                        MaterialTheme.typography.labelLarge.lineHeight.toDp() * 2
-                    })
             )
         }
     }
@@ -191,7 +190,9 @@ fun LazyGridScope.SleepTimerGridMenu(
                 ),
                 style = MaterialTheme.typography.labelLarge,
                 textAlign = TextAlign.Center,
+                minLines = 2,
                 maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.fillMaxWidth()
             )
         }


### PR DESCRIPTION
## Problem
The text in the Sleep Timer button and other GridMenu items is incorrectly positioned or truncated when translated into languages like Russian or French where the text is longer than a single line.

## Cause
The GridMenuItem text was using a fixed height based on the line height, while the SleepTimerGridMenu text was not constrained at all, leading to inconsistent text rendering and alignment issues across languages.

## Solution
Removed the fixed height workaround based on LocalDensity and instead implemented minLines and maxLines with TextOverflow.Ellipsis for both GridMenuItem and SleepTimerGridMenu to ensure consistent two-line text constraints across all languages.

## Testing
The layout changes were verified by inspecting the UI structure of GridMenu items to ensure they behave consistently under different text lengths.

## Related Issues
Closes #4175


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved grid menu text layout by limiting labels to two lines.
  * Added ellipsis truncation for longer menu labels, ensuring consistent item heights and clearer presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->