### PR TITLE
Changed the logic of the queue created by AA search

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
@@ -63,9 +63,13 @@ import kotlinx.coroutines.plus
 import javax.inject.Inject
 import com.metrolist.music.constants.AndroidAutoSectionsOrderKey
 import com.metrolist.music.constants.AndroidAutoYouTubePlaylistsKey
+import com.metrolist.music.constants.AutoRadioQueueKey
+import com.metrolist.music.playback.queues.ListQueue
+import com.metrolist.music.playback.queues.YouTubeQueue
 import com.metrolist.music.ui.screens.settings.AndroidAutoSection
 import com.metrolist.music.ui.screens.settings.deserializeSections
 import com.metrolist.music.ui.screens.settings.serializeSections
+import kotlinx.coroutines.withContext
 
 class MediaLibrarySessionCallback
 @Inject
@@ -749,24 +753,45 @@ constructor(
                         return@future defaultResult
                     }
 
-                    //Check if the voiceQuery is about a specific song and plays only that
-                    if (isVoiceSearch) {
-                        val snapshot: List<Song> = synchronized(searchResults) { searchResults.toList() }
-                        val bestMatch = VoiceSearchMatcher.findBest(searchQuery, snapshot)
-                        if (bestMatch != null) {
-                            return@future MediaItemsWithStartPosition(
-                                listOf(bestMatch.toMediaItem()),
-                                0,
-                                C.TIME_UNSET,
-                            )
+                    val selectedSong =
+                        if (isVoiceSearch) {    //Check if the voiceQuery is about a specific song
+                            val snapshot: List<Song> =
+                                synchronized(searchResults) { searchResults.toList() }
+                            VoiceSearchMatcher.findBest(searchQuery, snapshot)
+                        } else {
+                            searchResults.firstOrNull { it.id == songId }
                         }
+
+                    if(context.dataStore.get(AutoRadioQueueKey, true)) {
+                        val radioQueue = YouTubeQueue.radio(selectedSong?.toMediaMetadata() ?: return@future defaultResult)
+                        val radioStatus = radioQueue
+                            .getInitialStatus()
+                            .filterExplicit(context.dataStore.get(HideExplicitKey, false))
+                            .filterVideoSongs(context.dataStore.get(HideVideoSongsKey, false))
+
+                        withContext(Dispatchers.Main) {
+                            service.adoptQueue(radioQueue, radioStatus.title) //Used to make the radio queue load more songs when near the end
+                        }
+                        return@future MediaItemsWithStartPosition(
+                            radioStatus.items,
+                            radioStatus.items.indexOfFirst { it.mediaId == selectedSong.id }.coerceAtLeast(0),
+                            C.TIME_UNSET,
+                        )
                     }
 
-                    val targetIndex = searchResults.indexOfFirst { it.id == songId }
-
+                    val items = listOf(selectedSong?.toMediaItem() ?: return@future defaultResult)
+                    withContext(Dispatchers.Main) {
+                        service.adoptQueue(
+                            ListQueue(
+                                title = selectedSong.song.title,
+                                items = items,
+                            ),
+                            title = selectedSong.song.title,
+                        )
+                    }
                     MediaItemsWithStartPosition(
-                        searchResults.map { it.toMediaItem() },
-                        if (targetIndex >= 0) targetIndex else 0,
+                        items,
+                        0,
                         C.TIME_UNSET
                     )
                 }

--- a/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
@@ -764,19 +764,25 @@ constructor(
 
                     if(context.dataStore.get(AutoRadioQueueKey, true)) {
                         val radioQueue = YouTubeQueue.radio(selectedSong?.toMediaMetadata() ?: return@future defaultResult)
-                        val radioStatus = radioQueue
-                            .getInitialStatus()
-                            .filterExplicit(context.dataStore.get(HideExplicitKey, false))
-                            .filterVideoSongs(context.dataStore.get(HideVideoSongsKey, false))
+                        val radioStatus = runCatching {
+                            withContext(Dispatchers.IO) {
+                                radioQueue
+                                    .getInitialStatus()
+                                    .filterExplicit(context.dataStore.get(HideExplicitKey, false))
+                                    .filterVideoSongs(context.dataStore.get(HideVideoSongsKey, false))
+                            }
+                        }.getOrNull()
 
-                        withContext(Dispatchers.Main) {
-                            service.adoptQueue(radioQueue, radioStatus.title) //Used to make the radio queue load more songs when near the end
+                        if (radioStatus != null && radioStatus.items.isNotEmpty()) {
+                            withContext(Dispatchers.Main) {
+                                service.adoptQueue(radioQueue, radioStatus.title, radioStatus.items.size) //Used to make the radio queue load more songs when near the end
+                            }
+                            return@future MediaItemsWithStartPosition(
+                                radioStatus.items,
+                                radioStatus.items.indexOfFirst { it.mediaId == selectedSong.id }.coerceAtLeast(0),
+                                C.TIME_UNSET,
+                            )
                         }
-                        return@future MediaItemsWithStartPosition(
-                            radioStatus.items,
-                            radioStatus.items.indexOfFirst { it.mediaId == selectedSong.id }.coerceAtLeast(0),
-                            C.TIME_UNSET,
-                        )
                     }
 
                     val items = listOf(selectedSong?.toMediaItem() ?: return@future defaultResult)

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -1835,9 +1835,10 @@ class MusicService :
         }
     }
 
-    fun adoptQueue(queue: Queue, title: String? = null) {
+    fun adoptQueue(queue: Queue, title: String? = null, initialQueueSize: Int = 0) {
         currentQueue = queue
         queueTitle = title
+        originalQueueSize = initialQueueSize
     }
 
     fun startRadioSeamlessly() {

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -1835,6 +1835,11 @@ class MusicService :
         }
     }
 
+    fun adoptQueue(queue: Queue, title: String? = null) {
+        currentQueue = queue
+        queueTitle = title
+    }
+
     fun startRadioSeamlessly() {
         if (!playerInitialized.value) {
             Timber.tag(TAG).w("startRadioSeamlessly called before player initialization")


### PR DESCRIPTION
Now it checks for AutoRadioQueueKey instead of creating a nonsensical queue of search results.

## Problem
The Android Auto search page, when clicking on a song, creates a queue of search Results. This is in my opinion nonsensical, why, for example, should i want a queue of all the variants of Bohemian Rhapsody if i search precisely that title and click on the song i want? I should expect it to start that song and a queue of related song (aka radio songs).

## Cause
Simply as i said in the problem, the code was starting a searchResults.map

## Solution
Changed the logic of the queue created by AA search
- Now it checks for the already existing AutoRadioQueue setting to create a radio queue, if that is disabled, it instead plays only that song and not the search results map as before.
- Also, by changing the currentQueue of MusicService with a little new method, now the queue respect the other Load More Songs setting.

## Testing
Tested by using the AA Desktop Head Unit on Android Studio.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search-result playback now selects the requested song before building the queue.
  * When enabled, automatic radio can populate the playback queue and begin at the selected song.
  * Playback falls back to the selected song when radio content is unavailable.
  * Queue handling now better distinguishes original songs from automatically added tracks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->