### PR TITLE
Localize search section titles

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/search/OnlineSearchResult.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/search/OnlineSearchResult.kt
@@ -75,6 +75,7 @@ import com.metrolist.innertube.YouTube.SearchFilter.Companion.FILTER_PODCAST
 import com.metrolist.innertube.YouTube.SearchFilter.Companion.FILTER_PROFILE
 import com.metrolist.innertube.YouTube.SearchFilter.Companion.FILTER_SONG
 import com.metrolist.innertube.YouTube.SearchFilter.Companion.FILTER_VIDEO
+import com.metrolist.innertube.YouTubeConstants
 import com.metrolist.innertube.models.AlbumItem
 import com.metrolist.innertube.models.ArtistItem
 import com.metrolist.innertube.models.EpisodeItem
@@ -494,7 +495,7 @@ fun OnlineSearchResult(
                     if (searchFilter == null) {
                         searchSummary?.summaries?.forEach { summary ->
                             item {
-                                NavigationTitle(summary.title)
+                                NavigationTitle(summary.title.toLocalizedSearchSection())
                             }
 
                             itemsIndexed(
@@ -574,3 +575,19 @@ fun OnlineSearchResult(
         }
     }
 }
+
+@Composable
+private fun String.toLocalizedSearchSection(): String =
+    when (this) {
+        YouTubeConstants.DEFAULT_TOP_RESULT -> stringResource(R.string.top_result)
+        YouTubeConstants.DEFAULT_OTHER_RESULTS -> stringResource(R.string.other)
+        "Songs" -> stringResource(R.string.songs)
+        "Videos" -> stringResource(R.string.videos)
+        "Albums" -> stringResource(R.string.albums)
+        "Artists" -> stringResource(R.string.artists)
+        "Playlists" -> stringResource(R.string.playlists)
+        "Podcasts" -> stringResource(R.string.podcasts)
+        "Episodes" -> stringResource(R.string.episodes)
+        "Profiles" -> stringResource(R.string.profiles)
+        else -> this
+    }

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -277,4 +277,10 @@
     <string name="use_login_for_browse">İçerikleri görmek için Giriş yap\'ı kullanın</string>
     <string name="use_login_for_browse_desc">Bu gördüğünüz içerikleri etkileyebilir ve örnek olarak Premium\'a özel içerikleri Premium\'a sahip bir hesapla giriş yaptıysanız size sunabilir</string>
     <string name="action_login">Giriş Yap</string>
+    <string name="top_result">Öne Çıkan</string>
+    <string name="other">Diğer</string>
+    <string name="videos">Videolar</string>
+    <string name="episodes">Bölümler</string>
+    <string name="podcasts">Podcastler</string>
+    <string name="profiles">Profiller</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -343,4 +343,10 @@
     <string name="new_version_available">New version available</string>
     <string name="translation_models">Translation Models</string>
     <string name="clear_translation_models">Clear translation models</string>
+    <string name="top_result">Top result</string>
+    <string name="other">Other</string>
+    <string name="videos">Videos</string>
+    <string name="episodes">Episodes</string>
+    <string name="podcasts">Podcasts</string>
+    <string name="profiles">Profiles</string>
 </resources>


### PR DESCRIPTION
## Problem
<!-- Describe the issue or limitation this PR addresses  
DO NOT PR NEW FEATURES, WE'RE ON A FEATURE FREEZE!!! -->
Search section titles (e.g. "Top result", "Songs", "Albums") are displayed as hardcoded English strings, making them impossible to localize.

## Cause
<!-- Explain the root cause of the problem -->
The same string values are used both as internal identifiers and as the UI text shown to the user.

## Solution
<!-- List the changes made to fix the issue -->
- Localize search section titles only when rendering them in the UI.
- Keep the existing internal string identifiers unchanged to avoid affecting grouping and sorting logic.
- Add missing string resources for section titles.

## Testing
<!-- Describe how the changes were tested -->
- Verified that search section titles are displayed correctly after localization in Turkish (tr-TR) language.
- Confirmed that grouping and section ordering remain unchanged.
<img width="432" height="1243" alt="Screenshot" src="https://github.com/user-attachments/assets/1dda2f62-b1b9-4ace-9bea-77a72cda3bf8" />

## Related Issues
<!-- List any related issues or PRs -->
- Closes #
- Related to #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search result section titles are now localized for clearer navigation.
  * Added labels for top results, other results, videos, episodes, podcasts, and profiles.
  * Added Turkish translations for the new search categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->