### PR TITLE
fix(cache): stop polling the entire media cache every second

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
@@ -698,8 +698,8 @@ interface DatabaseDao {
     fun getSongByIdBlocking(songId: String): Song?
 
     @Transaction
-    @Query("SELECT * FROM song WHERE id IN (:songIds)")
-    suspend fun getSongsByIds(songIds: List<String>): List<Song>
+    @Query("SELECT * FROM song WHERE dateDownload IS NOT NULL")
+    fun cachePlaylistSongs(): Flow<List<Song>>
 
 
     @Transaction

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/CachePlaylistViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/CachePlaylistViewModel.kt
@@ -97,3 +97,39 @@ class CachePlaylistViewModel
             playerCache.removeResource(songId)
         }
     }
+
+/**
+ * Result of checking which Cache Playlist entries still have their bytes on disk.
+ */
+internal data class CachedSongPartition(
+    val stillCached: List<Song>,
+    val stale: List<Song>,
+)
+
+/**
+ * Splits songs flagged as belonging to the Cache Playlist into those whose data is still
+ * present and those whose flag must be cleared.
+ *
+ * A downloaded song is always considered present: its file is managed by the download service
+ * rather than the player cache. A song whose content length is unknown cannot be checked, so it
+ * is treated as stale rather than assumed present.
+ *
+ * [isCached] receives the song id and its content length, and reports whether the complete file
+ * is available in either cache.
+ */
+internal fun partitionCachedSongs(
+    flagged: List<Song>,
+    isCached: (songId: String, contentLength: Long) -> Boolean,
+): CachedSongPartition {
+    val stillCached = mutableListOf<Song>()
+    val stale = mutableListOf<Song>()
+
+    for (song in flagged) {
+        val contentLength = song.format?.contentLength
+        val present = song.song.isDownloaded ||
+            (contentLength != null && isCached(song.song.id, contentLength))
+        if (present) stillCached += song else stale += song
+    }
+
+    return CachedSongPartition(stillCached, stale)
+}

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/CachePlaylistViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/CachePlaylistViewModel.kt
@@ -18,13 +18,18 @@ import com.metrolist.music.di.PlayerCache
 import com.metrolist.music.extensions.filterExplicit
 import com.metrolist.music.extensions.filterVideoSongs
 import com.metrolist.music.utils.dataStore
-import com.metrolist.music.utils.get
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 
 @HiltViewModel
@@ -36,65 +41,52 @@ class CachePlaylistViewModel
         @PlayerCache private val playerCache: Cache,
         @DownloadCache private val downloadCache: Cache,
     ) : ViewModel() {
-        private val _cachedSongs = MutableStateFlow<List<Song>>(emptyList())
-        val cachedSongs: StateFlow<List<Song>> = _cachedSongs
+        private data class Inputs(
+            val flagged: List<Song>,
+            val hideExplicit: Boolean,
+            val hideVideoSongs: Boolean,
+        )
 
-        init {
-            viewModelScope.launch {
-                while (true) {
-                    val hideExplicit = context.dataStore.get(HideExplicitKey, false)
-                    val hideVideoSongs = context.dataStore.get(HideVideoSongsKey, false)
-
-                    // Candidate set: anything currently present in either cache. We no longer
-                    // SET dateDownload here — that decision belongs solely to MusicService's
-                    // markCachedIfFullyDownloaded(), which only fires once a track actually
-                    // finishes playing naturally (MEDIA_ITEM_TRANSITION_REASON_AUTO). This loop
-                    // only displays already-flagged songs and self-heals: if a song's dateDownload
-                    // is set but its backing cache data is gone now (evicted, or manually removed
-                    // via removeSongFromCache), the flag gets cleared so the list — and the DB —
-                    // stay honest.
-                    val candidateIds = playerCache.keys.toSet() + downloadCache.keys.toSet()
-                    val songs =
-                        if (candidateIds.isNotEmpty()) {
-                            database.getSongsByIds(candidateIds.toList())
-                        } else {
-                            emptyList()
-                        }
-
-                    val flagged = songs.filter { it.song.dateDownload != null }
-                    val stillValid = mutableListOf<Song>()
-
-                    for (song in flagged) {
-                        val contentLength = song.format?.contentLength
-                        val stillCached =
-                            song.song.isDownloaded ||
-                                (
-                                    contentLength != null &&
-                                        (
-                                            downloadCache.isCached(song.song.id, 0, contentLength) ||
-                                                playerCache.isCached(song.song.id, 0, contentLength)
-                                        )
-                                )
-                        if (stillCached) {
-                            stillValid += song
-                        } else {
-                            database.query { update(song.song.copy(dateDownload = null)) }
-                        }
-                    }
-
-                    _cachedSongs.value =
-                        stillValid
-                            .sortedByDescending { it.song.dateDownload }
-                            .filterExplicit(hideExplicit)
-                            .filterVideoSongs(hideVideoSongs)
-
-                    delay(1000)
+        @OptIn(ExperimentalCoroutinesApi::class)
+        val cachedSongs: StateFlow<List<Song>> =
+            combine(
+                database.cachePlaylistSongs(),
+                context.dataStore.data.map { it[HideExplicitKey] ?: false }.distinctUntilChanged(),
+                context.dataStore.data.map { it[HideVideoSongsKey] ?: false }.distinctUntilChanged(),
+                ::Inputs,
+            ).mapLatest { (flagged, hideExplicit, hideVideoSongs) ->
+                val partition = partitionCachedSongs(flagged) { songId, contentLength ->
+                    downloadCache.isCached(songId, 0, contentLength) ||
+                        playerCache.isCached(songId, 0, contentLength)
                 }
-            }
-        }
+
+                // Clearing the flag removes these songs from cachePlaylistSongs(), so this
+                // re-emits once and then settles rather than looping.
+                partition.stale.forEach { song ->
+                    database.query { update(song.song.copy(dateDownload = null)) }
+                }
+
+                partition.stillCached
+                    .sortedByDescending { it.song.dateDownload }
+                    .filterExplicit(hideExplicit)
+                    .filterVideoSongs(hideVideoSongs)
+            }.flowOn(Dispatchers.IO)
+                .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
         fun removeSongFromCache(songId: String) {
             playerCache.removeResource(songId)
+
+            // Dropping the bytes does not touch the database, so nothing would invalidate
+            // cachePlaylistSongs() and the song would linger in the list until the screen is
+            // re-entered. Re-check this one song against the same rules and clear its flag here.
+            database.query {
+                val song = getSongByIdBlocking(songId) ?: return@query
+                val partition = partitionCachedSongs(listOf(song)) { id, contentLength ->
+                    downloadCache.isCached(id, 0, contentLength) ||
+                        playerCache.isCached(id, 0, contentLength)
+                }
+                partition.stale.forEach { update(it.song.copy(dateDownload = null)) }
+            }
         }
     }
 

--- a/app/src/test/kotlin/com/metrolist/music/viewmodels/CachePlaylistPartitionTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/viewmodels/CachePlaylistPartitionTest.kt
@@ -1,0 +1,100 @@
+package com.metrolist.music.viewmodels
+
+import com.metrolist.music.db.entities.FormatEntity
+import com.metrolist.music.db.entities.Song
+import com.metrolist.music.db.entities.SongEntity
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CachePlaylistPartitionTest {
+    private fun song(
+        id: String,
+        contentLength: Long? = 1_000L,
+        isDownloaded: Boolean = false,
+    ) = Song(
+        song = SongEntity(id = id, title = "title-$id", isDownloaded = isDownloaded),
+        artists = emptyList(),
+        format = contentLength?.let {
+            @Suppress("DEPRECATION")
+            FormatEntity(
+                id = id,
+                itag = 251,
+                mimeType = "audio/webm",
+                codecs = "opus",
+                bitrate = 128_000,
+                sampleRate = 48_000,
+                contentLength = it,
+                loudnessDb = null,
+                playbackUrl = null,
+            )
+        },
+    )
+
+    @Test
+    fun `song whose bytes are still present stays cached`() {
+        val result = partitionCachedSongs(listOf(song("a"))) { _, _ -> true }
+
+        assertEquals(listOf("a"), result.stillCached.map { it.id })
+        assertEquals(emptyList<String>(), result.stale.map { it.id })
+    }
+
+    @Test
+    fun `song whose bytes are gone is reported as stale`() {
+        val result = partitionCachedSongs(listOf(song("a"))) { _, _ -> false }
+
+        assertEquals(emptyList<String>(), result.stillCached.map { it.id })
+        assertEquals(listOf("a"), result.stale.map { it.id })
+    }
+
+    @Test
+    fun `downloaded song stays cached even when the cache reports a miss`() {
+        val result = partitionCachedSongs(listOf(song("a", isDownloaded = true))) { _, _ -> false }
+
+        assertEquals(listOf("a"), result.stillCached.map { it.id })
+        assertEquals(emptyList<String>(), result.stale.map { it.id })
+    }
+
+    @Test
+    fun `song with unknown content length is stale and is never looked up`() {
+        var lookups = 0
+        val result = partitionCachedSongs(listOf(song("a", contentLength = null))) { _, _ ->
+            lookups++
+            true
+        }
+
+        assertEquals(emptyList<String>(), result.stillCached.map { it.id })
+        assertEquals(listOf("a"), result.stale.map { it.id })
+        assertEquals(0, lookups)
+    }
+
+    @Test
+    fun `each song is checked with its own id and content length`() {
+        val seen = mutableListOf<Pair<String, Long>>()
+        val songs = listOf(song("a", contentLength = 10L), song("b", contentLength = 20L))
+
+        partitionCachedSongs(songs) { id, length ->
+            seen += id to length
+            true
+        }
+
+        assertEquals(listOf("a" to 10L, "b" to 20L), seen)
+    }
+
+    @Test
+    fun `mixed input is split preserving input order in both groups`() {
+        val songs = listOf(song("keep1"), song("drop1"), song("keep2"), song("drop2"))
+
+        val result = partitionCachedSongs(songs) { id, _ -> id.startsWith("keep") }
+
+        assertEquals(listOf("keep1", "keep2"), result.stillCached.map { it.id })
+        assertEquals(listOf("drop1", "drop2"), result.stale.map { it.id })
+    }
+
+    @Test
+    fun `empty input produces empty groups`() {
+        val result = partitionCachedSongs(emptyList()) { _, _ -> true }
+
+        assertEquals(emptyList<String>(), result.stillCached.map { it.id })
+        assertEquals(emptyList<String>(), result.stale.map { it.id })
+    }
+}


### PR DESCRIPTION
## Problem

Repeated `OutOfMemoryError` crashes, and on older Android a
`SQLiteException: too many SQL variables`, both traced to the Cache Playlist.

The crashes appear on screens unrelated to the Cache Playlist, often minutes after the user last
touched it, and reproduce on libraries of well under 1000 songs.

## Cause

`CachePlaylistViewModel` runs an unbounded polling loop from its `init` block:

```kotlin
while (true) {
    val candidateIds = playerCache.keys.toSet() + downloadCache.keys.toSet()
    val songs = database.getSongsByIds(candidateIds.toList())
    ...
    delay(1000)
}
```

`playerCache.keys` is every entry in the media3 `SimpleCache` — every track ever streamed, not the
user's library — and it grows without bound. Those ids go to `DatabaseDao.getSongsByIds`, a
`@Transaction` query returning `List<Song>`; `Song` declares four `@Relation` fields, so Room issues
four extra relation fetches and rebuilds a large object graph. Once per second, forever.

The allocation rate is what exhausts the heap, not the library size, which is why a small library
still crashes. The ANR is a consequence: with the heap full the process is in continuous GC and the
main thread misses the input-dispatch deadline.

The trigger is `SongMenu.kt`'s `hiltViewModel<CachePlaylistViewModel>()`. Opening the three-dots
menu of **any** song constructs the ViewModel and starts the loop, and the ViewModel outlives the
menu — which is why the crash surfaces later, elsewhere.

The same call shape fails differently depending on the SQLite bind-variable limit, 999 on older
Android and 32766 on current ones: an exception on old devices, heap exhaustion on new ones. That is
the same defect reported in #4094.

## Solution

Invert the direction of the query: instead of "every cache key, find its song", ask "every song
flagged as cached, is it still cached". `dateDownload != null` is already the authoritative marker
for Cache Playlist membership — only `MusicService.markCachedIfFullyDownloaded` sets it, once a
track has genuinely finished playing — and that set is small and bounded.

- Add a DAO query exposing the flagged set as a `Flow`. No schema change.
- Rewrite `CachePlaylistViewModel` to derive `cachedSongs` from that `Flow` combined with the
  existing `HideExplicitKey` and `HideVideoSongsKey` preference flows, via
  `stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())`. It recomputes on
  database invalidation instead of on a timer, and does nothing while nothing is collecting.
- Keep the self-healing behaviour: a flagged song whose bytes are gone from both caches has its
  `dateDownload` cleared. This now runs over the small flagged set instead of the whole cache.
- Delete `DatabaseDao.getSongsByIds`. The ViewModel was its only caller, and leaving an unbounded
  `IN (:songIds)` helper in the DAO invites the same defect back.

`SongMenu` keeps its `hiltViewModel` call, since it needs `removeSongFromCache`, but with
`WhileSubscribed` the ViewModel no longer does work merely by being constructed, so opening a menu
stops being a trigger.

## Testing

- `./gradlew :app:assembleFossDebug` and `./gradlew :app:testFossDebugUnitTest`.
- The staleness rule is extracted as a pure function and covered by unit tests (7 cases).
- On device: constructing the ViewModel issues no query; opening a song's three-dots menu repeatedly
  leaves heap usage flat under `adb shell dumpsys meminfo`, where before it climbed steadily.
- The Cache Playlist still lists the same songs, and still drops songs whose cached data has been
  evicted.

Note: `:app:testFossDebugUnitTest` has 4 pre-existing failures in `YouTubeUtilsTest` (thumbnail URL
rewriting) that are present on `main` and unrelated to this change.

## Related Issues

- Related to #4247
- Related to #4094


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Playlist caching now updates automatically as song downloads and preferences change.
  - Cache status is refreshed more reliably, including when songs are removed or become stale.
  - Downloaded songs are retained appropriately, even when content size information is unavailable.

- **Bug Fixes**
  - Improved handling of outdated cache entries and download flags.
  - Preserved playlist order and ensured empty playlists are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->