### PR TITLE
fix(lyrics): stabilize experimental lyrics scrolling

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsFormat.kt
+++ b/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsFormat.kt
@@ -14,6 +14,5 @@ private val LRC_TIMESTAMP_HINT = Regex("""\[\d{1,2}:\d{2}""")
 fun lyricsTextLooksSynced(lyrics: String?): Boolean {
     if (lyrics.isNullOrBlank()) return false
     val t = lyrics.trim().removePrefix("\uFEFF").trimStart()
-    if (t.startsWith('[')) return true
     return LRC_TIMESTAMP_HINT.containsMatchIn(t.take(4096))
 }

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/ExperimentalLyrics.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/ExperimentalLyrics.kt
@@ -107,7 +107,6 @@ import com.metrolist.music.db.entities.LyricsEntity.Companion.LYRICS_NOT_FOUND
 import com.metrolist.music.lyrics.LyricsResyncHelper
 import com.metrolist.music.lyrics.LyricsTranslationHelper
 import com.metrolist.music.lyrics.LyricsUtils.findActiveLineIndices
-import com.metrolist.music.lyrics.lyricsTextLooksSynced
 import com.metrolist.music.ui.component.shimmer.ShimmerHost
 import com.metrolist.music.ui.component.shimmer.TextPlaceholder
 import com.metrolist.music.ui.screens.settings.LyricsPosition
@@ -119,8 +118,8 @@ import com.metrolist.music.utils.rememberPreference
 import com.metrolist.music.viewmodels.LyricsViewModel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlin.math.abs
@@ -131,6 +130,13 @@ private val LYRICS_ITEM_FALLBACK_HEIGHT_DP = 68.dp
 private val LYRICS_ITEM_GAP_DP = 16.dp
 private val LYRICS_FADE_TOP_DP = 130.dp
 private val LYRICS_FADE_BOTTOM_DP = 160.dp
+
+private sealed class ScrollCommand {
+    data object Stop : ScrollCommand()
+    data class Snap(val value: Float) : ScrollCommand()
+    data class Animate(val value: Float) : ScrollCommand()
+    data class Fling(val velocity: Float) : ScrollCommand()
+}
 
 @OptIn(
     ExperimentalMaterial3Api::class,
@@ -219,7 +225,7 @@ fun ExperimentalLyrics(
         lyricsViewModel.processLyrics(lyrics, enabledLanguages, romanizeCyrillicByLine, showIntervalIndicator)
     }
 
-    val isSynced = remember(lyrics) { lyricsTextLooksSynced(lyrics) }
+    val isSynced = remember(lyrics) { lyrics != null && com.metrolist.music.lyrics.LyricsUtils.isLineSynced(lyrics) }
     DisposableEffect(Unit) {
         LyricsTranslationHelper.setCompositionActive(true)
         onDispose {
@@ -310,7 +316,7 @@ fun ExperimentalLyrics(
     var isSelectionModeActive by rememberSaveable { mutableStateOf(false) }
     val selectedIndices = remember { mutableStateListOf<Int>() }
     var showMaxSelectionToast by remember { mutableStateOf(false) }
-    var isAutoScrollEnabled by rememberSaveable { mutableStateOf(true) }
+    var isAutoScrollEnabled by rememberSaveable(isSynced) { mutableStateOf(isSynced) }
     val isLyricsProviderShown = lyricsEntity != null &&
         lyricsEntity.provider != "Unknown" &&
         lyricsEntity.provider != "Manual" &&
@@ -360,16 +366,21 @@ fun ExperimentalLyrics(
             val lyricsOffset = currentSong?.song?.lyricsOffset ?: 0
             val effectivePosition = position + lyricsOffset
             
-            val activeIndices = findActiveLineIndices(lines, effectivePosition).toMutableSet()
-            for (i in activeIndices.toList()) {
-                if (lines.getOrNull(i)?.isBackground == true) {
-                    for (j in i - 1 downTo 0) {
-                        if (lines.getOrNull(j)?.isBackground == false) {
-                            activeIndices.add(j)
-                            break
+            val activeIndices = if (isSynced) {
+                val active = findActiveLineIndices(lines, effectivePosition).toMutableSet()
+                for (i in active.toList()) {
+                    if (lines.getOrNull(i)?.isBackground == true) {
+                        for (j in i - 1 downTo 0) {
+                            if (lines.getOrNull(j)?.isBackground == false) {
+                                active.add(j)
+                                break
+                            }
                         }
                     }
                 }
+                active
+            } else {
+                lines.indices.toSet()
             }
             activeLineIndices = activeIndices
         }
@@ -378,12 +389,17 @@ fun ExperimentalLyrics(
     val viewConfiguration = LocalViewConfiguration.current
     val itemHeights = remember(lyrics, mergedLyricsList) { mutableStateMapOf<Int, Int>() }
     val scrollOffset = remember { Animatable(0f) }
-    val manualScrollRequests = remember { Channel<Float>(Channel.CONFLATED) }
+    val scrollCommands = remember { Channel<ScrollCommand>(Channel.CONFLATED) }
     var hasAutoPositioned by remember(lyrics) { mutableStateOf(false) }
 
-    LaunchedEffect(manualScrollRequests) {
-        for (targetOffset in manualScrollRequests) {
-            scrollOffset.snapTo(targetOffset)
+    LaunchedEffect(scrollCommands) {
+        scrollCommands.receiveAsFlow().collectLatest { command ->
+            when (command) {
+                is ScrollCommand.Stop -> scrollOffset.stop()
+                is ScrollCommand.Snap -> scrollOffset.snapTo(command.value)
+                is ScrollCommand.Animate -> scrollOffset.animateTo(command.value, tween(450, easing = FastOutSlowInEasing))
+                is ScrollCommand.Fling -> scrollOffset.animateDecay(command.velocity, exponentialDecay())
+            }
         }
     }
 
@@ -447,46 +463,61 @@ fun ExperimentalLyrics(
         val contentTop = with(density) { 56.dp.toPx() }
         val indicatorHeightPx = with(density) { 72.dp.toPx() }
         val lineHeightPx = with(density) { LYRICS_ITEM_FALLBACK_HEIGHT_DP.toPx() }
+        val itemGapPx = with(density) { LYRICS_ITEM_GAP_DP.toPx() }
 
         // Each item is positioned from the start of the song. The active line only changes
         // the viewport's offset, so playback never changes the layout of individual lines.
-        val positions = remember(itemHeights.toMap(), mergedLyricsList) {
-            val map = mutableMapOf<Int, Float>()
-            var currentY = 0f
-            mergedLyricsList.forEachIndexed { index, item ->
-                map[index] = currentY
-                val height = itemHeights[index]?.toFloat()
-                    ?: (if (item is LyricsListItem.Indicator) indicatorHeightPx else lineHeightPx)
-                val noGap = (item as? LyricsListItem.Line)?.entry?.isBackground == true || item is LyricsListItem.Indicator
-                currentY += height + if (noGap) 0f else with(density) { LYRICS_ITEM_GAP_DP.toPx() }
+        val positions by remember(mergedLyricsList) {
+            derivedStateOf {
+                val map = mutableMapOf<Int, Float>()
+                var currentY = 0f
+                mergedLyricsList.forEachIndexed { index, item ->
+                    map[index] = currentY
+                    val height = itemHeights[index]?.toFloat()
+                        ?: (if (item is LyricsListItem.Indicator) indicatorHeightPx else lineHeightPx)
+                    val noGap = (item as? LyricsListItem.Line)?.entry?.isBackground == true || item is LyricsListItem.Indicator
+                    currentY += height + if (noGap) 0f else itemGapPx
+                }
+                map
             }
-            map
         }
         // Let the first and last entries reach the playback anchor instead of pinning
         // either edge of the list to the edge of the viewport.
         val firstAnchorOffset = contentTop - anchorY
-        val lastAnchorOffset = contentTop + (positions[mergedLyricsList.lastIndex] ?: 0f) - anchorY
-        val scrollClampMin = minOf(firstAnchorOffset, lastAnchorOffset)
-        val scrollClampMax = maxOf(firstAnchorOffset, lastAnchorOffset)
-        val latestScrollLimits = rememberUpdatedState(scrollClampMin to scrollClampMax)
-
-        LaunchedEffect(scrollClampMin, scrollClampMax) {
-            scrollOffset.updateBounds(scrollClampMin, scrollClampMax)
+        val lastAnchorOffset = remember(positions) {
+            derivedStateOf {
+                contentTop + (positions[mergedLyricsList.lastIndex] ?: 0f) - anchorY
+            }
+        }
+        val scrollClampMin = remember(lastAnchorOffset) { 
+            derivedStateOf { minOf(firstAnchorOffset, lastAnchorOffset.value) } 
+        }
+        val scrollClampMax = remember(lastAnchorOffset) { 
+            derivedStateOf { maxOf(firstAnchorOffset, lastAnchorOffset.value) } 
         }
 
-        val autoScrollTarget = if (positions.isEmpty()) {
-            null
-        } else {
-            ((positions[activeListIndex] ?: 0f) + contentTop - anchorY)
-                .coerceIn(scrollClampMin, scrollClampMax)
+        LaunchedEffect(scrollClampMin.value, scrollClampMax.value) {
+            scrollOffset.updateBounds(scrollClampMin.value, scrollClampMax.value)
         }
 
-        LaunchedEffect(autoScrollTarget, isAutoScrollEnabled) {
-            if (isAutoScrollEnabled && autoScrollTarget != null) {
-                if (hasAutoPositioned) {
-                    scrollOffset.animateTo(autoScrollTarget, tween(450, easing = FastOutSlowInEasing))
+        val autoScrollTarget = remember(positions, activeListIndex, scrollClampMin, scrollClampMax) {
+            derivedStateOf {
+                if (positions.isEmpty()) {
+                    null
                 } else {
-                    scrollOffset.snapTo(autoScrollTarget)
+                    ((positions[activeListIndex] ?: 0f) + contentTop - anchorY)
+                        .coerceIn(scrollClampMin.value, scrollClampMax.value)
+                }
+            }
+        }
+
+        LaunchedEffect(autoScrollTarget.value, isAutoScrollEnabled) {
+            val target = autoScrollTarget.value
+            if (isAutoScrollEnabled && target != null) {
+                if (hasAutoPositioned) {
+                    scrollCommands.send(ScrollCommand.Animate(target))
+                } else {
+                    scrollCommands.send(ScrollCommand.Snap(target))
                     hasAutoPositioned = true
                 }
             }
@@ -539,7 +570,6 @@ fun ExperimentalLyrics(
                     })
                     .pointerInput(Unit) {
                         coroutineScope {
-                            val gestureScope = this
                             while (isActive) {
                                 val velocity = awaitPointerEventScope {
                                     val down = awaitFirstDown(requireUnconsumed = false)
@@ -558,13 +588,12 @@ fun ExperimentalLyrics(
                                             dragging = true
                                             isAutoScrollEnabled = false
                                             targetOffset = scrollOffset.value
-                                            gestureScope.launch { scrollOffset.stop() }
+                                            scrollCommands.trySend(ScrollCommand.Stop)
                                         }
                                         if (dragging && delta != 0f) {
-                                            val (minOffset, maxOffset) = latestScrollLimits.value
                                             targetOffset = (targetOffset - delta)
-                                                .coerceIn(minOffset, maxOffset)
-                                            manualScrollRequests.trySend(targetOffset)
+                                                .coerceIn(scrollClampMin.value, scrollClampMax.value)
+                                            scrollCommands.trySend(ScrollCommand.Snap(targetOffset))
                                             tracker.addPointerInputChange(change)
                                             change.consume()
                                         }
@@ -572,7 +601,7 @@ fun ExperimentalLyrics(
                                     if (dragging) -tracker.calculateVelocity().y else 0f
                                 }
                                 if (velocity != 0f) {
-                                    launch { scrollOffset.animateDecay(velocity, exponentialDecay()) }
+                                    scrollCommands.send(ScrollCommand.Fling(velocity))
                                 }
                             }
                         }
@@ -582,23 +611,32 @@ fun ExperimentalLyrics(
                 val currentEffectivePosition = currentPositionState + lyricsOffsetVal
                 
                 if (isLyricsProviderShown) {
-                    val targetProviderBase = contentTop - scrollOffset.value - with(density) { 32.dp.toPx() }
                     Text(
                         text = stringResource(R.string.lyrics_from_provider, lyricsEntity.provider),
                         fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                        modifier = Modifier.fillMaxWidth().offset { IntOffset(0, targetProviderBase.roundToInt()) }.padding(horizontal = 24.dp, vertical = 4.dp)
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .offset { 
+                                val y = contentTop - scrollOffset.value - with(density) { 32.dp.toPx() }
+                                IntOffset(0, y.roundToInt()) 
+                            }
+                            .padding(horizontal = 24.dp, vertical = 4.dp)
                     )
                 }
 
                 mergedLyricsList.forEachIndexed { listIndex, listItem ->
                     key(listItem) {
-                        val targetOffset = contentTop + positions.getOrDefault(listIndex, listIndex * lineHeightPx) - scrollOffset.value
-
                         Box(
-                            modifier = Modifier.fillMaxWidth().layout { m, c -> 
-                                val p = m.measure(c.copy(maxHeight = Constraints.Infinity))
-                                layout(p.width, 0) { p.place(0, 0) }
-                            }.offset { IntOffset(0, targetOffset.roundToInt()) }
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .layout { m, c -> 
+                                    val p = m.measure(c.copy(maxHeight = Constraints.Infinity))
+                                    layout(p.width, 0) { p.place(0, 0) }
+                                }
+                                .offset {
+                                    val y = contentTop + (positions[listIndex] ?: (listIndex * lineHeightPx)) - scrollOffset.value
+                                    IntOffset(0, y.roundToInt())
+                                }
                         ) {
                             when (listItem) {
                                 is LyricsListItem.Indicator -> {
@@ -641,7 +679,7 @@ fun ExperimentalLyrics(
                                                     if (selectedIndices.isEmpty()) isSelectionModeActive = false
                                                 } else if (selectedIndices.size < maxSelectionLimit) selectedIndices.add(index)
                                                 else showMaxSelectionToast = true
-                                            } else if (changeLyrics && !isGuest) {
+                                            } else if (isSynced && changeLyrics && !isGuest) {
                                                 if (item.time < playerConnection.player.duration + 30000L) {
                                                     playerConnection.seekTo((item.time - (currentSong?.song?.lyricsOffset ?: 0)).coerceAtLeast(0))
                                                 }

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/ExperimentalLyrics.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/ExperimentalLyrics.kt
@@ -386,12 +386,17 @@ fun ExperimentalLyrics(
         }
     }
 
-    val activeListIndex by remember(mergedLyricsList, activeLineIndices) {
+    val anchoredLineIndex by remember(lines, activeLineIndices) {
         derivedStateOf {
-            val activeLine = activeLineIndices
+            activeLineIndices
                 .filter { lines.getOrNull(it)?.isBackground == false }
                 .maxOrNull() ?: activeLineIndices.maxOrNull() ?: 0
-            mergedLyricsList.indexOfFirst { it is LyricsListItem.Line && it.index == activeLine }
+        }
+    }
+
+    val activeListIndex by remember(mergedLyricsList, anchoredLineIndex) {
+        derivedStateOf {
+            mergedLyricsList.indexOfFirst { it is LyricsListItem.Line && it.index == anchoredLineIndex }
                 .coerceAtLeast(0)
         }
     }
@@ -438,14 +443,19 @@ fun ExperimentalLyrics(
             scrollOffset.updateBounds(scrollClampMin, scrollClampMax)
         }
 
-        LaunchedEffect(activeListIndex, isAutoScrollEnabled, scrollClampMax) {
-            if (isAutoScrollEnabled && positions.isNotEmpty()) {
-                val target = ((positions[activeListIndex] ?: 0f) + contentTop - anchorY)
-                    .coerceIn(scrollClampMin, scrollClampMax)
+        val autoScrollTarget = if (positions.isEmpty()) {
+            null
+        } else {
+            ((positions[activeListIndex] ?: 0f) + contentTop - anchorY)
+                .coerceIn(scrollClampMin, scrollClampMax)
+        }
+
+        LaunchedEffect(autoScrollTarget, isAutoScrollEnabled) {
+            if (isAutoScrollEnabled && autoScrollTarget != null) {
                 if (hasAutoPositioned) {
-                    scrollOffset.animateTo(target, tween(450, easing = FastOutSlowInEasing))
+                    scrollOffset.animateTo(autoScrollTarget, tween(450, easing = FastOutSlowInEasing))
                 } else {
-                    scrollOffset.snapTo(target)
+                    scrollOffset.snapTo(autoScrollTarget)
                     hasAutoPositioned = true
                 }
             }
@@ -516,6 +526,7 @@ fun ExperimentalLyrics(
                                         if (!dragging && abs(accumulatedDrag) > viewConfiguration.touchSlop) {
                                             dragging = true
                                             isAutoScrollEnabled = false
+                                            targetOffset = scrollOffset.value
                                             gestureScope.launch { scrollOffset.stop() }
                                         }
                                         if (dragging && delta != 0f) {
@@ -589,7 +600,7 @@ fun ExperimentalLyrics(
                                         playerConnection = playerConnection, lyricsTextSize = 36f, lyricsLineSpacing = 1.3f,
                                         expressiveAccent = expressiveAccent, lyricsTextPosition = lyricsTextPosition,
                                         respectAgentPositioning = respectAgentPositioning, isAutoScrollEnabled = isAutoScrollEnabled,
-                                        displayedCurrentLineIndex = if (isAutoScrollEnabled) activeLineIndices.maxOrNull() ?: 0 else index, romanizeAsMain = romanizeAsMain,
+                                        displayedCurrentLineIndex = if (isAutoScrollEnabled) anchoredLineIndex else index, romanizeAsMain = romanizeAsMain,
                                         enabledLanguages = enabledLanguages, romanizeLyrics = currentSong?.romanizeLyrics == true,
                                         onSizeChanged = { itemHeights[listIndex] = it },
                                         onClick = {

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/ExperimentalLyrics.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/ExperimentalLyrics.kt
@@ -38,6 +38,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateMapOf
@@ -394,10 +395,40 @@ fun ExperimentalLyrics(
         }
     }
 
-    val activeListIndex by remember(mergedLyricsList, anchoredLineIndex) {
+    val scrollTargetListIndex by remember(
+        mergedLyricsList,
+        activeLineIndices,
+        anchoredLineIndex,
+        currentPositionState,
+    ) {
         derivedStateOf {
-            mergedLyricsList.indexOfFirst { it is LyricsListItem.Line && it.index == anchoredLineIndex }
-                .coerceAtLeast(0)
+            val activeLineListIndex = if (activeLineIndices.isEmpty()) {
+                -1
+            } else {
+                mergedLyricsList.indexOfFirst {
+                    it is LyricsListItem.Line && it.index == anchoredLineIndex
+                }
+            }
+
+            if (activeLineListIndex >= 0) {
+                activeLineListIndex
+            } else {
+                mergedLyricsList.indexOfFirst { item ->
+                    item is LyricsListItem.Indicator &&
+                        currentPositionState >= item.gapStartMs &&
+                        currentPositionState <= item.gapEndMs - 650L
+                }.takeIf { it >= 0 }
+            }
+        }
+    }
+    var activeListIndex by remember(lyrics) { mutableIntStateOf(0) }
+
+    LaunchedEffect(scrollTargetListIndex, mergedLyricsList.lastIndex) {
+        val targetListIndex = scrollTargetListIndex
+        if (targetListIndex != null) {
+            activeListIndex = targetListIndex
+        } else if (mergedLyricsList.isNotEmpty()) {
+            activeListIndex = activeListIndex.coerceIn(0, mergedLyricsList.lastIndex)
         }
     }
 

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/ExperimentalLyrics.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/ExperimentalLyrics.kt
@@ -12,15 +12,10 @@ import android.view.WindowManager
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.AnimationState
 import androidx.compose.animation.core.FastOutSlowInEasing
-import androidx.compose.animation.core.animateDecay
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.exponentialDecay
-import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.gestures.awaitFirstDown
-import androidx.compose.foundation.gestures.verticalDrag
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -43,8 +38,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
-import androidx.compose.runtime.mutableFloatStateOf
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateMapOf
@@ -55,7 +48,6 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -67,22 +59,24 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.util.VelocityTracker
+import androidx.compose.ui.input.pointer.util.addPointerInputChange
+import androidx.compose.ui.input.pointer.changedToUp
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.res.stringResource
 import android.text.Layout
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.metrolist.music.LocalDatabase
 import com.metrolist.music.LocalListenTogetherManager
@@ -122,10 +116,10 @@ import com.metrolist.music.utils.ComposeToImage
 import com.metrolist.music.utils.rememberEnumPreference
 import com.metrolist.music.utils.rememberPreference
 import com.metrolist.music.viewmodels.LyricsViewModel
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlin.math.abs
@@ -136,9 +130,6 @@ private val LYRICS_ITEM_FALLBACK_HEIGHT_DP = 68.dp
 private val LYRICS_ITEM_GAP_DP = 16.dp
 private val LYRICS_FADE_TOP_DP = 130.dp
 private val LYRICS_FADE_BOTTOM_DP = 160.dp
-private const val LYRICS_STAGGER_DELAY_PER_DISTANCE = 20
-private const val LYRICS_STAGGER_DELAY_MAX_MS = 200
-private const val LYRICS_PREVIEW_TIME = 8000L
 
 @OptIn(
     ExperimentalMaterial3Api::class,
@@ -228,8 +219,6 @@ fun ExperimentalLyrics(
     }
 
     val isSynced = remember(lyrics) { lyricsTextLooksSynced(lyrics) }
-    val hasWordTimings = remember(lines) { lines.any { it.words?.isNotEmpty() == true } }
-
     DisposableEffect(Unit) {
         LyricsTranslationHelper.setCompositionActive(true)
         onDispose {
@@ -301,13 +290,17 @@ fun ExperimentalLyrics(
         PlayerBackgroundStyle.BLUR, PlayerBackgroundStyle.GRADIENT -> Color.White
     }
 
-    var activeLineIndices by remember { mutableStateOf(emptySet<Int>()) }
-    var scrollTargetIndex by rememberSaveable { mutableIntStateOf(-1) }
-    var previousScrollActiveIndices by remember { mutableStateOf(emptySet<Int>()) }
-    
-    var currentPositionState by remember { mutableLongStateOf(0L) }
-    var deferredCurrentLineIndex by rememberSaveable { mutableIntStateOf(0) }
-    var lastPreviewTime by rememberSaveable { mutableLongStateOf(0L) }
+    var currentPositionState by remember {
+        mutableLongStateOf(runCatching { playerConnection.player.currentPosition }.getOrDefault(0L))
+    }
+    var activeLineIndices by remember(lines, currentSong?.id) {
+        mutableStateOf(
+            findActiveLineIndices(
+                lines,
+                currentPositionState + (currentSong?.song?.lyricsOffset ?: 0),
+            ).toSet(),
+        )
+    }
     var isSeeking by remember { mutableStateOf(false) }
     var showProgressDialog by remember { mutableStateOf(false) }
     var showShareDialog by remember { mutableStateOf(false) }
@@ -316,8 +309,11 @@ fun ExperimentalLyrics(
     var isSelectionModeActive by rememberSaveable { mutableStateOf(false) }
     val selectedIndices = remember { mutableStateListOf<Int>() }
     var showMaxSelectionToast by remember { mutableStateOf(false) }
-    val isLyricsProviderShown = lyricsEntity != null && lyricsEntity.provider != "Unknown" && lyricsEntity.provider != "Manual" && !isSelectionModeActive
     var isAutoScrollEnabled by rememberSaveable { mutableStateOf(true) }
+    val isLyricsProviderShown = lyricsEntity != null &&
+        lyricsEntity.provider != "Unknown" &&
+        lyricsEntity.provider != "Manual" &&
+        !isSelectionModeActive
 
     BackHandler(enabled = isSelectionModeActive) {
         isSelectionModeActive = false
@@ -331,9 +327,6 @@ fun ExperimentalLyrics(
             showMaxSelectionToast = false
         }
     }
-
-    var lastMainMaxSeen by remember(lyrics, lines) { mutableIntStateOf(-1) }
-    var smoothPositionForSync by remember { mutableLongStateOf(0L) }
 
     LaunchedEffect(lyrics, lines) {
         if (lyrics.isNullOrEmpty() || lines.isEmpty()) {
@@ -363,129 +356,46 @@ fun ExperimentalLyrics(
             }
             
             currentPositionState = position
-            smoothPositionForSync = position
-            
             val lyricsOffset = currentSong?.song?.lyricsOffset ?: 0
             val effectivePosition = position + lyricsOffset
             
-            val initialActiveIndices = findActiveLineIndices(lines, effectivePosition)
-            val scrollActiveIndicesRaw = findActiveLineIndices(lines, effectivePosition + (if (hasWordTimings) 0L else 250L))
-            
-            val scrollActiveIndices = scrollActiveIndicesRaw.toMutableSet()
-            for (i in scrollActiveIndicesRaw) {
+            val activeIndices = findActiveLineIndices(lines, effectivePosition).toMutableSet()
+            for (i in activeIndices.toList()) {
                 if (lines.getOrNull(i)?.isBackground == true) {
                     for (j in i - 1 downTo 0) {
                         if (lines.getOrNull(j)?.isBackground == false) {
-                            scrollActiveIndices.add(j)
+                            activeIndices.add(j)
                             break
                         }
                     }
                 }
             }
-            
-            val newActiveIndices = initialActiveIndices.toMutableSet()
-            for (i in initialActiveIndices) {
-                if (lines.getOrNull(i)?.isBackground == true) {
-                    for (j in i - 1 downTo 0) {
-                        if (lines.getOrNull(j)?.isBackground == false) {
-                            newActiveIndices.add(j)
-                            break
-                        }
-                    }
-                }
-            }
-
-            val scrollMax = scrollActiveIndices
-                .filter { lines.getOrNull(it)?.isBackground == false }
-                .maxOrNull() ?: (scrollActiveIndices.maxOrNull() ?: -1)
-
-            val isCurrentTargetStillActive = scrollTargetIndex in scrollActiveIndices
-            val anyStillActive = scrollActiveIndices.isNotEmpty()
-
-            val shouldScroll = when {
-                isSeeking -> true
-                // If current target just ended and there are other active lines, scroll to the new max
-                !isCurrentTargetStillActive && anyStillActive && scrollMax > scrollTargetIndex -> true
-                
-                // If current target just ended and no other active lines
-                !isCurrentTargetStillActive && !anyStillActive && previousScrollActiveIndices.isNotEmpty() -> true
-                
-                // If we don't have a target yet and lines became active
-                scrollTargetIndex == -1 && anyStillActive -> true
-                
-                // New line started while nothing was active before
-                previousScrollActiveIndices.isEmpty() && anyStillActive && scrollMax > scrollTargetIndex -> true
-
-                else -> false
-            }
-
-            if (shouldScroll) {
-                val targetToScroll = when {
-                    isSeeking -> scrollMax
-                    !isCurrentTargetStillActive && anyStillActive -> scrollMax
-                    !isCurrentTargetStillActive && !anyStillActive -> {
-                        (lastMainMaxSeen + 1 until lines.size).firstOrNull {
-                            lines.getOrNull(it)?.isBackground == false
-                        } ?: scrollTargetIndex
-                    }
-                    else -> scrollMax
-                }
-                if (targetToScroll != -1 && (isSeeking || targetToScroll > scrollTargetIndex)) {
-                    scrollTargetIndex = targetToScroll
-                }
-            }
-            
-            if (scrollMax > lastMainMaxSeen && scrollMax != -1) {
-                lastMainMaxSeen = scrollMax
-            }
-            
-            previousScrollActiveIndices = scrollActiveIndices
-            activeLineIndices = newActiveIndices
+            activeLineIndices = activeIndices
         }
     }
 
-    LaunchedEffect(isSeeking, lastPreviewTime) {
-        if (isSeeking) {
-            lastPreviewTime = 0L
-        } else if (lastPreviewTime != 0L) {
-            delay(LYRICS_PREVIEW_TIME)
-            lastPreviewTime = 0L
-        }
-    }
-
-    LaunchedEffect(scrollTargetIndex, isAutoScrollEnabled) {
-        if (scrollTargetIndex != -1 && isAutoScrollEnabled) {
-            deferredCurrentLineIndex = scrollTargetIndex
-        }
-    }
-
-    var userManualOffset by remember { mutableFloatStateOf(0f) }
-    LaunchedEffect(lyrics, lines) {
-        isAutoScrollEnabled = true
-        userManualOffset = 0f
-        scrollTargetIndex = -1
-        deferredCurrentLineIndex = 0
-        isSelectionModeActive = false
-        selectedIndices.clear()
-        previousScrollActiveIndices = emptySet()
-    }
-    
-    var flingJob by remember { mutableStateOf<kotlinx.coroutines.Job?>(null) }
-    val velocityTracker = remember { VelocityTracker() }
-    val decayAnimSpec = remember { exponentialDecay<Float>(frictionMultiplier = 1.8f) }
+    val viewConfiguration = LocalViewConfiguration.current
     val itemHeights = remember(lyrics, mergedLyricsList) { mutableStateMapOf<Int, Int>() }
-    var isInitialLayout by remember(lyrics, mergedLyricsList) { mutableStateOf(true) }
+    val scrollOffset = remember { Animatable(0f) }
+    val manualScrollRequests = remember { Channel<Float>(Channel.CONFLATED) }
+    var hasAutoPositioned by remember(lyrics) { mutableStateOf(false) }
 
-    val activeListIndex by remember(mergedLyricsList, deferredCurrentLineIndex) {
-        derivedStateOf {
-            mergedLyricsList.indexOfFirst { 
-                (it is LyricsListItem.Line && it.index == deferredCurrentLineIndex) ||
-                (it is LyricsListItem.Indicator && it.afterLineIndex == deferredCurrentLineIndex)
-            }.coerceAtLeast(0)
+    LaunchedEffect(manualScrollRequests) {
+        for (targetOffset in manualScrollRequests) {
+            scrollOffset.snapTo(targetOffset)
         }
     }
 
-    val lifecycleOwner = LocalLifecycleOwner.current
+    val activeListIndex by remember(mergedLyricsList, activeLineIndices) {
+        derivedStateOf {
+            val activeLine = activeLineIndices
+                .filter { lines.getOrNull(it)?.isBackground == false }
+                .maxOrNull() ?: activeLineIndices.maxOrNull() ?: 0
+            mergedLyricsList.indexOfFirst { it is LyricsListItem.Line && it.index == activeLine }
+                .coerceAtLeast(0)
+        }
+    }
+
     DisposableEffect(showLyrics) {
         val activity = context as? Activity
         if (showLyrics) activity?.window?.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
@@ -498,145 +408,52 @@ fun ExperimentalLyrics(
     ) {
         val maxHeightPx = constraints.maxHeight.toFloat()
         val anchorY = maxHeightPx * LYRICS_ANCHOR_RATIO
-        val lineHeightPx = with(density) { LYRICS_ITEM_FALLBACK_HEIGHT_DP.toPx() }
+        val contentTop = with(density) { 56.dp.toPx() }
         val indicatorHeightPx = with(density) { 72.dp.toPx() }
-        
-        // Use a more permissive fallback for constraints to prevent "locks" if items are not measured yet
-        val constraintLineHeightPx = with(density) { 120.dp.toPx() }
+        val lineHeightPx = with(density) { LYRICS_ITEM_FALLBACK_HEIGHT_DP.toPx() }
 
-        val positions = remember(itemHeights.toMap(), activeListIndex, mergedLyricsList) {
+        // Each item is positioned from the start of the song. The active line only changes
+        // the viewport's offset, so playback never changes the layout of individual lines.
+        val positions = remember(itemHeights.toMap(), mergedLyricsList) {
             val map = mutableMapOf<Int, Float>()
-            if (activeListIndex == -1 || mergedLyricsList.isEmpty()) return@remember map
-            
-            map[activeListIndex] = 0f
             var currentY = 0f
-            for (i in activeListIndex - 1 downTo 0) {
-                val item = mergedLyricsList[i]
-                val height = itemHeights[i]?.toFloat() ?: (if (item is LyricsListItem.Indicator) indicatorHeightPx else lineHeightPx)
+            mergedLyricsList.forEachIndexed { index, item ->
+                map[index] = currentY
+                val height = itemHeights[index]?.toFloat()
+                    ?: (if (item is LyricsListItem.Indicator) indicatorHeightPx else lineHeightPx)
                 val noGap = (item as? LyricsListItem.Line)?.entry?.isBackground == true || item is LyricsListItem.Indicator
-                currentY -= (height + if (noGap) 0f else with(density) { LYRICS_ITEM_GAP_DP.toPx() })
-                map[i] = currentY
-            }
-            currentY = 0f
-            for (i in activeListIndex until mergedLyricsList.size - 1) {
-                val currentItem = mergedLyricsList[i]
-                val nextItem = mergedLyricsList[i + 1]
-                val height = itemHeights[i]?.toFloat() ?: (if (currentItem is LyricsListItem.Indicator) indicatorHeightPx else lineHeightPx)
-                val nextNoGap = (nextItem as? LyricsListItem.Line)?.entry?.isBackground == true || nextItem is LyricsListItem.Indicator
-                currentY += (height + if (nextNoGap) 0f else with(density) { LYRICS_ITEM_GAP_DP.toPx() })
-                map[i + 1] = currentY
+                currentY += height + if (noGap) 0f else with(density) { LYRICS_ITEM_GAP_DP.toPx() }
             }
             map
         }
-
-        val minOffset = remember(itemHeights.toMap(), mergedLyricsList, activeListIndex, anchorY) {
-            if (mergedLyricsList.isEmpty() || activeListIndex == -1) return@remember 0f
-            val totalBelow = (activeListIndex until mergedLyricsList.size - 1).sumOf { i ->
-                val currentItem = mergedLyricsList[i]
-                val nextItem = mergedLyricsList[i + 1]
-                val height = itemHeights[i]?.toFloat() ?: (if (currentItem is LyricsListItem.Indicator) indicatorHeightPx else constraintLineHeightPx)
-                val nextNoGap = (nextItem as? LyricsListItem.Line)?.entry?.isBackground == true || nextItem is LyricsListItem.Indicator
-                (height + if (nextNoGap) 0f else with(density) { LYRICS_ITEM_GAP_DP.toPx() }).toDouble()
-            }.toFloat()
-            val lastItem = mergedLyricsList.last()
-            val lastHeight = itemHeights[mergedLyricsList.size - 1]?.toFloat() ?: (if (lastItem is LyricsListItem.Indicator) indicatorHeightPx else constraintLineHeightPx)
-            with(density) { 100.dp.toPx() } - anchorY - totalBelow - lastHeight
-        }
-
-        val maxOffset = remember(itemHeights.toMap(), mergedLyricsList, activeListIndex, maxHeightPx, anchorY) {
-            if (mergedLyricsList.isEmpty() || activeListIndex == -1) return@remember 0f
-            val totalAbove = (0 until activeListIndex).sumOf { i ->
-                val item = mergedLyricsList[i]
-                val height = itemHeights[i]?.toFloat() ?: (if (item is LyricsListItem.Indicator) indicatorHeightPx else constraintLineHeightPx)
-                val noGap = (item as? LyricsListItem.Line)?.entry?.isBackground == true || item is LyricsListItem.Indicator
-                (height + if (noGap) 0f else with(density) { LYRICS_ITEM_GAP_DP.toPx() }).toDouble()
-            }.toFloat()
-            maxHeightPx - with(density) { 150.dp.toPx() } - anchorY + totalAbove
-        }
-
-        // Clamp to real content bounds only. minOffset/maxOffset already use conservative height
-        // fallbacks (constraintLineHeightPx) for items not yet measured; a large buffer here caused
-        // effectively unbounded overscroll away from the lyrics.
-        val scrollClampMin = minOf(minOffset, maxOffset)
-        val scrollClampMax = maxOf(minOffset, maxOffset)
+        // Let the first and last entries reach the playback anchor instead of pinning
+        // either edge of the list to the edge of the viewport.
+        val firstAnchorOffset = contentTop - anchorY
+        val lastAnchorOffset = contentTop + (positions[mergedLyricsList.lastIndex] ?: 0f) - anchorY
+        val scrollClampMin = minOf(firstAnchorOffset, lastAnchorOffset)
+        val scrollClampMax = maxOf(firstAnchorOffset, lastAnchorOffset)
+        val latestScrollLimits = rememberUpdatedState(scrollClampMin to scrollClampMax)
 
         LaunchedEffect(scrollClampMin, scrollClampMax) {
-            if (userManualOffset < scrollClampMin || userManualOffset > scrollClampMax) {
-                userManualOffset = userManualOffset.coerceIn(scrollClampMin, scrollClampMax)
-            }
+            scrollOffset.updateBounds(scrollClampMin, scrollClampMax)
         }
 
-        LaunchedEffect(isAutoScrollEnabled, lines) {
-            if (isAutoScrollEnabled) {
-                val start = userManualOffset
-                if (abs(start) < 1f) {
-                    userManualOffset = 0f
-                    return@LaunchedEffect
-                }
-                val anim = Animatable(start)
-                var lastValue = start
-                anim.animateTo(0f, tween((abs(start) / 4f).toInt().coerceIn(200, 600), easing = FastOutSlowInEasing)) {
-                    userManualOffset += (value - lastValue)
-                    lastValue = value
-                }
-                userManualOffset = 0f
-            }
-        }
-
-        LaunchedEffect(showLyrics, lyrics, mergedLyricsList.size) {
-            if (showLyrics && mergedLyricsList.isNotEmpty()) {
-                isInitialLayout = true
-                snapshotFlow { 
-                    val h = itemHeights.toMap()
-                    val windowStart = (activeListIndex - 8).coerceAtLeast(0)
-                    val windowEnd = (activeListIndex + 12).coerceAtMost(mergedLyricsList.size - 1)
-                    (windowStart..windowEnd).all { h.containsKey(it) } 
-                }.first { it }
-                isInitialLayout = false
-            }
-        }
-
-        // When jumping significantly, we might want to reset isInitialLayout to prevent jumps
-        LaunchedEffect(activeListIndex) {
-            if (mergedLyricsList.isNotEmpty()) {
-                val h = itemHeights.toMap()
-                val windowStart = (activeListIndex - 3).coerceAtLeast(0)
-                val windowEnd = (activeListIndex + 3).coerceAtMost(mergedLyricsList.size - 1)
-                val needsMeasurement = (windowStart..windowEnd).any { !h.containsKey(it) }
-                if (needsMeasurement) {
-                    isInitialLayout = true
-                    snapshotFlow { 
-                        val hh = itemHeights.toMap()
-                        (windowStart..windowEnd).all { hh.containsKey(it) } 
-                    }.first { it }
-                    isInitialLayout = false
+        LaunchedEffect(activeListIndex, isAutoScrollEnabled, scrollClampMax) {
+            if (isAutoScrollEnabled && positions.isNotEmpty()) {
+                val target = ((positions[activeListIndex] ?: 0f) + contentTop - anchorY)
+                    .coerceIn(scrollClampMin, scrollClampMax)
+                if (hasAutoPositioned) {
+                    scrollOffset.animateTo(target, tween(450, easing = FastOutSlowInEasing))
+                } else {
+                    scrollOffset.snapTo(target)
+                    hasAutoPositioned = true
                 }
             }
         }
 
         val latestShowLyrics by rememberUpdatedState(showLyrics)
         val latestResyncLyrics by rememberUpdatedState(
-            newValue = {
-                flingJob?.cancel()
-                var target = scrollTargetIndex
-                if (target == -1) {
-                    target =
-                        findActiveLineIndices(
-                            lines,
-                            currentPositionState + (currentSong?.song?.lyricsOffset ?: 0),
-                        ).maxOrNull() ?: -1
-                }
-                if (target != -1) {
-                    val listIdx =
-                        mergedLyricsList.indexOfFirst {
-                            it is LyricsListItem.Line && it.index == target
-                        }.coerceAtLeast(0)
-                    userManualOffset += positions[listIdx] ?: 0f
-                    deferredCurrentLineIndex = target
-                    scrollTargetIndex = target
-                }
-                isAutoScrollEnabled = true
-            },
+            newValue = { isAutoScrollEnabled = true },
         )
 
         LaunchedEffect(Unit) {
@@ -670,40 +487,50 @@ fun ExperimentalLyrics(
                     .clipToBounds()
                     .nestedScroll(remember {
                         object : NestedScrollConnection {
-                            override fun onPostScroll(consumed: Offset, available: Offset, source: NestedScrollSource): Offset {
-                                if (source == NestedScrollSource.UserInput) isAutoScrollEnabled = false
-                                if (!isSelectionModeActive) lastPreviewTime = System.currentTimeMillis()
-                                return super.onPostScroll(consumed, available, source)
-                            }
-                            override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
-                                isAutoScrollEnabled = false
-                                if (!isSelectionModeActive) lastPreviewTime = System.currentTimeMillis()
-                                return super.onPostFling(consumed, available)
+                            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                                return if (source == NestedScrollSource.UserInput && available.y != 0f) {
+                                    Offset(0f, available.y)
+                                } else {
+                                    Offset.Zero
+                                }
                             }
                         }
                     })
                     .pointerInput(Unit) {
-                        awaitPointerEventScope {
-                            while (true) {
-                                val down = awaitFirstDown(requireUnconsumed = false)
-                                if (isInitialLayout) continue
-                                flingJob?.cancel()
-                                velocityTracker.resetTracking()
-                                isAutoScrollEnabled = false
-                                lastPreviewTime = System.currentTimeMillis()
-                                velocityTracker.addPosition(down.uptimeMillis, down.position)
-                                verticalDrag(down.id) { change ->
-                                    userManualOffset = (userManualOffset + change.positionChange().y).coerceIn(scrollClampMin, scrollClampMax)
-                                    velocityTracker.addPosition(change.uptimeMillis, change.position)
-                                    change.consume()
-                                }
-                                val velocity = velocityTracker.calculateVelocity().y
-                                flingJob = scope.launch {
-                                    AnimationState(initialValue = userManualOffset, initialVelocity = velocity).animateDecay(decayAnimSpec) {
-                                        val clamped = value.coerceIn(scrollClampMin, scrollClampMax)
-                                        userManualOffset = clamped
-                                        if (value != clamped) cancelAnimation()
+                        coroutineScope {
+                            val gestureScope = this
+                            while (isActive) {
+                                val velocity = awaitPointerEventScope {
+                                    val down = awaitFirstDown(requireUnconsumed = false)
+                                    val tracker = VelocityTracker()
+                                    tracker.addPointerInputChange(down)
+                                    var dragging = false
+                                    var accumulatedDrag = 0f
+                                    var targetOffset = scrollOffset.value
+                                    while (true) {
+                                        val event = awaitPointerEvent(PointerEventPass.Initial)
+                                        val change = event.changes.firstOrNull { it.id == down.id } ?: break
+                                        if (change.changedToUp()) break
+                                        val delta = change.positionChange().y
+                                        accumulatedDrag += delta
+                                        if (!dragging && abs(accumulatedDrag) > viewConfiguration.touchSlop) {
+                                            dragging = true
+                                            isAutoScrollEnabled = false
+                                            gestureScope.launch { scrollOffset.stop() }
+                                        }
+                                        if (dragging && delta != 0f) {
+                                            val (minOffset, maxOffset) = latestScrollLimits.value
+                                            targetOffset = (targetOffset - delta)
+                                                .coerceIn(minOffset, maxOffset)
+                                            manualScrollRequests.trySend(targetOffset)
+                                            tracker.addPointerInputChange(change)
+                                            change.consume()
+                                        }
                                     }
+                                    if (dragging) -tracker.calculateVelocity().y else 0f
+                                }
+                                if (velocity != 0f) {
+                                    launch { scrollOffset.animateDecay(velocity, exponentialDecay()) }
                                 }
                             }
                         }
@@ -713,44 +540,23 @@ fun ExperimentalLyrics(
                 val currentEffectivePosition = currentPositionState + lyricsOffsetVal
                 
                 if (isLyricsProviderShown) {
-                    val targetProviderBase = anchorY + (positions[0] ?: 0f) - with(density) { 32.dp.toPx() }
-                    val animatedProviderBase by animateFloatAsState(
-                        targetValue = targetProviderBase,
-                        animationSpec = if (isInitialLayout || !isAutoScrollEnabled) snap()
-                        else {
-                            tween(750, 0, FastOutSlowInEasing)
-                        },
-                        label = "lyricsProviderOffset"
-                    )
+                    val targetProviderBase = contentTop - scrollOffset.value - with(density) { 32.dp.toPx() }
                     Text(
                         text = stringResource(R.string.lyrics_from_provider, lyricsEntity.provider),
                         fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                        modifier = Modifier.fillMaxWidth().offset { IntOffset(0, (animatedProviderBase + userManualOffset).roundToInt()) }.padding(horizontal = 24.dp, vertical = 4.dp)
+                        modifier = Modifier.fillMaxWidth().offset { IntOffset(0, targetProviderBase.roundToInt()) }.padding(horizontal = 24.dp, vertical = 4.dp)
                     )
                 }
 
                 mergedLyricsList.forEachIndexed { listIndex, listItem ->
                     key(listItem) {
-                        val distance = abs(listIndex - activeListIndex)
-                        val targetOffset = anchorY + positions.getOrDefault(listIndex, (listIndex - activeListIndex) * lineHeightPx)
-                        val frozenOffset = remember { mutableFloatStateOf(targetOffset) }
-                        LaunchedEffect(isAutoScrollEnabled, targetOffset, isInitialLayout) {
-                            if (isAutoScrollEnabled || isInitialLayout) frozenOffset.floatValue = targetOffset
-                        }
-                        val animatedOffset by animateFloatAsState(
-                            targetValue = if (isAutoScrollEnabled) targetOffset else frozenOffset.floatValue,
-                            animationSpec = if (isInitialLayout || !isAutoScrollEnabled) snap() 
-                                            else {
-                                                tween(750, (distance * LYRICS_STAGGER_DELAY_PER_DISTANCE).coerceAtMost(LYRICS_STAGGER_DELAY_MAX_MS), FastOutSlowInEasing)
-                                            },
-                            label = "lyricStaggeredOffset_$listIndex"
-                        )
+                        val targetOffset = contentTop + positions.getOrDefault(listIndex, listIndex * lineHeightPx) - scrollOffset.value
 
                         Box(
                             modifier = Modifier.fillMaxWidth().layout { m, c -> 
                                 val p = m.measure(c.copy(maxHeight = Constraints.Infinity))
                                 layout(p.width, 0) { p.place(0, 0) }
-                            }.offset { IntOffset(0, (animatedOffset + userManualOffset).roundToInt()) }
+                            }.offset { IntOffset(0, targetOffset.roundToInt()) }
                         ) {
                             when (listItem) {
                                 is LyricsListItem.Indicator -> {
@@ -783,7 +589,7 @@ fun ExperimentalLyrics(
                                         playerConnection = playerConnection, lyricsTextSize = 36f, lyricsLineSpacing = 1.3f,
                                         expressiveAccent = expressiveAccent, lyricsTextPosition = lyricsTextPosition,
                                         respectAgentPositioning = respectAgentPositioning, isAutoScrollEnabled = isAutoScrollEnabled,
-                                        displayedCurrentLineIndex = deferredCurrentLineIndex, romanizeAsMain = romanizeAsMain,
+                                        displayedCurrentLineIndex = if (isAutoScrollEnabled) activeLineIndices.maxOrNull() ?: 0 else index, romanizeAsMain = romanizeAsMain,
                                         enabledLanguages = enabledLanguages, romanizeLyrics = currentSong?.romanizeLyrics == true,
                                         onSizeChanged = { itemHeights[listIndex] = it },
                                         onClick = {
@@ -796,12 +602,8 @@ fun ExperimentalLyrics(
                                             } else if (changeLyrics && !isGuest) {
                                                 if (item.time < playerConnection.player.duration + 30000L) {
                                                     playerConnection.seekTo((item.time - (currentSong?.song?.lyricsOffset ?: 0)).coerceAtLeast(0))
-                                                } else {
-                                                    scrollTargetIndex = index
-                                                    deferredCurrentLineIndex = index
                                                 }
                                                 isAutoScrollEnabled = true
-                                                lastPreviewTime = 0L
                                             }
                                         },
                                         onLongClick = {

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/ExperimentalLyrics.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/ExperimentalLyrics.kt
@@ -338,7 +338,20 @@ fun ExperimentalLyrics(
         }
     }
 
-    LaunchedEffect(lyrics, lines, mergedLyricsList) {
+    val backgroundToMainMap = remember(lines) {
+        val map = mutableMapOf<Int, Int>()
+        for (i in lines.indices) {
+            if (lines[i].isBackground) {
+                val pairedMain = (i - 1 downTo 0).firstOrNull { !lines[it].isBackground } ?: -1
+                if (pairedMain != -1) {
+                    map[i] = pairedMain
+                }
+            }
+        }
+        map
+    }
+
+    LaunchedEffect(lyrics, lines, mergedLyricsList, backgroundToMainMap) {
         if (lyrics.isNullOrEmpty() || lines.isEmpty()) {
             activeLineIndices = emptySet()
             visibleBackgroundLineIndices = emptySet()
@@ -374,13 +387,9 @@ fun ExperimentalLyrics(
             val newActiveIndices = if (isSynced) {
                 val active = findActiveLineIndices(lines, effectivePosition).toMutableSet()
                 for (i in active.toList()) {
-                    if (lines.getOrNull(i)?.isBackground == true) {
-                        for (j in i - 1 downTo 0) {
-                            if (lines.getOrNull(j)?.isBackground == false) {
-                                active.add(j)
-                                break
-                            }
-                        }
+                    val pairedMain = backgroundToMainMap[i]
+                    if (pairedMain != null) {
+                        active.add(pairedMain)
                     }
                 }
                 active
@@ -393,17 +402,12 @@ fun ExperimentalLyrics(
 
             if (isSynced) {
                 val newBgVisible = mutableSetOf<Int>()
-                for (i in lines.indices) {
-                    val entry = lines[i]
-                    if (entry.isBackground) {
-                        val pairedMain = (i - 1 downTo 0).firstOrNull { lines.getOrNull(it)?.isBackground == false } ?: -1
-                        val inGap = if (pairedMain != -1) {
-                            val mainTime = lines[pairedMain].time
-                            effectivePosition in mainTime..entry.time
-                        } else false
-                        if (newActiveIndices.contains(i) || (pairedMain != -1 && newActiveIndices.contains(pairedMain)) || inGap) {
-                            newBgVisible.add(i)
-                        }
+                for ((bgIndex, pairedMain) in backgroundToMainMap) {
+                    val mainTime = lines[pairedMain].time
+                    val bgTime = lines[bgIndex].time
+                    val inGap = effectivePosition in mainTime..bgTime
+                    if (newActiveIndices.contains(bgIndex) || newActiveIndices.contains(pairedMain) || inGap) {
+                        newBgVisible.add(bgIndex)
                     }
                 }
                 if (visibleBackgroundLineIndices != newBgVisible) {
@@ -535,6 +539,34 @@ fun ExperimentalLyrics(
             derivedStateOf { maxOf(firstAnchorOffset, lastAnchorOffset.value) } 
         }
 
+        val latestScrollLimits = rememberUpdatedState(scrollClampMin.value to scrollClampMax.value)
+        val dragTargetOffsetRef = remember { object { var value: Float = 0f } }
+
+        val onItemHeightChanged = rememberUpdatedState { index: Int, newHeight: Int ->
+            val prevHeight = itemHeights[index]
+            if (prevHeight == newHeight) return@rememberUpdatedState
+
+            val fallbackHeight = if (mergedLyricsList.getOrNull(index) is LyricsListItem.Indicator) {
+                indicatorHeightPx.roundToInt()
+            } else {
+                lineHeightPx.roundToInt()
+            }
+            val oldHeight = prevHeight ?: fallbackHeight
+            val delta = (newHeight - oldHeight).toFloat()
+
+            itemHeights[index] = newHeight
+
+            if (delta != 0f && positions.isNotEmpty() && hasAutoPositioned) {
+                val currentAnchorY = scrollOffset.value - contentTop + anchorY
+                val itemY = positions.getOrElse(index) { 0f }
+                if (itemY < currentAnchorY) {
+                    val newOffset = scrollOffset.value + delta
+                    dragTargetOffsetRef.value += delta
+                    scrollCommands.trySend(ScrollCommand.Snap(newOffset))
+                }
+            }
+        }
+
         LaunchedEffect(scrollClampMin.value, scrollClampMax.value) {
             scrollOffset.updateBounds(scrollClampMin.value, scrollClampMax.value)
         }
@@ -642,6 +674,7 @@ fun ExperimentalLyrics(
                                     var dragging = false
                                     var accumulatedDrag = 0f
                                     var targetOffset = scrollOffset.value
+                                    dragTargetOffsetRef.value = targetOffset
                                     while (true) {
                                         val event = awaitPointerEvent(PointerEventPass.Initial)
                                         val change = event.changes.firstOrNull { it.id == down.id } ?: break
@@ -652,11 +685,14 @@ fun ExperimentalLyrics(
                                             dragging = true
                                             isAutoScrollEnabled = false
                                             targetOffset = scrollOffset.value
+                                            dragTargetOffsetRef.value = targetOffset
                                             scrollCommands.trySend(ScrollCommand.Stop)
                                         }
                                         if (dragging && delta != 0f) {
-                                            targetOffset = (targetOffset - delta)
-                                                .coerceIn(scrollClampMin.value, scrollClampMax.value)
+                                            val (minClamp, maxClamp) = latestScrollLimits.value
+                                            targetOffset = (dragTargetOffsetRef.value - delta)
+                                                .coerceIn(minClamp, maxClamp)
+                                            dragTargetOffsetRef.value = targetOffset
                                             scrollCommands.trySend(ScrollCommand.Snap(targetOffset))
                                             tracker.addPointerInputChange(change)
                                             change.consume()
@@ -711,7 +747,7 @@ fun ExperimentalLyrics(
                                         color = expressiveAccent,
                                         modifier = Modifier
                                             .fillMaxWidth()
-                                            .onSizeChanged { itemHeights[listIndex] = it.height }
+                                            .onSizeChanged { onItemHeightChanged.value(listIndex, it.height) }
                                             .padding(horizontal = 24.dp)
                                             .wrapContentWidth(Alignment.CenterHorizontally)
                                     )
@@ -734,7 +770,7 @@ fun ExperimentalLyrics(
                                         respectAgentPositioning = respectAgentPositioning, isAutoScrollEnabled = isAutoScrollEnabled,
                                         displayedCurrentLineIndex = if (isAutoScrollEnabled) anchoredLineIndex else index, romanizeAsMain = romanizeAsMain,
                                         enabledLanguages = enabledLanguages, romanizeLyrics = currentSong?.romanizeLyrics == true,
-                                        onSizeChanged = { itemHeights[listIndex] = it },
+                                        onSizeChanged = { onItemHeightChanged.value(listIndex, it) },
                                         onClick = {
                                             if (isSelectionModeActive) {
                                                 if (selectedIndices.contains(index)) {

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/ExperimentalLyrics.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/ExperimentalLyrics.kt
@@ -297,16 +297,19 @@ fun ExperimentalLyrics(
         PlayerBackgroundStyle.BLUR, PlayerBackgroundStyle.GRADIENT -> Color.White
     }
 
-    var currentPositionState by remember {
-        mutableLongStateOf(runCatching { playerConnection.player.currentPosition }.getOrDefault(0L))
+    val currentPositionRef = remember {
+        object {
+            var position: Long = runCatching { playerConnection.player.currentPosition }.getOrDefault(0L)
+        }
     }
     var activeLineIndices by remember(lines, currentSong?.id) {
-        mutableStateOf(
-            findActiveLineIndices(
-                lines,
-                currentPositionState + (currentSong?.song?.lyricsOffset ?: 0),
-            ).toSet(),
-        )
+        mutableStateOf(emptySet<Int>())
+    }
+    var visibleBackgroundLineIndices by remember(lines, currentSong?.id) {
+        mutableStateOf(emptySet<Int>())
+    }
+    var activeIndicatorListIndex by remember(mergedLyricsList) {
+        mutableStateOf<Int?>(null)
     }
     var isSeeking by remember { mutableStateOf(false) }
     var showProgressDialog by remember { mutableStateOf(false) }
@@ -335,24 +338,27 @@ fun ExperimentalLyrics(
         }
     }
 
-    LaunchedEffect(lyrics, lines) {
+    LaunchedEffect(lyrics, lines, mergedLyricsList) {
         if (lyrics.isNullOrEmpty() || lines.isEmpty()) {
             activeLineIndices = emptySet()
+            visibleBackgroundLineIndices = emptySet()
+            activeIndicatorListIndex = null
             return@LaunchedEffect
         }
         
-        var lastPlayerPos = playerConnection.player.currentPosition
+        var lastPlayerPos = runCatching { playerConnection.player.currentPosition }.getOrDefault(0L)
         var lastUpdateTime = System.currentTimeMillis()
         
         while (isActive) {
             withFrameNanos { _ -> }
             val now = System.currentTimeMillis()
             val sliderPosition = sliderPositionProvider()
-            isSeeking = sliderPosition != null
+            val isCurrentlySeeking = sliderPosition != null
+            if (isSeeking != isCurrentlySeeking) {
+                isSeeking = isCurrentlySeeking
+            }
             
-            val position = if (isSeeking) {
-                sliderPosition!!
-            } else {
+            val position = sliderPosition ?: run {
                 val playerPos = playerConnection.player.currentPosition
                 if (playerPos != lastPlayerPos) {
                     lastPlayerPos = playerPos
@@ -361,12 +367,11 @@ fun ExperimentalLyrics(
                 val elapsed = now - lastUpdateTime
                 lastPlayerPos + (if (playerConnection.player.isPlaying) elapsed else 0)
             }
-            
-            currentPositionState = position
+            currentPositionRef.position = position
             val lyricsOffset = currentSong?.song?.lyricsOffset ?: 0
             val effectivePosition = position + lyricsOffset
             
-            val activeIndices = if (isSynced) {
+            val newActiveIndices = if (isSynced) {
                 val active = findActiveLineIndices(lines, effectivePosition).toMutableSet()
                 for (i in active.toList()) {
                     if (lines.getOrNull(i)?.isBackground == true) {
@@ -382,7 +387,40 @@ fun ExperimentalLyrics(
             } else {
                 lines.indices.toSet()
             }
-            activeLineIndices = activeIndices
+            if (activeLineIndices != newActiveIndices) {
+                activeLineIndices = newActiveIndices
+            }
+
+            if (isSynced) {
+                val newBgVisible = mutableSetOf<Int>()
+                for (i in lines.indices) {
+                    val entry = lines[i]
+                    if (entry.isBackground) {
+                        val pairedMain = (i - 1 downTo 0).firstOrNull { lines.getOrNull(it)?.isBackground == false } ?: -1
+                        val inGap = if (pairedMain != -1) {
+                            val mainTime = lines[pairedMain].time
+                            effectivePosition in mainTime..entry.time
+                        } else false
+                        if (newActiveIndices.contains(i) || (pairedMain != -1 && newActiveIndices.contains(pairedMain)) || inGap) {
+                            newBgVisible.add(i)
+                        }
+                    }
+                }
+                if (visibleBackgroundLineIndices != newBgVisible) {
+                    visibleBackgroundLineIndices = newBgVisible
+                }
+            }
+
+            val newIndicator = if (newActiveIndices.isEmpty()) {
+                mergedLyricsList.indexOfFirst { item ->
+                    item is LyricsListItem.Indicator &&
+                        effectivePosition >= item.gapStartMs &&
+                        effectivePosition <= item.gapEndMs - 650L
+                }.takeIf { it >= 0 }
+            } else null
+            if (activeIndicatorListIndex != newIndicator) {
+                activeIndicatorListIndex = newIndicator
+            }
         }
     }
 
@@ -415,7 +453,7 @@ fun ExperimentalLyrics(
         mergedLyricsList,
         activeLineIndices,
         anchoredLineIndex,
-        currentPositionState,
+        activeIndicatorListIndex,
     ) {
         derivedStateOf {
             val activeLineListIndex = if (activeLineIndices.isEmpty()) {
@@ -429,11 +467,7 @@ fun ExperimentalLyrics(
             if (activeLineListIndex >= 0) {
                 activeLineListIndex
             } else {
-                mergedLyricsList.indexOfFirst { item ->
-                    item is LyricsListItem.Indicator &&
-                        currentPositionState >= item.gapStartMs &&
-                        currentPositionState <= item.gapEndMs - 650L
-                }.takeIf { it >= 0 }
+                activeIndicatorListIndex
             }
         }
     }
@@ -469,30 +503,35 @@ fun ExperimentalLyrics(
         // the viewport's offset, so playback never changes the layout of individual lines.
         val positions by remember(mergedLyricsList) {
             derivedStateOf {
-                val map = mutableMapOf<Int, Float>()
+                val n = mergedLyricsList.size
+                val arr = FloatArray(n)
                 var currentY = 0f
-                mergedLyricsList.forEachIndexed { index, item ->
-                    map[index] = currentY
-                    val height = itemHeights[index]?.toFloat()
+                for (i in 0 until n) {
+                    arr[i] = currentY
+                    val item = mergedLyricsList[i]
+                    val height = itemHeights[i]?.toFloat()
                         ?: (if (item is LyricsListItem.Indicator) indicatorHeightPx else lineHeightPx)
                     val noGap = (item as? LyricsListItem.Line)?.entry?.isBackground == true || item is LyricsListItem.Indicator
                     currentY += height + if (noGap) 0f else itemGapPx
                 }
-                map
+                arr
             }
         }
         // Let the first and last entries reach the playback anchor instead of pinning
         // either edge of the list to the edge of the viewport.
         val firstAnchorOffset = contentTop - anchorY
-        val lastAnchorOffset = remember(positions) {
+        val lastAnchorOffset = remember(positions, contentTop, anchorY, mergedLyricsList.lastIndex) {
             derivedStateOf {
-                contentTop + (positions[mergedLyricsList.lastIndex] ?: 0f) - anchorY
+                val lastY = if (positions.isNotEmpty() && mergedLyricsList.isNotEmpty()) {
+                    positions[mergedLyricsList.lastIndex]
+                } else 0f
+                contentTop + lastY - anchorY
             }
         }
-        val scrollClampMin = remember(lastAnchorOffset) { 
+        val scrollClampMin = remember(lastAnchorOffset, firstAnchorOffset) { 
             derivedStateOf { minOf(firstAnchorOffset, lastAnchorOffset.value) } 
         }
-        val scrollClampMax = remember(lastAnchorOffset) { 
+        val scrollClampMax = remember(lastAnchorOffset, firstAnchorOffset) { 
             derivedStateOf { maxOf(firstAnchorOffset, lastAnchorOffset.value) } 
         }
 
@@ -500,13 +539,35 @@ fun ExperimentalLyrics(
             scrollOffset.updateBounds(scrollClampMin.value, scrollClampMax.value)
         }
 
-        val autoScrollTarget = remember(positions, activeListIndex, scrollClampMin, scrollClampMax) {
+        val autoScrollTarget = remember(
+            positions,
+            activeListIndex,
+            scrollClampMin,
+            scrollClampMax,
+            contentTop,
+            anchorY
+        ) {
             derivedStateOf {
-                if (positions.isEmpty()) {
+                if (positions.isEmpty() || activeListIndex !in positions.indices) {
                     null
                 } else {
-                    ((positions[activeListIndex] ?: 0f) + contentTop - anchorY)
+                    (positions[activeListIndex] + contentTop - anchorY)
                         .coerceIn(scrollClampMin.value, scrollClampMax.value)
+                }
+            }
+        }
+
+        val visibleRange by remember(positions, contentTop, maxHeightPx, mergedLyricsList.size) {
+            derivedStateOf {
+                if (positions.isEmpty() || mergedLyricsList.isEmpty()) {
+                    IntRange.EMPTY
+                } else {
+                    val currentOffset = scrollOffset.value
+                    val minListY = currentOffset - contentTop - maxHeightPx
+                    val maxListY = currentOffset - contentTop + (2f * maxHeightPx)
+                    val start = findStartIndex(positions, minListY)
+                    val end = findEndIndex(positions, maxListY)
+                    start..end
                 }
             }
         }
@@ -573,6 +634,9 @@ fun ExperimentalLyrics(
                             while (isActive) {
                                 val velocity = awaitPointerEventScope {
                                     val down = awaitFirstDown(requireUnconsumed = false)
+                                    if (!isAutoScrollEnabled && scrollOffset.isRunning) {
+                                        scrollCommands.trySend(ScrollCommand.Stop)
+                                    }
                                     val tracker = VelocityTracker()
                                     tracker.addPointerInputChange(down)
                                     var dragging = false
@@ -607,9 +671,6 @@ fun ExperimentalLyrics(
                         }
                     }
             ) {
-                val lyricsOffsetVal = (currentSong?.song?.lyricsOffset ?: 0).toLong()
-                val currentEffectivePosition = currentPositionState + lyricsOffsetVal
-                
                 if (isLyricsProviderShown) {
                     Text(
                         text = stringResource(R.string.lyrics_from_provider, lyricsEntity.provider),
@@ -624,7 +685,8 @@ fun ExperimentalLyrics(
                     )
                 }
 
-                mergedLyricsList.forEachIndexed { listIndex, listItem ->
+                for (listIndex in visibleRange) {
+                    val listItem = mergedLyricsList[listIndex]
                     key(listItem) {
                         Box(
                             modifier = Modifier
@@ -634,37 +696,38 @@ fun ExperimentalLyrics(
                                     layout(p.width, 0) { p.place(0, 0) }
                                 }
                                 .offset {
-                                    val y = contentTop + (positions[listIndex] ?: (listIndex * lineHeightPx)) - scrollOffset.value
+                                    val y = contentTop + (positions.getOrElse(listIndex) { listIndex * lineHeightPx }) - scrollOffset.value
                                     IntOffset(0, y.roundToInt())
                                 }
                         ) {
                             when (listItem) {
                                 is LyricsListItem.Indicator -> {
-                                    val visible =
-                                        isAutoScrollEnabled &&
-                                            currentPositionState >= listItem.gapStartMs &&
-                                            currentPositionState <= listItem.gapEndMs - 650L
-                                    IntervalIndicator(listItem.gapStartMs, listItem.gapEndMs - 650L, currentPositionState, visible, expressiveAccent, 
-                                        Modifier.fillMaxWidth().onSizeChanged { itemHeights[listIndex] = it.height }.padding(horizontal = 24.dp).wrapContentWidth(Alignment.CenterHorizontally))
+                                    val visible = isAutoScrollEnabled && (listIndex == activeIndicatorListIndex)
+                                    IntervalIndicator(
+                                        gapStartMs = listItem.gapStartMs,
+                                        gapEndMs = listItem.gapEndMs - 650L,
+                                        currentPositionProvider = { currentPositionRef.position },
+                                        visible = visible,
+                                        color = expressiveAccent,
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .onSizeChanged { itemHeights[listIndex] = it.height }
+                                            .padding(horizontal = 24.dp)
+                                            .wrapContentWidth(Alignment.CenterHorizontally)
+                                    )
                                 }
                                 is LyricsListItem.Line -> {
                                     val index = listItem.index
                                     val item = listItem.entry
                                     val isActiveLine = activeLineIndices.contains(index)
-                                    val pairedMainLineIndex = if (item.isBackground) (index - 1 downTo 0).firstOrNull { lines.getOrNull(it)?.isBackground == false } ?: -1 else -1
-                                    
-                                    val isInGapWithMain = if (item.isBackground && pairedMainLineIndex != -1) {
-                                        val pairedMainLine = lines[pairedMainLineIndex]
-                                        currentEffectivePosition >= pairedMainLine.time && currentEffectivePosition <= item.time
-                                    } else false
-                                    
-                                    val bgVisible = item.isBackground && (activeLineIndices.contains(pairedMainLineIndex) || activeLineIndices.contains(index) || isInGapWithMain)
-                                    
+                                    val bgVisible = if (item.isBackground) visibleBackgroundLineIndices.contains(index) else false
+
                                     LyricsLine(
                                         index = index, item = item, isSynced = isSynced,
                                         isActiveLine = isActiveLine,
                                         bgVisible = bgVisible, isSelected = selectedIndices.contains(index),
-                                        isSelectionModeActive = isSelectionModeActive, currentPositionState = currentPositionState,
+                                        isSelectionModeActive = isSelectionModeActive,
+                                        sliderPositionProvider = sliderPositionProvider,
                                         lyricsOffset = (currentSong?.song?.lyricsOffset ?: 0).toLong(),
                                         playerConnection = playerConnection, lyricsTextSize = 36f, lyricsLineSpacing = 1.3f,
                                         expressiveAccent = expressiveAccent, lyricsTextPosition = lyricsTextPosition,
@@ -781,4 +844,38 @@ fun ExperimentalLyrics(
             }
         )
     }
+}
+
+private fun findStartIndex(positions: FloatArray, minListY: Float): Int {
+    if (positions.isEmpty()) return 0
+    var low = 0
+    var high = positions.size - 1
+    var result = 0
+    while (low <= high) {
+        val mid = (low + high) ushr 1
+        if (positions[mid] >= minListY) {
+            result = mid
+            high = mid - 1
+        } else {
+            low = mid + 1
+        }
+    }
+    return (result - 3).coerceAtLeast(0)
+}
+
+private fun findEndIndex(positions: FloatArray, maxListY: Float): Int {
+    if (positions.isEmpty()) return 0
+    var low = 0
+    var high = positions.size - 1
+    var result = positions.size - 1
+    while (low <= high) {
+        val mid = (low + high) ushr 1
+        if (positions[mid] <= maxListY) {
+            result = mid
+            low = mid + 1
+        } else {
+            high = mid - 1
+        }
+    }
+    return (result + 3).coerceAtMost(positions.size - 1)
 }

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/LyricsCommon.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/LyricsCommon.kt
@@ -6,8 +6,6 @@
 package com.metrolist.music.ui.component
 
 import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.LinearEasing
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.height
@@ -24,9 +22,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import com.metrolist.music.lyrics.LyricsEntry
+
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameMillis
+import kotlinx.coroutines.isActive
 
 sealed class LyricsListItem {
     data class Line(val index: Int, val entry: LyricsEntry) : LyricsListItem()
@@ -44,7 +46,7 @@ sealed class LyricsListItem {
 internal fun IntervalIndicator(
     gapStartMs: Long,
     gapEndMs: Long,
-    currentPositionMs: Long,
+    currentPositionProvider: () -> Long,
     visible: Boolean,
     color: Color,
     modifier: Modifier = Modifier
@@ -62,18 +64,22 @@ internal fun IntervalIndicator(
         }
     }
 
-    val density = LocalDensity.current
     val targetHeightDp = 72.dp
 
-    val progress = if (gapEndMs > gapStartMs) {
-        ((currentPositionMs - gapStartMs).toFloat() / (gapEndMs - gapStartMs).toFloat()).coerceIn(0f, 1f)
-    } else 0f
+    var currentProgress by remember { mutableFloatStateOf(0f) }
 
-    val animatedProgress by animateFloatAsState(
-        targetValue = progress,
-        animationSpec = tween(durationMillis = 100, easing = LinearEasing),
-        label = "intervalProgress"
-    )
+    LaunchedEffect(visible, gapStartMs, gapEndMs) {
+        if (visible && gapEndMs > gapStartMs) {
+            while (isActive) {
+                withFrameMillis {
+                    val pos = currentPositionProvider()
+                    currentProgress = ((pos - gapStartMs).toFloat() / (gapEndMs - gapStartMs).toFloat()).coerceIn(0f, 1f)
+                }
+            }
+        } else {
+            currentProgress = 0f
+        }
+    }
 
     Box(
         modifier = modifier
@@ -86,7 +92,7 @@ internal fun IntervalIndicator(
         contentAlignment = Alignment.Center
     ) {
         CircularWavyProgressIndicator(
-            progress = { animatedProgress },
+            progress = { currentProgress },
             modifier = Modifier
                 .size(36.dp)
                 .alpha(alpha.value),

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/LyricsLine.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/LyricsLine.kt
@@ -123,7 +123,7 @@ internal fun LyricsLine(
     bgVisible: Boolean,
     isSelected: Boolean,
     isSelectionModeActive: Boolean,
-    currentPositionState: Long,
+    sliderPositionProvider: () -> Long? = { null },
     lyricsOffset: Long,
     playerConnection: PlayerConnection,
     lyricsTextSize: Float,
@@ -258,7 +258,7 @@ internal fun LyricsLine(
                         mainText = mainText,
                         words = effectiveWords,
                         isActiveLine = isActiveLine,
-                        currentPositionState = currentPositionState,
+                        sliderPositionProvider = sliderPositionProvider,
                         lyricsOffset = lyricsOffset,
                         playerConnection = playerConnection,
                         lyricStyle = lyricStyle,
@@ -322,7 +322,7 @@ private fun WordLevelLyrics(
     mainText: String,
     words: List<WordTimestamp>,
     isActiveLine: Boolean,
-    currentPositionState: Long,
+    sliderPositionProvider: () -> Long?,
     lyricsOffset: Long,
     playerConnection: PlayerConnection,
     lyricStyle: TextStyle,
@@ -340,7 +340,7 @@ private fun WordLevelLyrics(
         }
     }
     
-    var smoothPosition by remember { mutableLongStateOf(currentPositionState + lyricsOffset) }
+    var smoothPosition by remember { mutableLongStateOf(0L) }
     
     LaunchedEffect(isActiveLine) {
         if (isActiveLine) {
@@ -349,21 +349,22 @@ private fun WordLevelLyrics(
             while (isActive) {
                 withFrameMillis {
                     val now = System.currentTimeMillis()
-                    val playerPos = playerConnection.player.currentPosition
-                    if (playerPos != lastPlayerPos) {
-                        lastPlayerPos = playerPos
+                    val sliderPos = sliderPositionProvider()
+                    if (sliderPos != null) {
+                        smoothPosition = sliderPos + lyricsOffset
+                        lastPlayerPos = sliderPos
                         lastUpdateTime = now
+                    } else {
+                        val playerPos = playerConnection.player.currentPosition
+                        if (playerPos != lastPlayerPos) {
+                            lastPlayerPos = playerPos
+                            lastUpdateTime = now
+                        }
+                        val elapsed = now - lastUpdateTime
+                        smoothPosition = lastPlayerPos + lyricsOffset + (if (playerConnection.player.isPlaying) elapsed else 0)
                     }
-                    val elapsed = now - lastUpdateTime
-                    smoothPosition = lastPlayerPos + lyricsOffset + (if (playerConnection.player.isPlaying) elapsed else 0)
                 }
             }
-        }
-    }
-    
-    LaunchedEffect(isActiveLine, currentPositionState) {
-        if (!isActiveLine) {
-            smoothPosition = currentPositionState + lyricsOffset
         }
     }
 

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/LyricsViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/LyricsViewModel.kt
@@ -53,11 +53,10 @@ class LyricsViewModel @Inject constructor() : ViewModel() {
                         listOf(LyricsEntry.HEAD_LYRICS_ENTRY) + parsedLines
                     } else {
                         // Fallback for unsynced or invalid LRC
-                        val baseTime = 1000000L
                         lyrics.lines()
                             .filter { it.isNotBlank() && !timestampRegex.containsMatchIn(it) }
-                            .mapIndexed { index, line ->
-                                LyricsEntry(baseTime + index, line)
+                            .map { line ->
+                                LyricsEntry(0L, line)
                             }
                     }
                 }


### PR DESCRIPTION
## Problem
<!-- Describe the issue or limitation this PR addresses
DO NOT PR NEW FEATURES, WE'RE ON A FEATURE FREEZE!!! -->
Experimental lyrics could become effectively stuck after seeking a long distance by tapping a later lyric line. The visible range no longer matched the lyric content: scrolling upward was limited while empty space remained available below.

Lyric-line taps were also unreliable. Small finger movement could be treated as the start of a drag, causing some taps to be ignored instead of seeking to the selected timestamp.

## Cause
<!-- Explain the root cause of the problem -->
Lyric item positions and scroll bounds were derived relative to the currently active line. A large seek changed that reference point, while estimated heights for not-yet-measured items could differ from their actual heights. This produced invalid scroll clamp bounds.

The custom pointer handling also used stale clamp values captured when the gesture handler was first created. In addition, it launched a separate scroll update coroutine for every drag event, which could accumulate on slower devices. Pointer movement handling could therefore interfere with click recognition and scrolling stability.

## Solution
<!-- List the changes made to fix the issue -->
- Position lyric items using absolute offsets from the start of the lyric list instead of offsets relative to the active line.
- Drive automatic following, manual dragging, and fling behavior through one bounded `Animatable` scroll offset.
- Calculate clamp bounds from the first and last lyric positions, allowing both endpoints to reach the playback anchor without exposing unbounded empty space.
- Preserve standard touch-slop behavior so taps remain taps until a real vertical drag begins.
- Consume vertical scroll input within the lyrics area to prevent it from moving the player sheet.
- Read the latest measured scroll bounds during gestures and process manual scroll updates through a conflated channel, preventing stale bounds and per-event coroutine buildup on slower devices.
- Initialize the active lyric position from the current playback position so the correct line is shown immediately when opening the player.

## Testing
<!-- Describe how the changes were tested -->
- Built successfully with `./gradlew :app:assembleFossDebug`.
- Verified lyric seeking, tapping, dragging, fling behavior, and top/bottom bounds on a Samsung Galaxy S23 running Android 16.
- Verified the same flows on a Redmi device running a custom Android 14 ROM.
- Verified the previous scrolling lockup no longer occurs on a stock Samsung device running Android 13.

before:
<img width="400" height="867" alt="before" src="https://github.com/user-attachments/assets/55ddb77b-811d-45cb-b81b-8a5dc64f714a" />

after:
<img width="400" height="867" alt="after" src="https://github.com/user-attachments/assets/784c87be-358f-42b9-a165-9826eede277e" />


## Related Issues
<!-- List any related issues or PRs -->
- Closes #3525 
- Related to #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Improved lyric synchronization using playback position, timing offsets, and interactive slider position.
  - Added smoother automatic scrolling with manual dragging, momentum support, and responsive nested scrolling.
  - Improved lyric positioning and alignment for a more consistent reading experience.
  - Selecting a lyric now seeks playback and resumes synchronized scrolling.
  - Scrolling remains responsive during lyric loading and playback.

- **Bug Fixes**
  - Improved detection of synchronized lyrics to avoid misclassifying bracketed text.
  - Unsynchronized lyrics now display consistently without artificial timing between lines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->