### PR TITLE
fix: Fix app not closing in background

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -4150,11 +4150,6 @@ class MusicService :
             return
         }
         super.onTaskRemoved(rootIntent)
-        // User removed the task while paused: drop foreground promotion so the process can idle.
-        // Queue/state remain persisted; opening the app restores playback as usual.
-        if (::player.isInitialized && !player.isPlaying) {
-            ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_DETACH)
-        }
     }
 
     override fun onGetSession(controllerInfo: MediaSession.ControllerInfo) = mediaSession


### PR DESCRIPTION
## Problem
The app remains in the background even after hours and the mini player is always on when the app is swiped away from recents.

## Cause
The onTaskRemoved callback incorrectly detached the foreground service instead of allowing Media3 to properly clean up and destroy the service.

## Solution
Removed the STOP_FOREGROUND_DETACH call so the service correctly shuts down via pauseAllPlayersAndStopSelf when the app is swiped away.

## Testing
Verified that removing the app from the recent apps list correctly dismisses the mini player and terminates the background process.

## Related Issues
Closes #4155


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback service behavior when the app is removed from recent tasks while playback is paused.
  * Prevented unnecessary changes to the service’s foreground state in this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->