### PR TITLE
fix(sync): keep local playlist order when syncing with YouTube

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
@@ -1560,56 +1560,87 @@ class SyncUtils @Inject constructor(
                     val localIds = database.playlistSongIds(playlistId)
                     val songIdsWithoutArtists = database.playlistSongIdsWithoutArtists(playlistId).toSet()
 
-                    if (remoteIds == localIds) {
+                    // Compare as sets rather than ordered lists: reorders are pushed to
+                    // YouTube Music from the playlist screen, so when both sides contain the
+                    // same songs the local order is authoritative and must not be overwritten
+                    // by the remote order (which may not have caught up with the reorder yet).
+                    if (remoteIds.toSet() == localIds.toSet()) {
+                        // Even when membership matches, repair any songs missing artist metadata.
                         val metadataRepairs = songs.filter {
                             it.id in songIdsWithoutArtists && it.artists.isNotEmpty()
                         }
                         if (metadataRepairs.isNotEmpty()) {
                             database.withTransaction {
-                                metadataRepairs.forEach(::insert)
+                                metadataRepairs.forEach(database::insert)
                             }
                         }
-                        Timber.d("syncPlaylist: Local and remote are in sync, no changes needed")
+                        Timber.d("syncPlaylist: Local and remote contain the same songs, no changes needed")
                         return@onSuccess
                     }
 
                     Timber.d("syncPlaylist: Updating local playlist (remote: ${remoteIds.size}, local: ${localIds.size})")
 
-                    val remoteIdSet = remoteIds.toSet()
-                    val localIdSet = localIds.toSet()
-                    val downloadedSongIds = database.downloadedPlaylistSongIds(playlistId).toSet()
-                    val metadataInserts = songs.filter {
-                        it.id !in localIdSet || it.id in songIdsWithoutArtists
-                    }
-
                     database.withTransaction {
-                        database.clearPlaylist(playlistId)
-                        metadataInserts.forEach(database::insert)
+                        // Merge remote membership changes without discarding the local order:
+                        // songs present on both sides keep their local position, songs removed
+                        // remotely (and not downloaded) are dropped, and new remote songs are
+                        // appended at the end in remote relative order.
+                        val localSongsBeforeSync = database.playlistSongsBlocking(playlistId)
+                        val localIdsBySongId = localSongsBeforeSync.associateBy { it.map.songId }
+                        val remoteSet = remoteIds.toSet()
+                        var changed = false
 
-                        downloadedSongIds.forEach { songId ->
-                            if (songId !in remoteIdSet) {
-                                val existingSong = database.getSongByIdBlocking(songId)
-                                if (existingSong != null) {
-                                    val maxPosition = database.playlistSongsBlocking(playlistId)
-                                        .maxOfOrNull { it.map.position } ?: -1
-                                    database.insert(
-                                        PlaylistSongMap(
-                                            songId = songId,
-                                            playlistId = playlistId,
-                                            position = maxPosition + 1
-                                        )
-                                    )
-                                    Timber.d("syncPlaylist: Preserved downloaded song $songId in playlist")
-                                }
+                        // Insert or repair metadata for all remote songs.
+                        songs.forEach { song ->
+                            if (database.getSongByIdBlocking(song.id) == null ||
+                                song.id in songIdsWithoutArtists && song.artists.isNotEmpty()
+                            ) {
+                                database.insert(song)
                             }
                         }
 
-                        val playlistEntity = database.playlistBlocking(playlistId)
-                        if (playlistEntity != null) {
-                            database.addSongsToPlaylist(
-                                playlistEntity,
-                                songs.map { it.id to it.setVideoId }
-                            )
+                        localSongsBeforeSync.forEach { playlistSong ->
+                            val map = playlistSong.map
+                            if (map.songId !in remoteSet &&
+                                !playlistSong.song.song.isDownloaded &&
+                                playlistSong.song.song.dateDownload == null
+                            ) {
+                                database.delete(map)
+                                changed = true
+                                Timber.d("syncPlaylist: Removed song ${map.songId} no longer in remote playlist")
+                            } else if (map.songId !in remoteSet) {
+                                Timber.d("syncPlaylist: Preserved downloaded song ${map.songId} in playlist")
+                            }
+                        }
+
+                        val missingRemoteSongs = remoteIds.filter { it !in localIdsBySongId }
+                        if (missingRemoteSongs.isNotEmpty()) {
+                            var maxPosition = database.playlistSongsBlocking(playlistId)
+                                .maxOfOrNull { it.map.position } ?: -1
+                            missingRemoteSongs.forEach { songId ->
+                                database.insert(
+                                    PlaylistSongMap(
+                                        songId = songId,
+                                        playlistId = playlistId,
+                                        position = ++maxPosition,
+                                        setVideoId = songs.firstOrNull { it.id == songId }?.setVideoId,
+                                    ),
+                                )
+                            }
+                            changed = true
+                        }
+
+                        // Keep positions contiguous so that later inserts (which start from the
+                        // song count) cannot collide with existing positions after the deletions.
+                        database.playlistSongsBlocking(playlistId)
+                            .forEachIndexed { index, playlistSong ->
+                                if (playlistSong.map.position != index) {
+                                    database.update(playlistSong.map.copy(position = index))
+                                }
+                            }
+
+                        if (changed) {
+                            updatePlaylistLastUpdated(playlistId)
                         }
                     }
                     Timber.d("syncPlaylist: Successfully synced playlist")

--- a/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
@@ -1551,11 +1551,6 @@ class SyncUtils @Inject constructor(
                     val songs = page.songs.map(SongItem::toMediaMetadata)
                     Timber.d("syncPlaylist: Fetched ${songs.size} songs from remote")
 
-                    if (songs.isEmpty()) {
-                        Timber.w("syncPlaylist: Remote playlist is empty, skipping sync")
-                        return@onSuccess
-                    }
-
                     val remoteIds = songs.map { it.id }
                     val localIds = database.playlistSongIds(playlistId)
                     val songIdsWithoutArtists = database.playlistSongIdsWithoutArtists(playlistId).toSet()


### PR DESCRIPTION
Replaces the closed #4267 (its head branch was squashed into a single commit and force-pushed, so GitHub blocks reopening it). Same change, clean history.

## Problem
Reordering songs in a synced playlist never sticks: after moving a song (e.g. from position 5 to position 1), the playlist snaps back to the original order — even with the lock button unlocked.

## Cause
`executeSyncPlaylist` compared the remote and local song ID lists by **order** (`remoteIds == localIds`). A reorder is pushed to YouTube Music from the playlist screen, but when that push hasn't propagated yet (or fails), the remote order still differs from local. The sync then treated the playlist as out of sync, wiped it (`clearPlaylist`) and rebuilt it in the remote order — reverting the user's reorder. Same root cause as #3561 / #1318 / #1231 (sync-related reorder reverts).

## Solution
- Compare song ID **sets** instead of ordered lists: when both sides contain the same songs, the local order is authoritative and the sync does nothing.
- When membership genuinely differs, **merge** instead of wipe-and-rebuild:
  - songs present on both sides keep their local position
  - songs removed remotely (and not downloaded) are dropped
  - new remote songs are appended at the end in remote relative order
  - downloaded songs are preserved
  - positions are re-normalized so future inserts can't collide

## Testing
- Build verified in CI on the fork: `:app:assembleFossDebug` passes (run [31986931101](https://github.com/fatuhsa/Metrolist/actions/runs/31986931101)).
- Manual test to confirm: unlock a synced playlist, move a song to a different position, then refresh / restart the app — the order should stick.

## Related Issues
- Related to #3561
- Related to #1318
- Related to #1231

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Empty remote playlists now synchronize correctly.
  * Playlist synchronization preserves local song ordering when memberships match.
  * Downloaded songs are retained while applying remote membership changes.
  * Newly available remote songs are appended and playlist positions are compacted.
  * Missing artist information is repaired during song and playlist synchronization.
  * Artist subscriptions now resolve aliased artist names correctly.
  * Library cleanup preserves downloaded songs and removes orphaned artist entries.
  * Playlist timestamps update only when membership changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->