### PR TITLE
fix(download): skip already-downloaded songs in bulk download

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/DownloadRequests.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/DownloadRequests.kt
@@ -1,0 +1,55 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.playback
+
+import android.content.Context
+import androidx.core.net.toUri
+import androidx.media3.exoplayer.offline.Download
+import androidx.media3.exoplayer.offline.DownloadRequest
+import androidx.media3.exoplayer.offline.DownloadService
+
+/**
+ * Builds download requests for [items], skipping any song whose download has already
+ * completed.
+ *
+ * Re-adding a completed download is not a no-op: media3 merges the request into the
+ * existing entry and moves it back to [Download.STATE_QUEUED], which re-runs the
+ * download and overwrites the song's `dateDownload` timestamp.
+ */
+fun <T> buildPendingDownloadRequests(
+    downloads: Map<String, Download>,
+    items: List<T>,
+    id: (T) -> String,
+    title: (T) -> String,
+): List<DownloadRequest> =
+    items
+        .filter { downloads[id(it)]?.state != Download.STATE_COMPLETED }
+        .map { item ->
+            DownloadRequest
+                .Builder(id(item), id(item).toUri())
+                .setCustomCacheKey(id(item))
+                .setData(title(item).toByteArray())
+                .build()
+        }
+
+/**
+ * Enqueues [items] for offline playback, skipping songs that are already downloaded.
+ */
+fun <T> Context.enqueuePendingDownloads(
+    downloads: Map<String, Download>,
+    items: List<T>,
+    id: (T) -> String,
+    title: (T) -> String,
+) {
+    buildPendingDownloadRequests(downloads, items, id, title).forEach { request ->
+        DownloadService.sendAddDownload(
+            this,
+            ExoDownloadService::class.java,
+            request,
+            false,
+        )
+    }
+}

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -273,6 +273,9 @@ class MusicService :
     lateinit var database: MusicDatabase
 
     @Inject
+    lateinit var downloadUtil: DownloadUtil
+
+    @Inject
     lateinit var lyricsHelper: LyricsHelper
 
     @Inject
@@ -2199,17 +2202,11 @@ class MusicService :
                     syncUtils.likeSong(song)
 
                     if (dataStore.get(AutoDownloadOnLikeKey, false) && song.liked) {
-                        val downloadRequest =
-                            androidx.media3.exoplayer.offline.DownloadRequest
-                                .Builder(song.id, song.id.toUri())
-                                .setCustomCacheKey(song.id)
-                                .setData(song.title.toByteArray())
-                                .build()
-                        androidx.media3.exoplayer.offline.DownloadService.sendAddDownload(
-                            this@MusicService,
-                            ExoDownloadService::class.java,
-                            downloadRequest,
-                            false,
+                        this@MusicService.enqueuePendingDownloads(
+                            downloadUtil.downloads.value,
+                            listOf(song),
+                            { it.id },
+                            { it.title },
                         )
                     }
                 }

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/AlbumMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/AlbumMenu.kt
@@ -57,12 +57,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.core.net.toUri
 import androidx.media3.exoplayer.offline.Download.STATE_COMPLETED
 import androidx.media3.exoplayer.offline.Download.STATE_DOWNLOADING
 import androidx.media3.exoplayer.offline.Download.STATE_QUEUED
 import androidx.media3.exoplayer.offline.Download.STATE_STOPPED
-import androidx.media3.exoplayer.offline.DownloadRequest
 import androidx.media3.exoplayer.offline.DownloadService
 import coil3.compose.AsyncImage
 import com.metrolist.music.LocalNavController
@@ -79,6 +77,7 @@ import com.metrolist.music.db.entities.Song
 import com.metrolist.music.db.entities.SpeedDialItem
 import com.metrolist.music.extensions.toMediaItem
 import com.metrolist.music.playback.ExoDownloadService
+import com.metrolist.music.playback.enqueuePendingDownloads
 import com.metrolist.music.playback.queues.ListQueue
 import com.metrolist.music.ui.component.AlbumListItem
 import com.metrolist.music.ui.component.ListDialog
@@ -544,23 +543,12 @@ fun AlbumMenu(
                                         )
                                     },
                                     onClick = {
-                                        val currentDownloads = downloadUtil.downloads.value
-                                        songs.filter {
-                                            currentDownloads[it.id]?.state != STATE_COMPLETED
-                                        }.forEach { song ->
-                                            val downloadRequest =
-                                                DownloadRequest
-                                                    .Builder(song.id, song.id.toUri())
-                                                    .setCustomCacheKey(song.id)
-                                                    .setData(song.song.title.toByteArray())
-                                                    .build()
-                                            DownloadService.sendAddDownload(
-                                                context,
-                                                ExoDownloadService::class.java,
-                                                downloadRequest,
-                                                false,
-                                            )
-                                        }
+                                        context.enqueuePendingDownloads(
+                                            downloadUtil.downloads.value,
+                                            songs,
+                                            { it.id },
+                                            { it.song.title },
+                                        )
                                     },
                                 )
                             }

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/AlbumMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/AlbumMenu.kt
@@ -544,7 +544,10 @@ fun AlbumMenu(
                                         )
                                     },
                                     onClick = {
-                                        songs.forEach { song ->
+                                        val currentDownloads = downloadUtil.downloads.value
+                                        songs.filter {
+                                            currentDownloads[it.id]?.state != STATE_COMPLETED
+                                        }.forEach { song ->
                                             val downloadRequest =
                                                 DownloadRequest
                                                     .Builder(song.id, song.id.toUri())

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/PlaylistMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/PlaylistMenu.kt
@@ -41,9 +41,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
-import androidx.core.net.toUri
 import androidx.media3.exoplayer.offline.Download
-import androidx.media3.exoplayer.offline.DownloadRequest
 import androidx.media3.exoplayer.offline.DownloadService
 import com.metrolist.innertube.YouTube
 import com.metrolist.music.LocalDatabase
@@ -57,6 +55,7 @@ import com.metrolist.music.db.entities.Song
 import com.metrolist.music.db.entities.SpeedDialItem
 import com.metrolist.music.extensions.toMediaItem
 import com.metrolist.music.playback.ExoDownloadService
+import com.metrolist.music.playback.enqueuePendingDownloads
 import com.metrolist.music.playback.queues.ListQueue
 import com.metrolist.music.playback.queues.YouTubeQueue
 import com.metrolist.music.ui.component.DefaultDialog
@@ -576,23 +575,12 @@ fun PlaylistMenu(
                                                 )
                                             },
                                             onClick = {
-                                                val currentDownloads = downloadUtil.downloads.value
-                                                songs.filter {
-                                                    currentDownloads[it.id]?.state != Download.STATE_COMPLETED
-                                                }.forEach { song ->
-                                                    val downloadRequest =
-                                                        DownloadRequest
-                                                            .Builder(song.id, song.id.toUri())
-                                                            .setCustomCacheKey(song.id)
-                                                            .setData(song.song.title.toByteArray())
-                                                            .build()
-                                                    DownloadService.sendAddDownload(
-                                                        context,
-                                                        ExoDownloadService::class.java,
-                                                        downloadRequest,
-                                                        false,
-                                                    )
-                                                }
+                                                context.enqueuePendingDownloads(
+                                                    downloadUtil.downloads.value,
+                                                    songs,
+                                                    { it.id },
+                                                    { it.song.title },
+                                                )
                                             },
                                         )
                                     }

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/PlaylistMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/PlaylistMenu.kt
@@ -576,7 +576,10 @@ fun PlaylistMenu(
                                                 )
                                             },
                                             onClick = {
-                                                songs.forEach { song ->
+                                                val currentDownloads = downloadUtil.downloads.value
+                                                songs.filter {
+                                                    currentDownloads[it.id]?.state != Download.STATE_COMPLETED
+                                                }.forEach { song ->
                                                     val downloadRequest =
                                                         DownloadRequest
                                                             .Builder(song.id, song.id.toUri())

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/SelectionSongsMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/SelectionSongsMenu.kt
@@ -40,11 +40,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.core.net.toUri
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline
 import androidx.media3.exoplayer.offline.Download
-import androidx.media3.exoplayer.offline.DownloadRequest
 import androidx.media3.exoplayer.offline.DownloadService
 import com.metrolist.innertube.YouTube
 import com.metrolist.music.LocalDatabase
@@ -58,6 +56,7 @@ import com.metrolist.music.extensions.toMediaItem
 import com.metrolist.music.models.MediaMetadata
 import com.metrolist.music.models.toMediaMetadata
 import com.metrolist.music.playback.ExoDownloadService
+import com.metrolist.music.playback.enqueuePendingDownloads
 import com.metrolist.music.playback.queues.ListQueue
 import com.metrolist.music.ui.component.DefaultDialog
 import com.metrolist.music.ui.component.Material3MenuGroup
@@ -560,20 +559,12 @@ fun SelectionSongMenu(
                                             )
                                         },
                                         onClick = {
-                                            songSelection.forEach { song ->
-                                                val downloadRequest =
-                                                    DownloadRequest
-                                                        .Builder(song.id, song.id.toUri())
-                                                        .setCustomCacheKey(song.id)
-                                                        .setData(song.song.title.toByteArray())
-                                                        .build()
-                                                DownloadService.sendAddDownload(
-                                                    context,
-                                                    ExoDownloadService::class.java,
-                                                    downloadRequest,
-                                                    false,
-                                                )
-                                            }
+                                            context.enqueuePendingDownloads(
+                                                downloadUtil.downloads.value,
+                                                songSelection,
+                                                { it.id },
+                                                { it.song.title },
+                                            )
                                         },
                                     )
                                 }
@@ -974,20 +965,12 @@ fun SelectionMediaMetadataMenu(
                                             )
                                         },
                                         onClick = {
-                                            songSelection.forEach { song ->
-                                                val downloadRequest =
-                                                    DownloadRequest
-                                                        .Builder(song.id, song.id.toUri())
-                                                        .setCustomCacheKey(song.id)
-                                                        .setData(song.title.toByteArray())
-                                                        .build()
-                                                DownloadService.sendAddDownload(
-                                                    context,
-                                                    ExoDownloadService::class.java,
-                                                    downloadRequest,
-                                                    false,
-                                                )
-                                            }
+                                            context.enqueuePendingDownloads(
+                                                downloadUtil.downloads.value,
+                                                songSelection,
+                                                { it.id },
+                                                { it.title },
+                                            )
                                         },
                                     )
                                 }

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeAlbumMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeAlbumMenu.kt
@@ -52,9 +52,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.core.net.toUri
 import androidx.media3.exoplayer.offline.Download
-import androidx.media3.exoplayer.offline.DownloadRequest
 import androidx.media3.exoplayer.offline.DownloadService
 import com.metrolist.innertube.YouTube
 import com.metrolist.music.LocalNavController
@@ -71,6 +69,7 @@ import com.metrolist.music.db.entities.Song
 import com.metrolist.music.db.entities.SpeedDialItem
 import com.metrolist.music.extensions.toMediaItem
 import com.metrolist.music.playback.ExoDownloadService
+import com.metrolist.music.playback.enqueuePendingDownloads
 import com.metrolist.music.playback.queues.YouTubeAlbumRadio
 import com.metrolist.music.ui.component.ListDialog
 import com.metrolist.music.ui.component.Material3MenuGroup
@@ -506,23 +505,12 @@ fun YouTubeAlbumMenu(
                                         )
                                     },
                                     onClick = {
-                                        val currentDownloads = downloadUtil.downloads.value
-                                        album?.songs?.filter {
-                                            currentDownloads[it.id]?.state != Download.STATE_COMPLETED
-                                        }?.forEach { song ->
-                                            val downloadRequest =
-                                                DownloadRequest
-                                                    .Builder(song.id, song.id.toUri())
-                                                    .setCustomCacheKey(song.id)
-                                                    .setData(song.song.title.toByteArray())
-                                                    .build()
-                                            DownloadService.sendAddDownload(
-                                                context,
-                                                ExoDownloadService::class.java,
-                                                downloadRequest,
-                                                false,
-                                            )
-                                        }
+                                        context.enqueuePendingDownloads(
+                                            downloadUtil.downloads.value,
+                                            album?.songs.orEmpty(),
+                                            { it.id },
+                                            { it.song.title },
+                                        )
                                     },
                                 )
                             }

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeAlbumMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeAlbumMenu.kt
@@ -506,7 +506,10 @@ fun YouTubeAlbumMenu(
                                         )
                                     },
                                     onClick = {
-                                        album?.songs?.forEach { song ->
+                                        val currentDownloads = downloadUtil.downloads.value
+                                        album?.songs?.filter {
+                                            currentDownloads[it.id]?.state != Download.STATE_COMPLETED
+                                        }?.forEach { song ->
                                             val downloadRequest =
                                                 DownloadRequest
                                                     .Builder(song.id, song.id.toUri())

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubePlaylistMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubePlaylistMenu.kt
@@ -647,7 +647,10 @@ fun YouTubePlaylistMenu(
                                                 )
                                             },
                                             onClick = {
-                                                songs.forEach { song ->
+                                                val currentDownloads = downloadUtil.downloads.value
+                                                songs.filter {
+                                                    currentDownloads[it.id]?.state != Download.STATE_COMPLETED
+                                                }.forEach { song ->
                                                     val downloadRequest =
                                                         DownloadRequest
                                                             .Builder(song.id, song.id.toUri())

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubePlaylistMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubePlaylistMenu.kt
@@ -52,9 +52,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.core.net.toUri
 import androidx.media3.exoplayer.offline.Download
-import androidx.media3.exoplayer.offline.DownloadRequest
 import androidx.media3.exoplayer.offline.DownloadService
 import coil3.compose.AsyncImage
 import com.metrolist.innertube.YouTube
@@ -76,6 +74,7 @@ import com.metrolist.music.extensions.toMediaItem
 import com.metrolist.music.models.MediaMetadata
 import com.metrolist.music.models.toMediaMetadata
 import com.metrolist.music.playback.ExoDownloadService
+import com.metrolist.music.playback.enqueuePendingDownloads
 import com.metrolist.music.playback.queues.YouTubeQueue
 import com.metrolist.music.ui.component.DefaultDialog
 import com.metrolist.music.ui.component.ListDialog
@@ -647,23 +646,12 @@ fun YouTubePlaylistMenu(
                                                 )
                                             },
                                             onClick = {
-                                                val currentDownloads = downloadUtil.downloads.value
-                                                songs.filter {
-                                                    currentDownloads[it.id]?.state != Download.STATE_COMPLETED
-                                                }.forEach { song ->
-                                                    val downloadRequest =
-                                                        DownloadRequest
-                                                            .Builder(song.id, song.id.toUri())
-                                                            .setCustomCacheKey(song.id)
-                                                            .setData(song.title.toByteArray())
-                                                            .build()
-                                                    DownloadService.sendAddDownload(
-                                                        context,
-                                                        ExoDownloadService::class.java,
-                                                        downloadRequest,
-                                                        false,
-                                                    )
-                                                }
+                                                context.enqueuePendingDownloads(
+                                                    downloadUtil.downloads.value,
+                                                    songs,
+                                                    { it.id },
+                                                    { it.title },
+                                                )
                                             },
                                         )
                                     }

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeSelectionSongMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeSelectionSongMenu.kt
@@ -32,9 +32,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.core.net.toUri
 import androidx.media3.exoplayer.offline.Download
-import androidx.media3.exoplayer.offline.DownloadRequest
 import androidx.media3.exoplayer.offline.DownloadService
 import com.metrolist.innertube.YouTube
 import com.metrolist.innertube.models.SongItem
@@ -46,6 +44,7 @@ import com.metrolist.music.R
 import com.metrolist.music.extensions.toMediaItem
 import com.metrolist.music.models.toMediaMetadata
 import com.metrolist.music.playback.ExoDownloadService
+import com.metrolist.music.playback.enqueuePendingDownloads
 import com.metrolist.music.playback.queues.ListQueue
 import com.metrolist.music.ui.component.DefaultDialog
 import com.metrolist.music.ui.component.Material3MenuGroup
@@ -378,20 +377,12 @@ fun YouTubeSelectionSongMenu(
                                     )
                                 },
                                 onClick = {
-                                    songSelection.forEach { song ->
-                                        val downloadRequest =
-                                            DownloadRequest
-                                                .Builder(song.id, song.id.toUri())
-                                                .setCustomCacheKey(song.id)
-                                                .setData(song.title.toByteArray())
-                                                .build()
-                                        DownloadService.sendAddDownload(
-                                            context,
-                                            ExoDownloadService::class.java,
-                                            downloadRequest,
-                                            false,
-                                        )
-                                    }
+                                    context.enqueuePendingDownloads(
+                                        downloadUtil.downloads.value,
+                                        songSelection,
+                                        { it.id },
+                                        { it.title },
+                                    )
                                     clearAction()
                                     onDismiss()
                                 },

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -85,11 +85,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastForEachReversed
 import androidx.compose.ui.util.fastSumBy
-import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import timber.log.Timber
 import androidx.media3.exoplayer.offline.Download
-import androidx.media3.exoplayer.offline.DownloadRequest
 import androidx.media3.exoplayer.offline.DownloadService
 import androidx.navigation.NavController
 import coil3.compose.AsyncImage
@@ -106,6 +104,7 @@ import com.metrolist.music.constants.YtmSyncKey
 import com.metrolist.music.db.entities.Song
 import com.metrolist.music.extensions.toMediaItem
 import com.metrolist.music.playback.ExoDownloadService
+import com.metrolist.music.playback.enqueuePendingDownloads
 import com.metrolist.music.playback.queues.ListQueue
 import com.metrolist.music.ui.component.DefaultDialog
 import com.metrolist.music.ui.component.DraggableScrollbar
@@ -1029,23 +1028,12 @@ private fun AutoPlaylistHeader(
                                     }
 
                                     else -> {
-                                        val currentDownloads = downloadUtil.downloads.value
-                                        songs.filter {
-                                            currentDownloads[it.song.id]?.state != Download.STATE_COMPLETED
-                                        }.forEach { song ->
-                                            val downloadRequest =
-                                                DownloadRequest
-                                                    .Builder(song.song.id, song.song.id.toUri())
-                                                    .setCustomCacheKey(song.song.id)
-                                                    .setData(song.song.title.toByteArray())
-                                                    .build()
-                                            DownloadService.sendAddDownload(
-                                                context,
-                                                ExoDownloadService::class.java,
-                                                downloadRequest,
-                                                false,
-                                            )
-                                        }
+                                        context.enqueuePendingDownloads(
+                                            downloadUtil.downloads.value,
+                                            songs,
+                                            { it.song.id },
+                                            { it.song.title },
+                                        )
                                     }
                                 }
                             },

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/AutoPlaylistScreen.kt
@@ -876,6 +876,7 @@ private fun AutoPlaylistHeader(
 ) {
     val playerConnection = LocalPlayerConnection.current ?: return
     val context = LocalContext.current
+    val downloadUtil = LocalDownloadUtil.current
 
     Column(
         modifier =
@@ -1028,7 +1029,10 @@ private fun AutoPlaylistHeader(
                                     }
 
                                     else -> {
-                                        songs.forEach { song ->
+                                        val currentDownloads = downloadUtil.downloads.value
+                                        songs.filter {
+                                            currentDownloads[it.song.id]?.state != Download.STATE_COMPLETED
+                                        }.forEach { song ->
                                             val downloadRequest =
                                                 DownloadRequest
                                                     .Builder(song.song.id, song.song.id.toUri())

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/CachePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/CachePlaylistScreen.kt
@@ -74,6 +74,7 @@ import androidx.media3.exoplayer.offline.DownloadRequest
 import androidx.media3.exoplayer.offline.DownloadService
 import androidx.navigation.NavController
 import coil3.compose.AsyncImage
+import com.metrolist.music.LocalDownloadUtil
 import com.metrolist.music.LocalPlayerAwareWindowInsets
 import com.metrolist.music.LocalPlayerConnection
 import com.metrolist.music.R
@@ -473,7 +474,8 @@ private fun CachePlaylistHeader(
     modifier: Modifier = Modifier
 ) {
     val playerConnection = LocalPlayerConnection.current ?: return
-    
+    val downloadUtil = LocalDownloadUtil.current
+
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -598,8 +600,11 @@ private fun CachePlaylistHeader(
                                 )
                             },
                             onDownload = {
-                                // Download all cached songs
-                                songs.forEach { song ->
+                                // Download all cached songs that aren't downloaded yet
+                                val currentDownloads = downloadUtil.downloads.value
+                                songs.filter {
+                                    currentDownloads[it.song.id]?.state != Download.STATE_COMPLETED
+                                }.forEach { song ->
                                     val downloadRequest = DownloadRequest
                                         .Builder(song.song.id, song.song.id.toUri())
                                         .setCustomCacheKey(song.song.id)

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/CachePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/CachePlaylistScreen.kt
@@ -67,11 +67,8 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastForEachReversed
-import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.media3.exoplayer.offline.Download
-import androidx.media3.exoplayer.offline.DownloadRequest
-import androidx.media3.exoplayer.offline.DownloadService
 import androidx.navigation.NavController
 import coil3.compose.AsyncImage
 import com.metrolist.music.LocalDownloadUtil
@@ -84,7 +81,7 @@ import com.metrolist.music.constants.SongSortType
 import com.metrolist.music.constants.SongSortTypeKey
 import com.metrolist.music.db.entities.Song
 import com.metrolist.music.extensions.toMediaItem
-import com.metrolist.music.playback.ExoDownloadService
+import com.metrolist.music.playback.enqueuePendingDownloads
 import com.metrolist.music.playback.queues.ListQueue
 import com.metrolist.music.ui.component.DraggableScrollbar
 import com.metrolist.music.ui.component.EmptyPlaceholder
@@ -600,23 +597,12 @@ private fun CachePlaylistHeader(
                                 )
                             },
                             onDownload = {
-                                // Download all cached songs that aren't downloaded yet
-                                val currentDownloads = downloadUtil.downloads.value
-                                songs.filter {
-                                    currentDownloads[it.song.id]?.state != Download.STATE_COMPLETED
-                                }.forEach { song ->
-                                    val downloadRequest = DownloadRequest
-                                        .Builder(song.song.id, song.song.id.toUri())
-                                        .setCustomCacheKey(song.song.id)
-                                        .setData(song.song.title.toByteArray())
-                                        .build()
-                                    DownloadService.sendAddDownload(
-                                        context,
-                                        ExoDownloadService::class.java,
-                                        downloadRequest,
-                                        false,
-                                    )
-                                }
+                                context.enqueuePendingDownloads(
+                                    downloadUtil.downloads.value,
+                                    songs,
+                                    { it.song.id },
+                                    { it.song.title },
+                                )
                             },
                             onDismiss = { menuState.dismiss() }
                         )

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -94,11 +94,9 @@ import androidx.compose.ui.util.fastForEachIndexed
 import androidx.compose.ui.util.fastForEachReversed
 import androidx.compose.ui.util.fastSumBy
 import androidx.core.content.FileProvider
-import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.media3.exoplayer.offline.Download
-import androidx.media3.exoplayer.offline.DownloadRequest
 import androidx.media3.exoplayer.offline.DownloadService
 import androidx.navigation.NavController
 import coil3.compose.AsyncImage
@@ -126,6 +124,7 @@ import com.metrolist.music.extensions.move
 import com.metrolist.music.extensions.toMediaItem
 import com.metrolist.music.models.toMediaMetadata
 import com.metrolist.music.playback.ExoDownloadService
+import com.metrolist.music.playback.enqueuePendingDownloads
 import com.metrolist.music.playback.queues.ListQueue
 import com.metrolist.music.ui.component.ActionPromptDialog
 import com.metrolist.music.ui.component.DefaultDialog
@@ -1427,25 +1426,12 @@ fun LocalPlaylistHeader(
                                     }
 
                                     else -> {
-                                        val currentDownloads = downloadUtil.downloads.value
-                                        songs.filter {
-                                            currentDownloads[it.song.id]?.state != Download.STATE_COMPLETED
-                                        }.forEach { song ->
-                                            val downloadRequest =
-                                                DownloadRequest
-                                                    .Builder(song.song.id, song.song.id.toUri())
-                                                    .setCustomCacheKey(song.song.id)
-                                                    .setData(
-                                                        song.song.song.title
-                                                            .toByteArray(),
-                                                    ).build()
-                                            DownloadService.sendAddDownload(
-                                                context,
-                                                ExoDownloadService::class.java,
-                                                downloadRequest,
-                                                false,
-                                            )
-                                        }
+                                        context.enqueuePendingDownloads(
+                                            downloadUtil.downloads.value,
+                                            songs,
+                                            { it.song.id },
+                                            { it.song.song.title },
+                                        )
                                     }
                                 }
                             },

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -1427,7 +1427,10 @@ fun LocalPlaylistHeader(
                                     }
 
                                     else -> {
-                                        songs.forEach { song ->
+                                        val currentDownloads = downloadUtil.downloads.value
+                                        songs.filter {
+                                            currentDownloads[it.song.id]?.state != Download.STATE_COMPLETED
+                                        }.forEach { song ->
                                             val downloadRequest =
                                                 DownloadRequest
                                                     .Builder(song.song.id, song.song.id.toUri())

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/TopPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/TopPlaylistScreen.kt
@@ -534,7 +534,8 @@ private fun TopPlaylistHeader(
 ) {
     val playerConnection = LocalPlayerConnection.current ?: return
     val context = LocalContext.current
-    
+    val downloadUtil = LocalDownloadUtil.current
+
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -678,7 +679,10 @@ private fun TopPlaylistHeader(
                                         }
                                     }
                                     else -> {
-                                        songs.forEach { song ->
+                                        val currentDownloads = downloadUtil.downloads.value
+                                        songs.filter {
+                                            currentDownloads[it.id]?.state != Download.STATE_COMPLETED
+                                        }.forEach { song ->
                                             val downloadRequest = DownloadRequest
                                                 .Builder(song.id, song.id.toUri())
                                                 .setCustomCacheKey(song.id)

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/TopPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/TopPlaylistScreen.kt
@@ -70,10 +70,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastForEachReversed
 import androidx.compose.ui.util.fastSumBy
-import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.media3.exoplayer.offline.Download
-import androidx.media3.exoplayer.offline.DownloadRequest
 import androidx.media3.exoplayer.offline.DownloadService
 import androidx.navigation.NavController
 import coil3.compose.AsyncImage
@@ -85,6 +83,7 @@ import com.metrolist.music.constants.MyTopFilter
 import com.metrolist.music.db.entities.Song
 import com.metrolist.music.extensions.toMediaItem
 import com.metrolist.music.playback.ExoDownloadService
+import com.metrolist.music.playback.enqueuePendingDownloads
 import com.metrolist.music.playback.queues.ListQueue
 import com.metrolist.music.ui.component.DefaultDialog
 import com.metrolist.music.ui.component.DraggableScrollbar
@@ -679,22 +678,12 @@ private fun TopPlaylistHeader(
                                         }
                                     }
                                     else -> {
-                                        val currentDownloads = downloadUtil.downloads.value
-                                        songs.filter {
-                                            currentDownloads[it.id]?.state != Download.STATE_COMPLETED
-                                        }.forEach { song ->
-                                            val downloadRequest = DownloadRequest
-                                                .Builder(song.id, song.id.toUri())
-                                                .setCustomCacheKey(song.id)
-                                                .setData(song.title.toByteArray())
-                                                .build()
-                                            DownloadService.sendAddDownload(
-                                                context,
-                                                ExoDownloadService::class.java,
-                                                downloadRequest,
-                                                false,
-                                            )
-                                        }
+                                        context.enqueuePendingDownloads(
+                                            downloadUtil.downloads.value,
+                                            songs,
+                                            { it.id },
+                                            { it.title },
+                                        )
                                     }
                                 }
                             },

--- a/app/src/test/kotlin/com/metrolist/music/playback/DownloadRequestsTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/playback/DownloadRequestsTest.kt
@@ -1,0 +1,102 @@
+package com.metrolist.music.playback
+
+import androidx.core.net.toUri
+import androidx.media3.exoplayer.offline.Download
+import androidx.media3.exoplayer.offline.DownloadRequest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = android.app.Application::class)
+class DownloadRequestsTest {
+    private data class TestSong(val id: String, val title: String)
+
+    private fun download(id: String, state: Int): Download =
+        Download(
+            DownloadRequest.Builder(id, id.toUri()).build(),
+            state,
+            /* startTimeMs = */ 0L,
+            /* updateTimeMs = */ 0L,
+            /* contentLength = */ 0L,
+            /* stopReason = */ Download.STOP_REASON_NONE,
+            // media3 requires failureReason to be set if and only if state is STATE_FAILED
+            /* failureReason = */
+            if (state == Download.STATE_FAILED) {
+                Download.FAILURE_REASON_UNKNOWN
+            } else {
+                Download.FAILURE_REASON_NONE
+            },
+        )
+
+    private fun requestsFor(
+        downloads: Map<String, Download>,
+        songs: List<TestSong>,
+    ) = buildPendingDownloadRequests(downloads, songs, { it.id }, { it.title })
+
+    @Test
+    fun `mixed selection only enqueues songs that are not completed`() {
+        val songs = listOf(
+            TestSong("a", "A"),
+            TestSong("b", "B"),
+            TestSong("c", "C"),
+            TestSong("d", "D"),
+        )
+        val downloads = mapOf(
+            "a" to download("a", Download.STATE_COMPLETED),
+            "b" to download("b", Download.STATE_FAILED),
+            "c" to download("c", Download.STATE_COMPLETED),
+            // "d" has never been downloaded and is absent from the map
+        )
+
+        val requests = requestsFor(downloads, songs)
+
+        assertEquals(2, requests.size)
+        assertEquals(listOf("b", "d"), requests.map { it.id })
+    }
+
+    @Test
+    fun `fully downloaded selection enqueues nothing`() {
+        val songs = listOf(TestSong("a", "A"), TestSong("b", "B"))
+        val downloads = mapOf(
+            "a" to download("a", Download.STATE_COMPLETED),
+            "b" to download("b", Download.STATE_COMPLETED),
+        )
+
+        assertEquals(0, requestsFor(downloads, songs).size)
+    }
+
+    @Test
+    fun `selection with no downloads enqueues every song`() {
+        val songs = listOf(TestSong("a", "A"), TestSong("b", "B"), TestSong("c", "C"))
+
+        val requests = requestsFor(emptyMap(), songs)
+
+        assertEquals(3, requests.size)
+        assertEquals(listOf("a", "b", "c"), requests.map { it.id })
+    }
+
+    @Test
+    fun `in-flight states are re-enqueued so retries still work`() {
+        val songs = listOf(TestSong("a", "A"), TestSong("b", "B"), TestSong("c", "C"))
+        val downloads = mapOf(
+            "a" to download("a", Download.STATE_QUEUED),
+            "b" to download("b", Download.STATE_DOWNLOADING),
+            "c" to download("c", Download.STATE_STOPPED),
+        )
+
+        assertEquals(3, requestsFor(downloads, songs).size)
+    }
+
+    @Test
+    fun `request carries the custom cache key and title payload`() {
+        val requests = requestsFor(emptyMap(), listOf(TestSong("a", "Song A")))
+
+        assertEquals(1, requests.size)
+        assertEquals("a", requests[0].id)
+        assertEquals("a", requests[0].customCacheKey)
+        assertEquals("Song A", String(requests[0].data))
+    }
+}


### PR DESCRIPTION
## Problem

Bulk download actions re-queue songs that are already downloaded instead of
skipping them. In a 50-song playlist with 25 already downloaded, all 50 get
queued again.

## Cause

These call sites compute an aggregate download state
(`songs.all { ... == STATE_COMPLETED }`), then enqueue **every** song in the
non-completed branch:

| File | Line |
|---|---|
| `ui/screens/playlist/LocalPlaylistScreen.kt` | 1429 |
| `ui/screens/playlist/AutoPlaylistScreen.kt` | 1031 |
| `ui/screens/playlist/TopPlaylistScreen.kt` | 681 |
| `ui/screens/playlist/CachePlaylistScreen.kt` | 602 |
| `ui/menu/PlaylistMenu.kt` | 578 |
| `ui/menu/AlbumMenu.kt` | 546 |
| `ui/menu/YouTubePlaylistMenu.kt` | 644 |
| `ui/menu/YouTubeAlbumMenu.kt` | 505 |

On a partially downloaded collection the aggregate is not `STATE_COMPLETED`,
so the else-branch runs and re-adds the completed songs too.

Re-adding a completed download is not a no-op. media3's
`DownloadManager.mergeRequest()` moves it back to `STATE_QUEUED` with
`contentLength` reset to `LENGTH_UNSET`. On re-completion, `DownloadUtil`'s
listener calls `updateDownloadedInfo(id, true, LocalDateTime.now())`, which
overwrites `dateDownload` and breaks "date downloaded" ordering.

Note: the issue lists `Library → Playlist → ⋮ → Download` as working
correctly. It has the same bug — `PlaylistMenu.kt` had an identical
unfiltered loop. The paths only look different because the menu shows
"Remove download" solely when **all** songs are complete.

## Solution

- Skip songs already in `STATE_COMPLETED` before building and sending
  `DownloadRequest`s, at all 8 bulk call sites.
- `downloadUtil.downloads` is a `StateFlow`, so `.value` is read in the click
  handler — no recomposition changes.
- Added `LocalDownloadUtil.current` to the three `*Header` composables that
  lacked it (`AutoPlaylistScreen`, `TopPlaylistScreen`, `CachePlaylistScreen`).
- `SongMenu.kt` and `QueueMenu.kt` are unchanged: they switch on
  `when (download?.state)` for a single song, so a completed song shows
  "Remove download" and the re-add path is unreachable.

## Testing

Built `:app:assembleFossDebug`, installed on an API 36 arm64 emulator.
Verified against ExoPlayer's download index (`exoplayer_internal.db`,
table `ExoPlayerDownloads`).

**Before** — two songs downloaded in a 95-song playlist, then playlist ⋮ →
Download. Both completed rows were rewritten:

| song | `update_time_ms` before | after |
|---|---|---|
| `m6Y8xEfyXTs` | 1786824116811 | 1786824365146 |
| `3QhajVg6SjE` | 1786824217877 | 1786824365180 |

All 95 songs were queued. In `song.db`, the two `dateDownload` values ended up
24 ms apart despite the originals being ~100 s apart.

**After** — same action, with download states seeded directly in the index:

| song | in playlist | seeded | after |
|---|---|---|---|
| `m6Y8xEfyXTs` | yes | `state=3 upd=1111111111111` | **unchanged** (skipped) |
| `AlvUuGJccKs` | yes | `state=4 upd=2222222222222` | `state=3 upd=1786827032349` (enqueued) |
| `ilNt2bikxDI` | no | `state=4 upd=3333333333333` | unchanged |

The completed song is skipped, the non-completed song in the same playlist is
still enqueued, and songs outside the collection are untouched.

## Related Issues

- Closes #4261

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented completed songs from being added to download queues again.
  * Improved retry behavior for downloads that failed, stopped, or remain in progress.
  * Updated album, playlist, cached, local, automatic, selection, and top-list downloads to process only tracks that still require downloading.
  * Improved artist name display consistency in YouTube album and playlist menus.
  * Improved playback cleanup and recovery, including more reliable metadata, synchronization, thumbnails, and connection-state handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->