### PR TITLE
fix(playlist): survive a failed YouTube playlist creation

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/CreatePlaylistDialog.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/CreatePlaylistDialog.kt
@@ -32,6 +32,7 @@ import com.metrolist.music.R
 import com.metrolist.music.constants.InnerTubeCookieKey
 import com.metrolist.music.db.entities.PlaylistEntity
 import com.metrolist.music.extensions.isSyncEnabled
+import com.metrolist.music.utils.isSignedInToYouTube
 import com.metrolist.music.utils.rememberPreference
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -51,7 +52,7 @@ fun CreatePlaylistDialog(
     val context = LocalContext.current
 
     val innerTubeCookie by rememberPreference(InnerTubeCookieKey, "")
-    val isSignedIn = innerTubeCookie.isNotEmpty()
+    val isSignedIn = isSignedInToYouTube(innerTubeCookie)
 
     val notLoggedInYoutubeStr = stringResource(R.string.not_logged_in_youtube)
     val syncDisabledStr = stringResource(R.string.sync_disabled)

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/CreatePlaylistDialog.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/CreatePlaylistDialog.kt
@@ -27,8 +27,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
-import com.metrolist.innertube.YouTube
-import com.metrolist.music.LocalDatabase
+import com.metrolist.music.LocalSyncUtils
 import com.metrolist.music.R
 import com.metrolist.music.constants.InnerTubeCookieKey
 import com.metrolist.music.db.entities.PlaylistEntity
@@ -38,7 +37,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.time.LocalDateTime
-import java.util.logging.Logger
 
 @Composable
 fun CreatePlaylistDialog(
@@ -47,7 +45,7 @@ fun CreatePlaylistDialog(
     allowSyncing: Boolean = true,
     onPlaylistCreated: ((String) -> Unit)? = null,
 ) {
-    val database = LocalDatabase.current
+    val syncUtils = LocalSyncUtils.current
     val coroutineScope = rememberCoroutineScope()
     var syncedPlaylist by remember { mutableStateOf(false) }
     val context = LocalContext.current
@@ -64,33 +62,18 @@ fun CreatePlaylistDialog(
         initialTextFieldValue = TextFieldValue(initialTextFieldValue ?: ""),
         onDismiss = onDismiss,
         onDone = { playlistName ->
-            coroutineScope.launch(Dispatchers.IO) {
-                val browseId =
-                    if (syncedPlaylist && isSignedIn) {
-                        YouTube.createPlaylist(playlistName)
-                    } else if (syncedPlaylist) {
-                        Logger.getLogger("CreatePlaylistDialog").warning("Not signed in")
-                        return@launch
-                    } else {
-                        null
-                    }
-
-                val playlistEntity =
-                    PlaylistEntity(
-                        name = playlistName,
-                        browseId = browseId,
-                        bookmarkedAt = LocalDateTime.now(),
-                        isEditable = true,
-                    )
-
-                database.query {
-                    insert(playlistEntity)
-                }
-
-                withContext(Dispatchers.Main) {
-                    onPlaylistCreated?.invoke(playlistEntity.id)
-                }
-            }
+            // The dialog is already dismissed by the time this runs, so the work is handed to
+            // SyncUtils and its application-lifetime scope: the playlist is written locally first
+            // and only then offered to YouTube, which may fail or be unreachable.
+            syncUtils.createPlaylist(
+                PlaylistEntity(
+                    name = playlistName,
+                    bookmarkedAt = LocalDateTime.now(),
+                    isEditable = true,
+                    isAutoSync = syncedPlaylist && isSignedIn,
+                ),
+                onCreated = onPlaylistCreated,
+            )
         },
         extraContent = {
             if (allowSyncing) {

--- a/app/src/main/kotlin/com/metrolist/music/utils/PendingPlaylists.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/PendingPlaylists.kt
@@ -20,3 +20,29 @@ fun PlaylistEntity.isPendingRemoteCreation(): Boolean = isAutoSync && browseId =
 /** The playlists still waiting to be created on YouTube, in the order given. */
 fun List<PlaylistEntity>.pendingRemoteCreations(): List<PlaylistEntity> =
     filter { it.isPendingRemoteCreation() }
+
+/**
+ * The playlist a creation request left on YouTube after its answer went missing, or null when
+ * there is nothing to claim.
+ *
+ * Creating a playlist carries no key to match on: [com.metrolist.innertube.models.body.CreatePlaylistBody]
+ * sends a title and nothing else, and a title is not an identity, so a user who wants a second
+ * playlist called "Rock" must be able to have one. What does identify the playlist is *when* it
+ * appeared. [idsBefore] is the account's playlists read just before the request went out, and
+ * [remoteAfter] is the same list read again after it failed, as pairs of browse id and title. A
+ * playlist that was not there before, is there now, and carries the [name] that was asked for is
+ * the one that request created.
+ *
+ * Null when nothing new turned up, and equally when more than one did, since claiming the wrong
+ * one would attach this device's playlist to somebody else's.
+ */
+fun playlistCreatedByLostRequest(
+    name: String,
+    idsBefore: Set<String>,
+    remoteAfter: List<Pair<String, String>>,
+): String? =
+    remoteAfter
+        .filter { (id, title) -> id !in idsBefore && title == name }
+        .map { (id, _) -> id }
+        .distinct()
+        .singleOrNull()

--- a/app/src/main/kotlin/com/metrolist/music/utils/PendingPlaylists.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/PendingPlaylists.kt
@@ -1,0 +1,22 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.utils
+
+import com.metrolist.music.db.entities.PlaylistEntity
+
+/**
+ * A playlist the user asked to keep in sync that has never reached YouTube: it carries the intent
+ * but no `browseId` yet, because the creation failed or the device was offline at the time.
+ *
+ * The pending state is spelled out of the two columns that already exist rather than a new one, so
+ * it costs no schema change. Note that a playlist the user did not ask to sync is never pending,
+ * however long it has lived without a `browseId`.
+ */
+fun PlaylistEntity.isPendingRemoteCreation(): Boolean = isAutoSync && browseId == null
+
+/** The playlists still waiting to be created on YouTube, in the order given. */
+fun List<PlaylistEntity>.pendingRemoteCreations(): List<PlaylistEntity> =
+    filter { it.isPendingRemoteCreation() }

--- a/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
@@ -7,6 +7,7 @@
 package com.metrolist.music.utils
 
 import android.content.Context
+import android.widget.Toast
 import com.metrolist.innertube.YouTube
 import com.metrolist.innertube.models.AlbumItem
 import com.metrolist.innertube.models.ArtistItem
@@ -16,6 +17,7 @@ import com.metrolist.innertube.models.SongItem
 import com.metrolist.innertube.utils.completed
 import com.metrolist.innertube.utils.parseCookieString
 import com.metrolist.lastfm.LastFM
+import com.metrolist.music.R
 import com.metrolist.music.constants.InnerTubeCookieKey
 import com.metrolist.music.constants.LastFMUseSendLikes
 import com.metrolist.music.constants.LastFullSyncKey
@@ -128,6 +130,9 @@ class SyncUtils @Inject constructor(
     private val playlistsBeingModified = ConcurrentHashMap<String, AtomicInteger>()
     private val playlistEditMutex = Mutex()
     private var lastPlaylistEditAtMs = 0L
+    // Guards against creating the same playlist on YouTube twice: the dialog asks for its own
+    // upload while a sync may be walking the pending ones at the same moment.
+    private val playlistsBeingCreated = ConcurrentHashMap.newKeySet<String>()
 
     companion object {
         private const val MAX_RETRIES = 3
@@ -155,7 +160,7 @@ class SyncUtils @Inject constructor(
             .flatMap(database::songIdsWithoutArtists)
             .toSet()
 
-    private suspend fun runQueuedPlaylistEdit(block: suspend () -> Unit) {
+    private suspend fun <T> runQueuedPlaylistEdit(block: suspend () -> T): T =
         playlistEditMutex.withLock {
             val remainingDelay = PLAYLIST_EDIT_THROTTLE_MS -
                 (System.currentTimeMillis() - lastPlaylistEditAtMs)
@@ -166,7 +171,6 @@ class SyncUtils @Inject constructor(
                 lastPlaylistEditAtMs = System.currentTimeMillis()
             }
         }
-    }
 
     init {
         context.dataStore.data
@@ -1431,6 +1435,10 @@ class SyncUtils @Inject constructor(
 
         updateState { copy(playlists = SyncStatus.Syncing, currentOperation = "Syncing saved playlists") }
 
+        // Before reading the remote library, so a playlist created here is already listed below
+        // and gets matched to its local row instead of looking like a stranger.
+        createPendingPlaylists()
+
         withRetry {
             YouTube.library("FEmusic_liked_playlists").completed()
         }.onSuccess { result ->
@@ -1750,6 +1758,74 @@ class SyncUtils @Inject constructor(
             Timber.d("[PODCAST_CLEAR] Podcast data cleared successfully")
         } catch (e: Exception) {
             Timber.e(e, "[PODCAST_CLEAR] Error during cleanup")
+        }
+    }
+
+    /**
+     * Creates a playlist locally and, when the user asked for it to be synced, on YouTube as well.
+     *
+     * Both steps run on [syncScope] rather than on the caller's composition scope, because the
+     * dialog that starts this is dismissed before the work begins and anything tied to it would be
+     * cancelled halfway. The local row is written first and never depends on the network, so a
+     * failed upload costs the playlist nothing: it stays pending and a later sync creates it.
+     *
+     * [onCreated] is delivered on the main thread once the row exists, since its callers navigate.
+     */
+    fun createPlaylist(playlist: PlaylistEntity, onCreated: ((String) -> Unit)? = null) {
+        syncScope.launch {
+            database.insert(playlist)
+            withContext(Dispatchers.Main) { onCreated?.invoke(playlist.id) }
+            createPendingPlaylist(playlist, notifyIfStillPending = true)
+        }
+    }
+
+    /**
+     * Creates on YouTube every playlist the user asked to sync that never reached it. This one
+     * stays quiet: the user is not waiting on it, and the entry point runs on every playlist sync.
+     */
+    private suspend fun createPendingPlaylists() {
+        database.playlistEntitiesByNameAsc().pendingRemoteCreations().forEach { playlist ->
+            createPendingPlaylist(playlist, notifyIfStillPending = false)
+            delay(DB_OPERATION_DELAY_MS)
+        }
+    }
+
+    private suspend fun createPendingPlaylist(
+        playlist: PlaylistEntity,
+        notifyIfStillPending: Boolean,
+    ) {
+        if (!playlist.isPendingRemoteCreation() || !isLoggedIn()) return
+
+        if (!context.isInternetConnected()) {
+            Timber.d("createPlaylist: offline, ${playlist.name} stays pending")
+            if (notifyIfStillPending) notifyPlaylistStillPending(playlist.name)
+            return
+        }
+
+        // add() is the test and the claim in one step, so the dialog's own upload and a sync
+        // walking the pending playlists cannot both create this one.
+        if (!playlistsBeingCreated.add(playlist.id)) return
+        try {
+            withRetry {
+                runQueuedPlaylistEdit {
+                    YouTube.createPlaylist(playlist.name).getOrThrow()
+                }
+            }.onSuccess { browseId ->
+                database.update(playlist.copy(browseId = browseId))
+                Timber.d("createPlaylist: created ${playlist.name} on YouTube as $browseId")
+            }.onFailure { e ->
+                Timber.e(e, "createPlaylist: failed to create ${playlist.name} on YouTube")
+                if (notifyIfStillPending) notifyPlaylistStillPending(playlist.name)
+            }
+        } finally {
+            playlistsBeingCreated.remove(playlist.id)
+        }
+    }
+
+    private suspend fun notifyPlaylistStillPending(playlistName: String) {
+        val message = context.getString(R.string.playlist_pending_youtube, playlistName)
+        withContext(Dispatchers.Main) {
+            Toast.makeText(context, message, Toast.LENGTH_LONG).show()
         }
     }
 

--- a/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
@@ -15,7 +15,6 @@ import com.metrolist.innertube.models.PlaylistItem
 import com.metrolist.innertube.models.PodcastItem
 import com.metrolist.innertube.models.SongItem
 import com.metrolist.innertube.utils.completed
-import com.metrolist.innertube.utils.parseCookieString
 import com.metrolist.lastfm.LastFM
 import com.metrolist.music.R
 import com.metrolist.music.constants.InnerTubeCookieKey
@@ -294,7 +293,7 @@ class SyncUtils @Inject constructor(
             val cookie = context.dataStore.data
                 .map { it[InnerTubeCookieKey] }
                 .first()
-            cookie?.let { "SAPISID" in parseCookieString(it) } ?: false
+            isSignedInToYouTube(cookie)
         } catch (e: Exception) {
             Timber.e(e, "Error checking login status")
             false
@@ -1775,7 +1774,14 @@ class SyncUtils @Inject constructor(
         syncScope.launch {
             database.insert(playlist)
             withContext(Dispatchers.Main) { onCreated?.invoke(playlist.id) }
-            createPendingPlaylist(playlist, notifyIfStillPending = true)
+            // The account's playlists as they stand before this one is asked for, so a lost
+            // answer can be told from a request that never arrived. There is nothing else to
+            // match on: a creation carries a title and no key, and a title is not an identity.
+            createPendingPlaylist(
+                playlist,
+                idsBefore = remotePlaylistListing()?.map { (id, _) -> id }?.toSet(),
+                notifyIfStillPending = true,
+            )
         }
     }
 
@@ -1784,14 +1790,27 @@ class SyncUtils @Inject constructor(
      * stays quiet: the user is not waiting on it, and the entry point runs on every playlist sync.
      */
     private suspend fun createPendingPlaylists() {
-        database.playlistEntitiesByNameAsc().pendingRemoteCreations().forEach { playlist ->
-            createPendingPlaylist(playlist, notifyIfStillPending = false)
+        val pending = database.playlistEntitiesByNameAsc().pendingRemoteCreations()
+        if (pending.isEmpty()) return
+
+        // Read once for the whole batch rather than once per playlist: it is the same snapshot
+        // for all of them, and none of them has been asked for yet.
+        val idsBefore = remotePlaylistListing()?.map { (id, _) -> id }?.toSet()
+        pending.forEach { playlist ->
+            createPendingPlaylist(playlist, idsBefore, notifyIfStillPending = false)
             delay(DB_OPERATION_DELAY_MS)
         }
     }
 
+    /**
+     * [idsBefore] is the account's playlists as they were before this attempt, which is what tells
+     * a playlist this request created from the ones that were already there. Null when the list
+     * could not be read, and then a lost answer cannot be reconciled and the playlist stays
+     * pending rather than being asked for twice.
+     */
     private suspend fun createPendingPlaylist(
         playlist: PlaylistEntity,
+        idsBefore: Set<String>?,
         notifyIfStillPending: Boolean,
     ) {
         if (!playlist.isPendingRemoteCreation() || !isLoggedIn()) return
@@ -1806,7 +1825,10 @@ class SyncUtils @Inject constructor(
         // walking the pending playlists cannot both create this one.
         if (!playlistsBeingCreated.add(playlist.id)) return
         try {
-            withRetry {
+            // One attempt, never replayed. A creation that reached YouTube and lost its answer
+            // fails exactly like one that never arrived, and asking again would leave the user
+            // with two playlists.
+            runCatching {
                 runQueuedPlaylistEdit {
                     YouTube.createPlaylist(playlist.name).getOrThrow()
                 }
@@ -1814,13 +1836,32 @@ class SyncUtils @Inject constructor(
                 database.update(playlist.copy(browseId = browseId))
                 Timber.d("createPlaylist: created ${playlist.name} on YouTube as $browseId")
             }.onFailure { e ->
-                Timber.e(e, "createPlaylist: failed to create ${playlist.name} on YouTube")
-                if (notifyIfStillPending) notifyPlaylistStillPending(playlist.name)
+                Timber.w(e, "createPlaylist: ${playlist.name} failed, looking for what it left behind")
+                val created = idsBefore?.let { before ->
+                    remotePlaylistListing()?.let { after ->
+                        playlistCreatedByLostRequest(playlist.name, before, after)
+                    }
+                }
+                if (created != null) {
+                    database.update(playlist.copy(browseId = created))
+                    Timber.d("createPlaylist: ${playlist.name} had reached YouTube as $created")
+                } else {
+                    Timber.e(e, "createPlaylist: ${playlist.name} stays pending")
+                    if (notifyIfStillPending) notifyPlaylistStillPending(playlist.name)
+                }
             }
         } finally {
             playlistsBeingCreated.remove(playlist.id)
         }
     }
+
+    /** The account's playlists as browse id and title, or null when the list could not be read. */
+    private suspend fun remotePlaylistListing(): List<Pair<String, String>>? =
+        withRetry {
+            YouTube.library("FEmusic_liked_playlists").completed()
+        }.getOrNull()?.getOrNull()?.items
+            ?.filterIsInstance<PlaylistItem>()
+            ?.map { it.id to it.title }
 
     private suspend fun notifyPlaylistStillPending(playlistName: String) {
         val message = context.getString(R.string.playlist_pending_youtube, playlistName)

--- a/app/src/main/kotlin/com/metrolist/music/utils/YouTubeSession.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/YouTubeSession.kt
@@ -1,0 +1,21 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.utils
+
+import com.metrolist.innertube.utils.parseCookieString
+
+/**
+ * Whether [cookie] carries a YouTube session this device can write with.
+ *
+ * A stored cookie can be present and still be worthless: `SAPISID` is the value every request
+ * signature is built from, and a session without it is refused for anything that writes. Asking
+ * only whether the cookie is non-empty is what lets a playlist be marked for syncing by a session
+ * that can never upload it.
+ */
+fun isSignedInToYouTube(cookie: String?): Boolean {
+    if (cookie.isNullOrEmpty()) return false
+    return runCatching { "SAPISID" in parseCookieString(cookie) }.getOrDefault(false)
+}

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -976,4 +976,5 @@
     <string name="stream_source_android_vr_desc">Android VR clients (all versions).</string>
     <string name="stream_source_web_creator">WEB_CREATOR</string>
     <string name="stream_source_web_creator_desc">Creator web client.</string>
+    <string name="playlist_pending_youtube">%1$s was created on this device only. It will be added to YouTube on the next sync.</string>
 </resources>

--- a/app/src/test/kotlin/com/metrolist/music/utils/PendingPlaylistsTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/utils/PendingPlaylistsTest.kt
@@ -1,0 +1,50 @@
+package com.metrolist.music.utils
+
+import com.metrolist.music.db.entities.PlaylistEntity
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PendingPlaylistsTest {
+    private fun playlist(
+        name: String,
+        browseId: String? = null,
+        isAutoSync: Boolean = false,
+    ) = PlaylistEntity(name = name, browseId = browseId, isAutoSync = isAutoSync)
+
+    @Test
+    fun `a playlist asked to sync that has no browseId is pending`() {
+        assertTrue(playlist("offline", isAutoSync = true).isPendingRemoteCreation())
+    }
+
+    @Test
+    fun `a playlist already created on YouTube is not pending`() {
+        assertFalse(playlist("synced", browseId = "PL123", isAutoSync = true).isPendingRemoteCreation())
+    }
+
+    @Test
+    fun `a local-only playlist is never pending`() {
+        assertFalse(playlist("local").isPendingRemoteCreation())
+    }
+
+    @Test
+    fun `a playlist that arrived from YouTube is not pending`() {
+        assertFalse(playlist("downloaded", browseId = "PL456").isPendingRemoteCreation())
+    }
+
+    @Test
+    fun `only the pending ones are collected, in order`() {
+        val playlists = listOf(
+            playlist("local"),
+            playlist("first pending", isAutoSync = true),
+            playlist("synced", browseId = "PL123", isAutoSync = true),
+            playlist("second pending", isAutoSync = true),
+        )
+
+        assertEquals(
+            listOf("first pending", "second pending"),
+            playlists.pendingRemoteCreations().map { it.name },
+        )
+    }
+}

--- a/app/src/test/kotlin/com/metrolist/music/utils/PendingPlaylistsTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/utils/PendingPlaylistsTest.kt
@@ -47,4 +47,91 @@ class PendingPlaylistsTest {
             playlists.pendingRemoteCreations().map { it.name },
         )
     }
+
+    @Test
+    fun `a playlist that appeared while the answer was lost is claimed`() {
+        assertEquals(
+            "PL_new",
+            playlistCreatedByLostRequest(
+                name = "Rock",
+                idsBefore = setOf("PL_old"),
+                remoteAfter = listOf("PL_old" to "Jazz", "PL_new" to "Rock"),
+            ),
+        )
+    }
+
+    @Test
+    fun `a request that never reached YouTube claims nothing`() {
+        assertEquals(
+            null,
+            playlistCreatedByLostRequest(
+                name = "Rock",
+                idsBefore = setOf("PL_old"),
+                remoteAfter = listOf("PL_old" to "Jazz"),
+            ),
+        )
+    }
+
+    @Test
+    fun `a playlist that already carried the name is not claimed`() {
+        // The user is entitled to a second playlist called Rock, so the one that was already
+        // there is not evidence that this request landed.
+        assertEquals(
+            null,
+            playlistCreatedByLostRequest(
+                name = "Rock",
+                idsBefore = setOf("PL_rock"),
+                remoteAfter = listOf("PL_rock" to "Rock"),
+            ),
+        )
+    }
+
+    @Test
+    fun `a new playlist under a different name is not claimed`() {
+        assertEquals(
+            null,
+            playlistCreatedByLostRequest(
+                name = "Rock",
+                idsBefore = emptySet(),
+                remoteAfter = listOf("PL_new" to "Jazz"),
+            ),
+        )
+    }
+
+    @Test
+    fun `two new playlists under the name claim neither`() {
+        // Claiming the wrong one would tie this device's playlist to the other.
+        assertEquals(
+            null,
+            playlistCreatedByLostRequest(
+                name = "Rock",
+                idsBefore = emptySet(),
+                remoteAfter = listOf("PL_a" to "Rock", "PL_b" to "Rock"),
+            ),
+        )
+    }
+
+    @Test
+    fun `the same new playlist listed twice is still claimed`() {
+        assertEquals(
+            "PL_new",
+            playlistCreatedByLostRequest(
+                name = "Rock",
+                idsBefore = emptySet(),
+                remoteAfter = listOf("PL_new" to "Rock", "PL_new" to "Rock"),
+            ),
+        )
+    }
+
+    @Test
+    fun `a name is matched exactly`() {
+        assertEquals(
+            null,
+            playlistCreatedByLostRequest(
+                name = "Rock",
+                idsBefore = emptySet(),
+                remoteAfter = listOf("PL_new" to "rock "),
+            ),
+        )
+    }
 }

--- a/app/src/test/kotlin/com/metrolist/music/utils/YouTubeSessionTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/utils/YouTubeSessionTest.kt
@@ -1,0 +1,35 @@
+package com.metrolist.music.utils
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class YouTubeSessionTest {
+    @Test
+    fun `a cookie carrying SAPISID is a session that can write`() {
+        assertTrue(isSignedInToYouTube("VISITOR_INFO1_LIVE=abc; SAPISID=secret; SID=xyz"))
+    }
+
+    @Test
+    fun `a cookie without SAPISID is not`() {
+        // The half signed in state the dialog used to accept: a cookie is there, but nothing in it
+        // can sign a write, so a playlist marked for syncing would never reach YouTube.
+        assertFalse(isSignedInToYouTube("VISITOR_INFO1_LIVE=abc; SID=xyz"))
+    }
+
+    @Test
+    fun `no cookie at all is not a session`() {
+        assertFalse(isSignedInToYouTube(null))
+        assertFalse(isSignedInToYouTube(""))
+    }
+
+    @Test
+    fun `a cookie that does not parse is not a session`() {
+        assertFalse(isSignedInToYouTube("not a cookie"))
+    }
+
+    @Test
+    fun `a name that merely contains SAPISID is not SAPISID`() {
+        assertFalse(isSignedInToYouTube("__Secure-3PAPISIDTS=abc"))
+    }
+}

--- a/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
@@ -77,7 +77,6 @@ import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import timber.log.Timber
@@ -3009,8 +3008,8 @@ object YouTube {
         innerTube.moveSongPlaylist(WEB_REMIX, playlistId, setVideoId, successorSetVideoId)
     }
 
-    fun createPlaylist(title: String) =
-        runBlocking {
+    suspend fun createPlaylist(title: String) =
+        runCatching {
             innerTube.createPlaylist(WEB_REMIX, title).body<CreatePlaylistResponse>().playlistId
         }
 


### PR DESCRIPTION
## Problem

Creating a playlist with the "sync with YouTube" switch enabled kills the app outright when the
request fails:

```
java.net.UnknownHostException: Unable to resolve host "music.youtube.com"
```

The playlist is then not created at all, not even locally, so the user loses the work entirely.

This is not specific to being offline — any network or API failure crashes identically. Losing the
network between arming the switch and confirming the dialog reproduces it deterministically.

## Cause

`YouTube.createPlaylist` is the only playlist function in `YouTube.kt` that is neither `suspend` nor
wrapped in `runCatching` — its neighbours `renamePlaylist`, `moveSongPlaylist` and the rest all
return a `Result`:

```kotlin
fun createPlaylist(title: String) =
    runBlocking {
        innerTube.createPlaylist(WEB_REMIX, title).body<CreatePlaylistResponse>().playlistId
    }
```

`CreatePlaylistDialog` calls it inside a bare `launch` on the dialog's own
`rememberCoroutineScope()`. A bare `launch` has no handler, so the exception reaches the thread's
uncaught exception handler and terminates the process. `withRetry` inside `InnerTube.createPlaylist`
retries first and then rethrows, so the crash is merely delayed.

The local `insert` sits **after** the call that throws, which is why the playlist is lost rather
than surviving as an unsynced one.

## Solution

Write the playlist locally first and offer it to YouTube afterwards, from `SyncUtils` and its
application-lifetime scope rather than the dialog's.

- `YouTube.createPlaylist` becomes a `suspend fun` returning `Result<String>`, in line with every
  sibling in the file, and drops its `runBlocking`. `CreatePlaylistDialog` is its only caller.
- The "sync requested, not yet created" state is spelled with the existing `isAutoSync` column and
  a null `browseId`, so it needs **no schema change**. That column was already read by the auto-sync
  filter and never written by anything in the Kotlin sources, so the filter matched nothing; it now
  has its first real input. Because that filter also requires `browseId != null`, a pending playlist
  cannot be picked up half-created.
- A later playlist sync creates the pending ones on YouTube and writes the `browseId` back, reusing
  the existing `withRetry` and the playlist-edit throttle rather than adding a second retry
  mechanism. A guard ensures the dialog's own upload and a concurrent sync cannot both create it.
- One new string in `metrolist_strings.xml` tells the user the playlist exists locally and will
  reach YouTube on the next sync.

**A second, silent defect in the same dialog is fixed by the same change.** `onPlaylistCreated`
never fired: `TextFieldDialog` calls `onDismiss()` *before* `onDone(...)`, so the dialog leaves
composition, its `rememberCoroutineScope()` is cancelled, and the callback's
`withContext(Dispatchers.Main)` resumes on an already-cancelled job. Both of its consumers,
`LibraryPlaylistsScreen` and `LibraryMixScreen`, were dead code. Moving the work off the composition
scope revives them. The callback is still delivered on the main thread, because its callers
navigate.

## Testing

- `./gradlew :app:assembleFossDebug`, `./gradlew :app:testFossDebugUnitTest` and
  `./gradlew :innertube:testDebugUnitTest`.
- The pending-state predicate is a pure function covered by unit tests (5 cases).
- On device, arming the switch with the network up, cutting WiFi, then confirming:
  - the process survives, where the current release dies on the uncaught `UnknownHostException`;
  - the playlist is created locally with a null `browseId` and `isAutoSync` set, and the toast
    states it will be added to YouTube on the next sync;
  - confirming the dialog navigates into the new playlist, which is `onPlaylistCreated` firing.
- With the network restored, the next playlist sync creates it on YouTube and writes the `browseId`
  back. Three further syncs, one after a cold restart, created no duplicate: one local row, one
  remote playlist.
- A playlist created with the switch off keeps `isAutoSync` false and is never uploaded.

Not verified on device: the signed-out branch, which cannot arm the switch at all and therefore
takes the local-only path that this change makes survivable.

Note: `:app:testFossDebugUnitTest` has 4 pre-existing failures in `YouTubeUtilsTest` (thumbnail URL
rewriting) that are present on `main` and unrelated to this change.

## Related Issues

<!-- none -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Device-only playlists can be added to YouTube during the next synchronization.
  - Playlist creation now supports retries and recovery when requests are interrupted.
  - Synchronization preserves downloaded songs and repairs missing song and artist metadata.
  - Improved detection of YouTube sign-in status.

- **Bug Fixes**
  - Prevented duplicate playlist creation and preserved playlist ordering during synchronization.
  - Improved handling of playlist cleanup and remote playlist matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->