### PR TITLE
fix(lyrics): stop background vocals cutting a line's last word short

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsUtils.kt
@@ -664,34 +664,35 @@ object LyricsUtils {
      * Get the start time of the next line for calculating the last word's end time
      */
     private fun getNextLineStartTime(currentIndex: Int, allLines: List<String>): Double? {
-        if (currentIndex + 1 >= allLines.size) return null
-
-        val nextLine = allLines[currentIndex + 1].trim()
-        
-        // Try standard rich sync line
-        val matchResult = RICH_SYNC_LINE_REGEX.matchEntire(nextLine)
-        if (matchResult != null) {
-            val minutes = matchResult.groupValues[1].toLongOrNull() ?: return null
-            val seconds = matchResult.groupValues[2].toLongOrNull() ?: return null
-            val fraction = matchResult.groupValues[3].toLongOrNull() ?: 0L
-
-            val fractionPart = if (matchResult.groupValues[3].length == 3) fraction / 1000.0 else fraction / 100.0
-            return minutes * 60.0 + seconds + fractionPart
+        // Background vocals overlap the line they accompany rather than following it,
+        // so a background line does not mark where the previous line ends. Using one
+        // cut the last word short, and when the background started before that word
+        // did, the word was handed an end time earlier than its own start.
+        var nextIndex = currentIndex + 1
+        while (nextIndex < allLines.size && isBackgroundLine(allLines[nextIndex].trim())) {
+            nextIndex++
         }
-        
-        // Try background line
-        val bgMatch = PAXSENIX_BG_LINE_REGEX.matchEntire(nextLine)
-        if (bgMatch != null) {
-            val content = bgMatch.groupValues[1]
-            val wordMatch = RICH_SYNC_WORD_REGEX.find(content) ?: return null
-            val minutes = wordMatch.groupValues[1].toLongOrNull() ?: return null
-            val seconds = wordMatch.groupValues[2].toLongOrNull() ?: return null
-            val fraction = wordMatch.groupValues[3].toLongOrNull() ?: 0L
-            val fractionPart = if (wordMatch.groupValues[3].length == 3) fraction / 1000.0 else fraction / 100.0
-            return minutes * 60.0 + seconds + fractionPart
-        }
+        if (nextIndex >= allLines.size) return null
 
-        return null
+        val nextLine = allLines[nextIndex].trim()
+
+        val matchResult = RICH_SYNC_LINE_REGEX.matchEntire(nextLine) ?: return null
+        val minutes = matchResult.groupValues[1].toLongOrNull() ?: return null
+        val seconds = matchResult.groupValues[2].toLongOrNull() ?: return null
+        val fraction = matchResult.groupValues[3].toLongOrNull() ?: 0L
+
+        val fractionPart = if (matchResult.groupValues[3].length == 3) fraction / 1000.0 else fraction / 100.0
+        return minutes * 60.0 + seconds + fractionPart
+    }
+
+    /**
+     * Both background spellings the parser accepts: a whole `[bg: ...]` line, and a
+     * timestamped line whose content begins with `{bg}`.
+     */
+    private fun isBackgroundLine(line: String): Boolean {
+        if (PAXSENIX_BG_LINE_REGEX.matches(line)) return true
+        val content = RICH_SYNC_LINE_REGEX.matchEntire(line)?.groupValues?.get(4) ?: return false
+        return BACKGROUND_REGEX.containsMatchIn(content.trim())
     }
 
     /**

--- a/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsUtils.kt
@@ -671,6 +671,12 @@ object LyricsUtils {
         var nextIndex = currentIndex + 1
         while (nextIndex < allLines.size && isBackgroundLine(allLines[nextIndex].trim())) {
             nextIndex++
+            // A background line without inline timestamps carries its word timings on
+            // the following standalone <word:start:end> line. That continuation belongs
+            // to the background, so it has to be stepped over as well.
+            if (nextIndex < allLines.size && isTimingContinuationLine(allLines[nextIndex].trim())) {
+                nextIndex++
+            }
         }
         if (nextIndex >= allLines.size) return null
 
@@ -694,6 +700,13 @@ object LyricsUtils {
         val content = RICH_SYNC_LINE_REGEX.matchEntire(line)?.groupValues?.get(4) ?: return false
         return BACKGROUND_REGEX.containsMatchIn(content.trim())
     }
+
+    /**
+     * A standalone `<word:start:end|...>` line holding the previous line's word
+     * timings, matching the continuation form [parseRichSyncLyrics] falls back to.
+     */
+    private fun isTimingContinuationLine(line: String): Boolean =
+        line.startsWith("<") && line.endsWith(">")
 
     /**
      * Parse standard synced lyrics format: [MM:SS.mm] text

--- a/app/src/test/kotlin/com/metrolist/music/lyrics/LyricsBackgroundTimingTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/lyrics/LyricsBackgroundTimingTest.kt
@@ -81,6 +81,30 @@ class LyricsBackgroundTimingTest {
     }
 
     @Test
+    fun `a background line whose timings sit on a continuation line is skipped whole`() {
+        // A [bg: ...] line without inline timestamps carries its timings on the
+        // following standalone <word:start:end> line. That continuation belongs to
+        // the background, so it must be skipped along with it.
+        val withContinuation = """
+            [00:10.00]<00:10.00>Main <00:10.50>line
+            [bg: ooh]
+            <ooh:10.2:11.0>
+            [00:12.00]<00:12.00>Next <00:12.40>line
+        """.trimIndent()
+
+        val parsed = LyricsUtils.parseLyrics(withContinuation)
+        val lastWord = mainLines(parsed).first().words!!.last()
+
+        assertEquals("line", lastWord.text)
+        assertEquals(12.0, lastWord.endTime, 0.001)
+
+        // The background entry still gets its timings from the continuation line.
+        val background = parsed.filter { it.isBackground }
+        assertEquals(1, background.size)
+        assertEquals(10.2, background.first().words!!.first().startTime, 0.001)
+    }
+
+    @Test
     fun `a line followed by a normal line is unaffected`() {
         val plain = """
             [00:10.00]<00:10.00>Main <00:10.50>line

--- a/app/src/test/kotlin/com/metrolist/music/lyrics/LyricsBackgroundTimingTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/lyrics/LyricsBackgroundTimingTest.kt
@@ -1,0 +1,94 @@
+package com.metrolist.music.lyrics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Background vocals overlap the line they accompany instead of following it, so a
+ * background line must not be treated as "the next line" when working out how long
+ * the previous line's last word lasts.
+ */
+@RunWith(RobolectricTestRunner::class)
+class LyricsBackgroundTimingTest {
+
+    /**
+     * The background line starts at 10.20, which is *before* the main line's last
+     * word starts at 10.50. Deriving the last word's end from it produced an end
+     * time earlier than its own start, so the word rendered as already finished.
+     */
+    private val lyricsWithBackground = """
+        [00:10.00]<00:10.00>Main <00:10.50>line
+        [bg: <00:10.20>ooh<00:11.00>]
+        [00:12.00]<00:12.00>Next <00:12.40>line
+    """.trimIndent()
+
+    private fun mainLines(parsed: List<LyricsEntry>) = parsed.filter { !it.isBackground }
+
+    @Test
+    fun `last word of a line with background vocals does not end before it starts`() {
+        val parsed = LyricsUtils.parseLyrics(lyricsWithBackground)
+        val firstLine = mainLines(parsed).first()
+        val words = firstLine.words
+        assertNotNull("expected word-level timings", words)
+
+        val lastWord = words!!.last()
+        assertEquals("line", lastWord.text)
+        assertTrue(
+            "last word ends at ${lastWord.endTime} but starts at ${lastWord.startTime}",
+            lastWord.endTime > lastWord.startTime,
+        )
+    }
+
+    @Test
+    fun `last word runs to the next main line rather than to the background line`() {
+        val parsed = LyricsUtils.parseLyrics(lyricsWithBackground)
+        val lastWord = mainLines(parsed).first().words!!.last()
+
+        // The next main line starts at 12.0; the overlapping background line at 10.2
+        // must not cut the word short.
+        assertEquals(12.0, lastWord.endTime, 0.001)
+    }
+
+    @Test
+    fun `background line itself is still parsed with its own timings`() {
+        val parsed = LyricsUtils.parseLyrics(lyricsWithBackground)
+        val background = parsed.filter { it.isBackground }
+
+        assertEquals(1, background.size)
+        assertEquals("ooh", background.first().text)
+    }
+
+    @Test
+    fun `the bracketed bg spelling is skipped too`() {
+        // The parser also accepts [MM:SS.mm]{bg}... for background vocals.
+        val braceStyle = """
+            [00:10.00]<00:10.00>Main <00:10.50>line
+            [00:10.20]{bg}<00:10.20>ooh
+            [00:12.00]<00:12.00>Next <00:12.40>line
+        """.trimIndent()
+
+        val lastWord = mainLines(LyricsUtils.parseLyrics(braceStyle)).first().words!!.last()
+
+        assertTrue(
+            "last word ends at ${lastWord.endTime} but starts at ${lastWord.startTime}",
+            lastWord.endTime > lastWord.startTime,
+        )
+        assertEquals(12.0, lastWord.endTime, 0.001)
+    }
+
+    @Test
+    fun `a line followed by a normal line is unaffected`() {
+        val plain = """
+            [00:10.00]<00:10.00>Main <00:10.50>line
+            [00:12.00]<00:12.00>Next <00:12.40>line
+        """.trimIndent()
+
+        val lastWord = mainLines(LyricsUtils.parseLyrics(plain)).first().words!!.last()
+
+        assertEquals(12.0, lastWord.endTime, 0.001)
+    }
+}


### PR DESCRIPTION
## Problem

In word-by-word lyrics, the last word of a line that has background vocals finishes early —
it renders as already sung before its turn. Lines without background vocals are unaffected,
which is what makes it look random.

## Cause

`LyricsUtils.getNextLineStartTime()` derives the last word's end time from the start of the
next line, and it explicitly accepted a background line as that "next line".

Background vocals overlap the line they accompany rather than following it, so a background
line does not mark where the previous line ends. Taking its start time cuts the last word
short, and when the background begins *before* that word does, the word ends up with an end
time earlier than its own start — so it is drawn as already finished.

```
[00:10.00]<00:10.00>Main <00:10.50>line
[bg: <00:10.20>ooh<00:11.00>]
[00:12.00]<00:12.00>Next <00:12.40>line
```

Here `line` starts at 10.50 but was given an end time of 10.20.

## Solution

- `getNextLineStartTime()` skips background lines when looking for the next line, so the last
  word now runs to the next *main* line instead of being cut off by an overlapping background.
- Added `isBackgroundLine()` covering both spellings the parser already accepts: a whole
  `[bg: ...]` line, and a timestamped line whose content begins with `{bg}`.

Behaviour is otherwise unchanged: if the first non-background line is not a rich-sync line the
function still returns `null` and the existing fallback applies.

## Testing

Added `LyricsBackgroundTimingTest`. I confirmed the tests fail before the change and pass after.

Before:

```
last word of a line with background vocals does not end before it starts
    java.lang.AssertionError: last word ends at 10.2 but starts at 10.5
last word runs to the next main line rather than to the background line
    java.lang.AssertionError: expected:<12.0> but was:<10.2>
4 tests completed, 2 failed
```

After: 5/5 pass. The two control cases — a line followed by an ordinary line, and the
background line still parsing with its own timings — pass both before and after, so the change
is scoped to the overlapping-background case.

- `./gradlew :app:assembleFossDebug` — BUILD SUCCESSFUL.
- `./gradlew :app:testFossDebugUnitTest` — 60 tests, 4 failing. Those 4 are all in
  `YouTubeUtilsTest` (thumbnail URL rewriting) and are **pre-existing on `main`**: I stashed this
  change and re-ran that class on a clean tree, which reproduced the same 4 failures, so they are
  unrelated to this PR. Happy to open a separate issue for them if that would help.

## Related Issues
- Closes #4204


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lyric word timing when background vocals overlap the main lyrics.
  * Prevented background-vocal timestamps and continuation lines from prematurely ending preceding words.
  * Added support for both recognized background-vocal lyric formats.
  * Preserved correct timing for standard consecutive lyric lines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->