### PR TITLE
fix: Fix sleep timer dialog layout

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
@@ -678,9 +678,9 @@ fun BottomSheetPlayer(
                         steps = (120 - 5) / 5 - 1,
                     )
 
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalAlignment = Alignment.CenterVertically,
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
                     ) {
                         if (isAtDefault) {
                             FilledIconButton(

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Queue.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Queue.kt
@@ -593,9 +593,9 @@ fun Queue(
 
                             Spacer(Modifier.height(8.dp))
 
-                            Row(
-                                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                verticalAlignment = Alignment.CenterVertically,
+                            Column(
+                                verticalArrangement = Arrangement.spacedBy(8.dp),
+                                horizontalAlignment = Alignment.CenterHorizontally,
                             ) {
                                 if (isAtDefault) {
                                     Button(


### PR DESCRIPTION
## Problem
The sleep timer dialog displays the 'Set as default' and 'End of song' options side by side (horizontally).

## Cause
The options in the sleep timer dialog were contained within a Row layout.

## Solution
Changed the Row layout to a Column layout in both Player and Queue sleep timer dialogs so that the options are displayed one below the other vertically.

## Testing
Verified that the sleep timer dialog displays both options correctly aligned one below the other.

## Related Issues
Related to #4175

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated sleep timer dialog controls to display vertically with improved spacing and alignment.
  * Applied the same layout refinement across the player and queue interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->