### PR TITLE
ci: cap Blacksmith job runtime at 15 minutes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
     name: Build Release (${{ matrix.variant }})
     if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
 
     strategy:
       matrix:
@@ -91,6 +92,7 @@ jobs:
     name: Build Debug (${{ matrix.variant }})
     if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
 
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
   check-version:
     if: "!contains(github.ref, 'refs/tags')"
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
     outputs:
       version_changed: ${{ steps.check_version.outputs.version_changed }}
       new_version: ${{ steps.check_version.outputs.new_version }}
@@ -73,6 +74,7 @@ jobs:
     needs: check-version
     if: needs.check-version.outputs.version_changed == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
     strategy:
       matrix:
         include:
@@ -159,6 +161,7 @@ jobs:
     needs: [check-version, build]
     if: needs.check-version.outputs.version_changed == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
A build recently hung for ~2 hours before anyone noticed. None of the Blacksmith jobs in this repo had a `timeout-minutes`, so they inherited GitHub's 6-hour default. This adds an explicit 15-minute cap to every Blacksmith job in `build.yml` and `release.yml`:

```yaml
  build_release:
    name: Build Release (${{ matrix.variant }})
    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
    runs-on: blacksmith-4vcpu-ubuntu-2404
    timeout-minutes: 15
```

The two `ubuntu-latest` jobs (`build_pr.yml`, `build_quick.yml`) are untouched since they aren't Blacksmith-managed.

Headroom check against the last 30 days of Blacksmith metrics for this repo: p50 duration 338s, p90 445s, slowest observed run 822s (13.7 min, `Build Debug (gms)`). That slowest run is uncomfortably close to the new cap, so a cold Gradle cache run could trip it. If that turns into flakiness, 20 minutes is the safer number here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added 15-minute time limits to debug and release build jobs.
  * Added time limits to release validation, build, and publishing jobs to prevent stalled workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->