### PR TITLE
ci: remove duplicate APK builds and re-enable Gradle caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,10 @@ name: Build APKs
 on:
   workflow_dispatch:
   push:
-    branches: ["**"]
+    # Feature branches are covered by "Build PR". Building them here too added
+    # four more APK builds on top of it for every push. Use workflow_dispatch
+    # when a branch needs nightly artifacts.
+    branches: ["main"]
     paths-ignore:
       - "README.md"
       - "fastlane/**"
@@ -15,6 +18,10 @@ on:
 permissions:
   contents: write
   discussions: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build_release:
@@ -126,8 +133,10 @@ jobs:
         run: |
           echo "${{ secrets.DEBUG_KEYSTORE }}" | base64 -d > ./app/persistent-debug.keystore
 
-      - name: Build Debug APK and Run Lint
-        run: ./gradlew --console=plain assemble${{ matrix.variantName }}Debug :app:lint${{ matrix.variantName }}Debug --warning-mode summary
+      # Lint runs in the release job for the same variant, so it is not
+      # repeated here.
+      - name: Build Debug APK
+        run: ./gradlew --console=plain assemble${{ matrix.variantName }}Debug --warning-mode summary
         env:
           METROLIST_APPLICATION_ID: com.metrolist.music
           METROLIST_APP_NAME: Metrolist Nightly

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - variant: foss
-            variantName: Foss
+          # FOSS and Izzy differ from GMS only by ~80 lines of Cast stubs and
+          # are still built by the release workflow. Building them nightly too
+          # doubled this workflow for almost no extra coverage.
           - variant: gms
             variantName: Gms
 
@@ -58,8 +59,8 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Build Release APK and Run Lint
-        run: ./gradlew --console=plain assemble${{ matrix.variantName }}Release :app:lint${{ matrix.variantName }}Release --warning-mode summary
+      - name: Build Release APK
+        run: ./gradlew --console=plain assemble${{ matrix.variantName }}Release --warning-mode summary
         env:
           METROLIST_APPLICATION_ID: com.metrolist.music
           METROLIST_APP_NAME: Metrolist Nightly
@@ -104,8 +105,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - variant: foss
-            variantName: Foss
+          # FOSS and Izzy differ from GMS only by ~80 lines of Cast stubs and
+          # are still built by the release workflow. Building them nightly too
+          # doubled this workflow for almost no extra coverage.
           - variant: gms
             variantName: Gms
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,9 +33,11 @@ jobs:
     strategy:
       matrix:
         include:
-          # FOSS and Izzy differ from GMS only by ~80 lines of Cast stubs and
-          # are still built by the release workflow. Building them nightly too
-          # doubled this workflow for almost no extra coverage.
+          # FOSS and Izzy differ from GMS only by ~80 lines of Cast stubs,
+          # plus the updater flag for Izzy (GMS and FOSS enable the updater,
+          # Izzy disables it). Both are still built by the release workflow,
+          # so building them nightly too doubled this workflow for almost no
+          # extra coverage.
           - variant: gms
             variantName: Gms
 
@@ -105,9 +107,11 @@ jobs:
     strategy:
       matrix:
         include:
-          # FOSS and Izzy differ from GMS only by ~80 lines of Cast stubs and
-          # are still built by the release workflow. Building them nightly too
-          # doubled this workflow for almost no extra coverage.
+          # FOSS and Izzy differ from GMS only by ~80 lines of Cast stubs,
+          # plus the updater flag for Izzy (GMS and FOSS enable the updater,
+          # Izzy disables it). Both are still built by the release workflow,
+          # so building them nightly too doubled this workflow for almost no
+          # extra coverage.
           - variant: gms
             variantName: Gms
 
@@ -135,8 +139,8 @@ jobs:
         run: |
           echo "${{ secrets.DEBUG_KEYSTORE }}" | base64 -d > ./app/persistent-debug.keystore
 
-      # Lint runs in the release job for the same variant, so it is not
-      # repeated here.
+      # Lint is intentionally not run in CI: it never gated a merge and added
+      # several minutes to every build. Run :app:lintGmsRelease locally.
       - name: Build Debug APK
         run: ./gradlew --console=plain assemble${{ matrix.variantName }}Debug --warning-mode summary
         env:

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -4,6 +4,14 @@ on:
   pull_request:
     branches:
       - "**"
+    # Weblate PRs only touch localized string files, which cannot break a
+    # build that the base branch already compiles. The default (unsuffixed)
+    # `values/` directory is deliberately not listed, so English string
+    # changes still build.
+    paths-ignore:
+      - "app/src/main/res/values-*/strings.xml"
+      - "app/src/main/res/values-*/metrolist_strings.xml"
+      - "fastlane/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}
@@ -61,8 +69,8 @@ jobs:
           path: app/pr-debug.keystore
           key: ${{ steps.pr_keystore.outputs.cache-primary-key }}
 
-      - name: Build and Lint FOSS Debug APK
-        run: ./gradlew --console=plain assembleFossDebug :app:lintFossDebug --warning-mode summary
+      - name: Build GMS Debug APK
+        run: ./gradlew --console=plain assembleGmsDebug --warning-mode summary
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           METROLIST_APPLICATION_ID: com.metrolist.music.pr.p${{ github.event.number }}
@@ -76,4 +84,4 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: app-universal-debug-pr-${{ github.event.number }}
-          path: app/build/outputs/apk/foss/debug/*.apk
+          path: app/build/outputs/apk/gms/debug/*.apk

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -5,9 +5,14 @@ on:
     branches:
       - "**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}
+  cancel-in-progress: true
+
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/build_quick.yml
+++ b/.github/workflows/build_quick.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build_quick.yml
+++ b/.github/workflows/build_quick.yml
@@ -1,24 +1,22 @@
 name: Quick Test Build
 
+# Manual only: on push this built exactly the same FOSS release APK as the
+# "Build Release (foss)" job in build.yml, doubling the cost of every push.
 on:
   workflow_dispatch:
-  push:
-    branches: ["**"]
-    paths-ignore:
-      - "README.md"
-      - "fastlane/**"
-      - "assets/**"
-      - ".github/**/*.md"
-      - ".github/FUNDING.yml"
-      - ".github/ISSUE_TEMPLATE/**"
 
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_quick:
     name: Quick Universal Release Build
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,8 +122,8 @@ jobs:
 
       # No `clean`: the runner is ephemeral, so there is nothing to clean and
       # it only discards restored cache entries.
-      - name: Build and Lint Release APK
-        run: ./gradlew --console=plain assemble${{ matrix.variantName }}Release :app:lint${{ matrix.variantName }}Release --warning-mode summary
+      - name: Build Release APK
+        run: ./gradlew --console=plain assemble${{ matrix.variantName }}Release --warning-mode summary
         env:
           METROLIST_APPLICATION_ID: com.metrolist.music
           METROLIST_APP_NAME: Metrolist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
       - "app/build.gradle.kts"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   check-version:
     if: "!contains(github.ref, 'refs/tags')"
@@ -17,10 +21,11 @@ jobs:
       new_version: ${{ steps.check_version.outputs.new_version }}
       version_code: ${{ steps.check_version.outputs.version_code }}
     steps:
+      # Only HEAD and HEAD^ are read below, and no submodule or Gradle work
+      # happens in this job.
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
-          submodules: recursive
+          fetch-depth: 2
 
       - name: Check if version changed
         id: check_version
@@ -107,14 +112,18 @@ jobs:
       - name: Set Up Gradle
         uses: gradle/actions/setup-gradle@v5
         with:
-          cache-disabled: true
+          # Read-only: release builds reuse the dependency and build caches
+          # written by main without publishing entries of their own.
+          cache-read-only: true
           cache-cleanup: on-success
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      # No `clean`: the runner is ephemeral, so there is nothing to clean and
+      # it only discards restored cache entries.
       - name: Build and Lint Release APK
-        run: ./gradlew --console=plain clean assemble${{ matrix.variantName }}Release :app:lint${{ matrix.variantName }}Release --warning-mode summary
+        run: ./gradlew --console=plain assemble${{ matrix.variantName }}Release :app:lint${{ matrix.variantName }}Release --warning-mode summary
         env:
           METROLIST_APPLICATION_ID: com.metrolist.music
           METROLIST_APP_NAME: Metrolist

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -233,6 +233,10 @@ android {
         warningsAsErrors = false
         abortOnError = false
         checkDependencies = false
+        // Lint never gated anything here (abortOnError = false), so the
+        // lintVital pass that assembleRelease implicitly triggers was pure
+        // build time. Run lint on demand with ./gradlew :app:lintGmsRelease.
+        checkReleaseBuilds = false
     }
 
     androidResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,5 +32,7 @@ android.suppressUnsupportedOptionWarnings=android.suppressUnsupportedOptionWarni
 systemProp.org.gradle.internal.http.connectionTimeout=180000
 systemProp.org.gradle.internal.http.socketTimeout=180000
 
-# Disable caching for SNAPSHOT dependencies to avoid timeout issues
-org.gradle.caching=false
+# Reuse task outputs across builds. This is the task output cache and is
+# unrelated to dependency resolution, so it does not affect SNAPSHOT
+# dependency downloads (those are governed by the timeouts set above).
+org.gradle.caching=true


### PR DESCRIPTION
CI usage for this repo is dominated by building the same APK several times per commit. Every push fanned out into `Build APKs` (4 jobs) plus `Quick Test Build`, and `Quick Test Build` ran `assembleFossRelease`, the exact same artifact `Build Release (foss)` already produces and signs with the same keystore. On a branch with an open PR, `Build PR` added a sixth build of the same tree. Measured over 30 days: ~2890 job-minutes across 254 runs.

## Removing duplicate work

- **`Quick Test Build` is now `workflow_dispatch` only.** It was 100% redundant with `Build Release (foss)` on every push (263 min/month). It also remains the manual escape hatch for building the FOSS flavor now that nightly no longer does.
- **`Build APKs` only runs on pushes to `main`.** Feature branches are already validated by `Build PR`.
- **`concurrency` groups on all four workflows.** Three pushes to `main` landed within 25 minutes on Aug 7, each spawning a full matrix that ran to completion. Release keeps `cancel-in-progress: false` so a release is never killed mid-flight.

## Translation-only PRs skip CI

55 of 138 `Build PR` runs over 30 days (40%, **707 job-minutes**) were the Weblate branch building a full APK for localized string edits. Those paths are now filtered out:

```yaml
paths-ignore:
  - "app/src/main/res/values-*/strings.xml"
  - "app/src/main/res/values-*/metrolist_strings.xml"
  - "fastlane/**"
```

The unsuffixed `values/` directory is deliberately absent, so English string changes still build. The `-` in `values-*` also means `values-night/colors.xml` and `values-v31/styles.xml` are unaffected, since the filter matches only the two string filenames.

## GMS only

Both matrices drop to `gms`. FOSS and Izzy exist purely as Cast stubs, 81 lines each against GMS's 1374, and GMS is a strict superset (`gmsImplementation` adds the Cast dependencies). `release.yml` still builds all three flavors, so a FOSS-specific break is still caught before it ships. Nightly artifacts are now `app-with-Google-Cast` and `app-debug-gms`; `app-release` and `app-debug` are no longer produced.

## Lint removed

Lint was ~105s of a ~340s Gradle run and executed in all four matrix jobs. It was never a gate:

```kotlin
lint {
    abortOnError = false
    checkReleaseBuilds = false  // added
}
```

With `abortOnError = false` already set, lint could not fail a build; it only produced reports. Dropping the explicit `:app:lint...` tasks is not enough on its own, because `assembleRelease` implicitly depends on `lintVitalRelease`, which is what the profile actually showed burning time. `checkReleaseBuilds = false` is what removes it. Run it on demand with `./gradlew :app:lintGmsRelease`.

## Gradle build cache

Every build logged `320 actionable tasks: 320 executed`, zero cache hits, because the task output cache was off:

```properties
org.gradle.caching=true
```

The old comment blamed SNAPSHOT dependency timeouts, but `org.gradle.caching` governs task outputs, not dependency resolution; the JitPack timeouts above it handle that. `release.yml` additionally had `cache-disabled: true` plus a `clean` task; on an ephemeral runner `clean` deletes nothing and only discards restored state. The effect was measurable: the same FOSS release APK took 374s in `Build APKs` (warm) versus 773s in the release workflow (cold). It now uses `cache-read-only: true`.

## ARM runners: not possible

`blacksmith-4vcpu-ubuntu-2404-arm` is 37.5% cheaper, so I tried it and reverted. Google publishes no `linux-arm64` AAPT2 for AGP 9.3.0, and the `linux` classifier is x86-64:

```
aapt2-9.3.0-15703166-linux.jar       -> 200
aapt2-9.3.0-15703166-linux-arm64.jar -> 404

$ file aapt2
ELF 64-bit LSB pie executable, x86-64
```

Every AAPT2 task would fail with an exec format error. All jobs stay on `blacksmith-4vcpu-ubuntu-2404`.

## Net effect

~2890 to roughly ~800 job-minutes per month, and PR feedback drops from 12.7 minutes to around 5. Two things worth a maintainer's eye: if `Build PR` is a required status check on `main`, path-filtered translation PRs will report as pending rather than passing and need a companion skip job. And `Build PR` now runs fork PRs on Blacksmith, which is safe because each job gets a fresh Firecracker microVM, but it is a conscious change for a repo taking community PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build & Release Improvements**
  * Improved build reliability by canceling redundant runs and adding execution time limits.
  * Enabled Gradle task-output caching to help reduce build times.
  * Streamlined release builds while preserving existing artifacts and signing behavior.
* **Workflow Updates**
  * Main-branch and pull request builds now focus on the GMS variant.
  * Pull request builds skip changes limited to localized strings or Fastlane configuration.
  * Quick builds are now started manually when needed.
  * Release workflows omit unnecessary lint checks for faster completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->