### PR TITLE
fix(sync): make playlist additions reach YouTube reliably

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
@@ -1240,20 +1240,20 @@ interface DatabaseDao {
     @Query("UPDATE playlist_song_map SET position = position + :delta WHERE playlistId = :playlistId")
     fun shiftPlaylistSongPositions(playlistId: String, delta: Int)
 
-    // The subselect matters: adding a song that is already in the playlist leaves two rows for it,
-    // and only the one still awaiting confirmation should take the new setVideoId.
+    // By row id, not by (playlistId, songId): a playlist may hold the same song twice, and the
+    // setVideoId names one of those two items on YouTube rather than the song.
+    @Query("UPDATE playlist_song_map SET setVideoId = :setVideoId WHERE id = :mapId")
+    fun updatePlaylistSongSetVideoId(mapId: Long, setVideoId: String)
+
+    // The copies of this song the playlist has already had confirmed, which is what an upload
+    // whose answer went missing is weighed against.
     @Query(
         """
-        UPDATE playlist_song_map SET setVideoId = :setVideoId
-        WHERE id = (
-            SELECT id FROM playlist_song_map
-            WHERE playlistId = :playlistId AND songId = :songId AND setVideoId IS NULL
-            ORDER BY position
-            LIMIT 1
-        )
+        SELECT setVideoId FROM playlist_song_map
+        WHERE playlistId = :playlistId AND songId = :songId AND setVideoId IS NOT NULL
         """
     )
-    fun updatePlaylistSongSetVideoId(playlistId: String, songId: String, setVideoId: String)
+    fun playlistSongSetVideoIds(playlistId: String, songId: String): List<String>
 
     @Transaction
     fun addSongToPlaylist(playlist: Playlist, songIds: List<String>) {
@@ -1274,54 +1274,44 @@ interface DatabaseDao {
     }
 
     // This prevents songs from being removed during automatic playlist synchronization
+    /**
+     * Returns the row each song was inserted as, paired with its id, so a caller uploading them
+     * can later say which row an answer belongs to. A playlist is allowed to hold the same song
+     * twice, and the two rows are only told apart by their id.
+     */
     @Transaction
     fun addSongsToPlaylist(
         playlist: Playlist,
         songs: List<Pair<String, String?>>, // Pair of (songId, setVideoId)
         prepend: Boolean = false,
-    ) {
+    ): List<Pair<String, Long>> {
         val now = LocalDateTime.now()
         val songsToInsert =
             songs.mapNotNull { (id, setVideoId) ->
                 getSongByIdBlocking(id)?.let { id to setVideoId }
             }
-        if (songsToInsert.isEmpty()) return
+        if (songsToInsert.isEmpty()) return emptyList()
 
         if (prepend) {
             shiftPlaylistSongPositions(playlist.id, songsToInsert.size)
-            var position = 0
-            songsToInsert.forEach { (id, setVideoId) ->
-                val existingSong = getSongByIdBlocking(id)!!
-                if (existingSong.song.inLibrary == null) {
-                    inLibrary(id, now)
-                }
-                insert(
-                    PlaylistSongMap(
-                        songId = id,
-                        playlistId = playlist.id,
-                        position = position++,
-                        setVideoId = setVideoId,
-                    ),
-                )
+        }
+        var position = if (prepend) 0 else playlist.songCount
+        val inserted = songsToInsert.map { (id, setVideoId) ->
+            val existingSong = getSongByIdBlocking(id)!!
+            if (existingSong.song.inLibrary == null) {
+                inLibrary(id, now)
             }
-        } else {
-            var position = playlist.songCount
-            songsToInsert.forEach { (id, setVideoId) ->
-                val existingSong = getSongByIdBlocking(id)!!
-                if (existingSong.song.inLibrary == null) {
-                    inLibrary(id, now)
-                }
-                insert(
-                    PlaylistSongMap(
-                        songId = id,
-                        playlistId = playlist.id,
-                        position = position++,
-                        setVideoId = setVideoId,
-                    ),
-                )
-            }
+            id to insert(
+                PlaylistSongMap(
+                    songId = id,
+                    playlistId = playlist.id,
+                    position = position++,
+                    setVideoId = setVideoId,
+                ),
+            )
         }
         updatePlaylistLastUpdated(playlist.id)
+        return inserted
     }
 
     fun downloadedSongs(
@@ -1804,7 +1794,7 @@ interface DatabaseDao {
     fun insert(map: AlbumArtistMap)
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
-    fun insert(map: PlaylistSongMap)
+    fun insert(map: PlaylistSongMap): Long
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insert(searchHistory: SearchHistory)

--- a/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
@@ -1240,6 +1240,21 @@ interface DatabaseDao {
     @Query("UPDATE playlist_song_map SET position = position + :delta WHERE playlistId = :playlistId")
     fun shiftPlaylistSongPositions(playlistId: String, delta: Int)
 
+    // The subselect matters: adding a song that is already in the playlist leaves two rows for it,
+    // and only the one still awaiting confirmation should take the new setVideoId.
+    @Query(
+        """
+        UPDATE playlist_song_map SET setVideoId = :setVideoId
+        WHERE id = (
+            SELECT id FROM playlist_song_map
+            WHERE playlistId = :playlistId AND songId = :songId AND setVideoId IS NULL
+            ORDER BY position
+            LIMIT 1
+        )
+        """
+    )
+    fun updatePlaylistSongSetVideoId(playlistId: String, songId: String, setVideoId: String)
+
     @Transaction
     fun addSongToPlaylist(playlist: Playlist, songIds: List<String>) {
         var position = playlist.songCount

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialog.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialog.kt
@@ -123,10 +123,16 @@ fun AddToPlaylistDialog(
 
     suspend fun addSongsAndSync(targetPlaylist: Playlist, ids: List<String>) {
         database.addSongsToPlaylist(targetPlaylist, ids.map { it to null }, prepend = true)
-        targetPlaylist.playlist.browseId?.let { plist ->
-            ids.forEach { songId ->
-                syncUtils.addToPlaylist(plist, targetPlaylist.id, songId)
-            }
+        // Handed to syncUtils, which uploads on its own application-lifetime scope: a throttled
+        // batch outlives this dialog, and dismissing it used to cancel the pending uploads while
+        // the local rows were already committed.
+        targetPlaylist.playlist.browseId?.let { browseId ->
+            syncUtils.addSongsToPlaylist(
+                browseId,
+                targetPlaylist.id,
+                targetPlaylist.playlist.name,
+                ids,
+            )
         }
     }
 
@@ -303,8 +309,8 @@ fun AddToPlaylistDialog(
                             if (duplicates.isNotEmpty()) {
                                 showDuplicateDialog = true
                             } else {
-                                onDismiss()
                                 addSongsAndSync(playlist, songIds!!)
+                                onDismiss()
                             }
                         }
                     }
@@ -329,12 +335,12 @@ fun AddToPlaylistDialog(
                     TextButton(
                         onClick = {
                             showDuplicateDialog = false
-                            onDismiss()
                             coroutineScope.launch(Dispatchers.IO) {
                                 addSongsAndSync(
                                     selectedPlaylist!!,
                                     songIds!!.filter { !duplicates.contains(it) }
                                 )
+                                onDismiss()
                             }
                         }
                     ) {
@@ -344,9 +350,9 @@ fun AddToPlaylistDialog(
                     TextButton(
                         onClick = {
                             showDuplicateDialog = false
-                            onDismiss()
                             coroutineScope.launch(Dispatchers.IO) {
                                 addSongsAndSync(selectedPlaylist!!, songIds!!)
+                                onDismiss()
                             }
                         }
                     ) {

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialog.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialog.kt
@@ -122,7 +122,7 @@ fun AddToPlaylistDialog(
     }
 
     suspend fun addSongsAndSync(targetPlaylist: Playlist, ids: List<String>) {
-        database.addSongsToPlaylist(targetPlaylist, ids.map { it to null }, prepend = true)
+        val rows = database.addSongsToPlaylist(targetPlaylist, ids.map { it to null }, prepend = true)
         // Handed to syncUtils, which uploads on its own application-lifetime scope: a throttled
         // batch outlives this dialog, and dismissing it used to cancel the pending uploads while
         // the local rows were already committed.
@@ -131,7 +131,7 @@ fun AddToPlaylistDialog(
                 browseId,
                 targetPlaylist.id,
                 targetPlaylist.playlist.name,
-                ids,
+                rows,
             )
         }
     }

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/AlbumMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/AlbumMenu.kt
@@ -174,14 +174,7 @@ fun AlbumMenu(
 
     AddToPlaylistDialog(
         isVisible = showChoosePlaylistDialog,
-        onGetSong = { playlist ->
-            coroutineScope.launch(Dispatchers.IO) {
-                playlist.playlist.browseId?.let { playlistId ->
-                    album.album.playlistId?.let { addPlaylistId ->
-                        YouTube.addPlaylistToPlaylist(playlistId, addPlaylistId)
-                    }
-                }
-            }
+        onGetSong = {
             songs.map { it.id }
         },
         onGetSongIds = { songs.map { it.id } },

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/PlayerMenu.kt
@@ -78,7 +78,6 @@ import androidx.media3.common.PlaybackParameters
 import androidx.media3.exoplayer.offline.Download
 import androidx.media3.exoplayer.offline.DownloadRequest
 import androidx.media3.exoplayer.offline.DownloadService
-import com.metrolist.innertube.YouTube
 import com.metrolist.music.LocalNavController
 import com.metrolist.music.LocalDatabase
 import com.metrolist.music.LocalDownloadUtil
@@ -171,12 +170,9 @@ fun PlayerMenu(
 
     AddToPlaylistDialog(
         isVisible = showChoosePlaylistDialog,
-        onGetSong = { playlist ->
+        onGetSong = {
             database.withTransaction {
                 insert(mediaMetadata)
-            }
-            coroutineScope.launch(Dispatchers.IO) {
-                playlist.playlist.browseId?.let { YouTube.addToPlaylist(it, mediaMetadata.id) }
             }
             listOf(mediaMetadata.id)
         },

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/QueueMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/QueueMenu.kt
@@ -117,12 +117,9 @@ fun QueueMenu(
 
     AddToPlaylistDialog(
         isVisible = showChoosePlaylistDialog,
-        onGetSong = { playlist ->
+        onGetSong = {
             database.withTransaction {
                 insert(mediaMetadata)
-            }
-            coroutineScope.launch(Dispatchers.IO) {
-                playlist.playlist.browseId?.let { YouTube.addToPlaylist(it, mediaMetadata.id) }
             }
             listOf(mediaMetadata.id)
         },

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/SelectionSongsMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/SelectionSongsMenu.kt
@@ -138,14 +138,7 @@ fun SelectionSongMenu(
 
     AddToPlaylistDialog(
         isVisible = showChoosePlaylistDialog,
-        onGetSong = { playlist ->
-            coroutineScope.launch(Dispatchers.IO) {
-                songSelection.forEach { song ->
-                    playlist.playlist.browseId?.let { browseId ->
-                        YouTube.addToPlaylist(browseId, song.id)
-                    }
-                }
-            }
+        onGetSong = {
             songSelection.map { it.id }
         },
         onGetSongIds = { songSelection.map { it.id } },

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/SongMenu.kt
@@ -239,12 +239,7 @@ fun SongMenu(
 
     AddToPlaylistDialog(
         isVisible = showChoosePlaylistDialog,
-        onGetSong = { playlist ->
-            coroutineScope.launch(Dispatchers.IO) {
-                playlist.playlist.browseId?.let { browseId ->
-                    YouTube.addToPlaylist(browseId, song.id)
-                }
-            }
+        onGetSong = {
             listOf(song.id)
         },
         onGetSongIds = { listOf(song.id) },

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeAlbumMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeAlbumMenu.kt
@@ -156,14 +156,7 @@ fun YouTubeAlbumMenu(
 
     AddToPlaylistDialog(
         isVisible = showChoosePlaylistDialog,
-        onGetSong = { playlist ->
-            coroutineScope.launch(Dispatchers.IO) {
-                playlist.playlist.browseId?.let { playlistId ->
-                    album?.album?.playlistId?.let { addPlaylistId ->
-                        YouTube.addPlaylistToPlaylist(playlistId, addPlaylistId)
-                    }
-                }
-            }
+        onGetSong = {
             album?.songs?.map { it.id }.orEmpty()
         },
         onGetSongIds = { album?.songs?.map { it.id }.orEmpty() },

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubePlaylistMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubePlaylistMenu.kt
@@ -145,11 +145,6 @@ fun YouTubePlaylistMenu(
             database.withTransaction {
                 allSongs.forEach(::insert)
             }
-            coroutineScope.launch(Dispatchers.IO) {
-                targetPlaylist.playlist.browseId?.let { playlistId ->
-                    YouTube.addPlaylistToPlaylist(playlistId, targetPlaylist.id)
-                }
-            }
             allSongs.map { it.id }
         },
         onGetSongIds = {

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeSongMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeSongMenu.kt
@@ -129,14 +129,9 @@ fun YouTubeSongMenu(
 
     AddToPlaylistDialog(
         isVisible = showChoosePlaylistDialog,
-        onGetSong = { playlist ->
+        onGetSong = {
             database.withTransaction {
                 insert(song.toMediaMetadata())
-            }
-            coroutineScope.launch(Dispatchers.IO) {
-                playlist.playlist.browseId?.let { browseId ->
-                    YouTube.addToPlaylist(browseId, song.id)
-                }
             }
             listOf(song.id)
         },

--- a/app/src/main/kotlin/com/metrolist/music/utils/PlaylistUploads.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/PlaylistUploads.kt
@@ -1,0 +1,44 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.utils
+
+/** What reading the playlist said about an upload whose answer never came back. */
+sealed interface UploadOutcome {
+    /** The song reached the playlist. [setVideoId] names the copy it created, when it is knowable. */
+    data class Landed(val setVideoId: String?) : UploadOutcome
+
+    /** The playlist holds no more copies than before, so the request never arrived. */
+    data object DidNotLand : UploadOutcome
+
+    /** The playlist could not be read, so nothing can be said either way. */
+    data object Unknown : UploadOutcome
+}
+
+/**
+ * Settles an upload that failed without saying whether it had already been applied.
+ *
+ * An add carries no key to match on, and asking whether the song is in the playlist answers the
+ * wrong question: a playlist is allowed to hold the same song twice, which is exactly what the
+ * duplicate warning's "add anyway" leaves behind, so presence proves nothing. What does settle it
+ * is how many copies there are. [knownSetVideoIds] are the copies of that song this device had
+ * already recorded for the playlist, and [remoteSetVideoIds] are the copies the playlist holds
+ * now: one more than before means the request landed, and the copy that was not there before is
+ * the one it created.
+ *
+ * A landed upload whose new copy cannot be picked out, because more than one appeared, still
+ * counts as landed with no [UploadOutcome.Landed.setVideoId]. Guessing which copy is which would
+ * point the row at an item it does not name, while leaving it empty only costs a lookup when the
+ * song is later removed.
+ */
+fun reconcileUpload(
+    knownSetVideoIds: List<String>,
+    remoteSetVideoIds: List<String>,
+): UploadOutcome {
+    if (remoteSetVideoIds.size <= knownSetVideoIds.size) return UploadOutcome.DidNotLand
+    val appeared = remoteSetVideoIds.toMutableList()
+    knownSetVideoIds.forEach { appeared.remove(it) }
+    return UploadOutcome.Landed(appeared.singleOrNull())
+}

--- a/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
@@ -1754,32 +1754,60 @@ class SyncUtils @Inject constructor(
         }
     }
 
-    // Runs on syncScope, not on the caller's scope: the menu that starts an upload is dismissed
-    // long before a throttled batch finishes, and dismissing it cancels a composition scope.
+    /**
+     * Uploads songs a playlist has already been given locally.
+     *
+     * Runs on [syncScope] rather than the caller's: the menu that starts an upload is dismissed
+     * long before a throttled batch finishes, and dismissing it cancels a composition scope.
+     *
+     * [rows] pairs each song with the playlist row it was written as, since a playlist may hold
+     * the same song twice and only the row id tells the two apart.
+     */
     fun addSongsToPlaylist(
         browseId: String,
         playlistId: String,
         playlistName: String,
-        songIds: List<String>,
+        rows: List<Pair<String, Long>>,
     ) {
-        if (songIds.isEmpty()) return
+        if (rows.isEmpty()) return
         markPlaylistModifying(playlistId)
         syncScope.launch {
             var failedCount = 0
             try {
-                songIds.forEach { songId ->
-                    // withRetry stays outside the queue so a backoff never holds playlistEditMutex.
-                    withRetry {
-                        runQueuedPlaylistEdit {
-                            YouTube.addToPlaylist(browseId, songId).getOrThrow()
-                        }
-                    }.onSuccess { setVideoId ->
+                rows.forEach { (songId, mapId) ->
+                    // The copies this device has already had confirmed, read before the request
+                    // goes out, so an answer that never comes back can be settled against them.
+                    val knownSetVideoIds = database.playlistSongSetVideoIds(playlistId, songId)
+
+                    uploadSong(browseId, songId).onSuccess { setVideoId ->
                         if (setVideoId != null) {
-                            database.updatePlaylistSongSetVideoId(playlistId, songId, setVideoId)
+                            database.updatePlaylistSongSetVideoId(mapId, setVideoId)
                         }
                     }.onFailure { e ->
-                        failedCount++
-                        Timber.e(e, "Failed to add song $songId to playlist $browseId")
+                        Timber.w(e, "Adding $songId to $browseId gave no answer, asking the playlist")
+                        when (val outcome = settleUpload(browseId, songId, knownSetVideoIds)) {
+                            is UploadOutcome.Landed -> {
+                                outcome.setVideoId?.let {
+                                    database.updatePlaylistSongSetVideoId(mapId, it)
+                                }
+                                Timber.d("Song $songId had reached $browseId after all")
+                            }
+                            // Only now is asking again safe: the playlist says the first request
+                            // never arrived, so a second one cannot leave a duplicate behind.
+                            UploadOutcome.DidNotLand -> uploadSong(browseId, songId)
+                                .onSuccess { setVideoId ->
+                                    if (setVideoId != null) {
+                                        database.updatePlaylistSongSetVideoId(mapId, setVideoId)
+                                    }
+                                }.onFailure {
+                                    failedCount++
+                                    Timber.e(it, "Failed to add song $songId to playlist $browseId")
+                                }
+                            UploadOutcome.Unknown -> {
+                                failedCount++
+                                Timber.e(e, "Could not tell whether $songId reached $browseId")
+                            }
+                        }
                     }
                 }
             } finally {
@@ -1798,6 +1826,30 @@ class SyncUtils @Inject constructor(
                 }
             }
         }
+    }
+
+    /** One attempt, never replayed on its own. */
+    private suspend fun uploadSong(browseId: String, songId: String): Result<String?> =
+        runCatching {
+            runQueuedPlaylistEdit {
+                YouTube.addToPlaylist(browseId, songId).getOrThrow()
+            }
+        }
+
+    /** Asks the playlist what became of an upload that failed without saying so. */
+    private suspend fun settleUpload(
+        browseId: String,
+        songId: String,
+        knownSetVideoIds: List<String>,
+    ): UploadOutcome {
+        val remote = withRetry {
+            YouTube.playlist(browseId).completed()
+        }.getOrNull()?.getOrNull() ?: return UploadOutcome.Unknown
+
+        return reconcileUpload(
+            knownSetVideoIds = knownSetVideoIds,
+            remoteSetVideoIds = remote.songs.filter { it.id == songId }.mapNotNull { it.setVideoId },
+        )
     }
 
     fun scheduleRemoveFromPlaylist(

--- a/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
@@ -7,6 +7,7 @@
 package com.metrolist.music.utils
 
 import android.content.Context
+import android.widget.Toast
 import com.metrolist.innertube.YouTube
 import com.metrolist.innertube.models.AlbumItem
 import com.metrolist.innertube.models.ArtistItem
@@ -19,6 +20,7 @@ import com.metrolist.lastfm.LastFM
 import com.metrolist.music.constants.InnerTubeCookieKey
 import com.metrolist.music.constants.LastFMUseSendLikes
 import com.metrolist.music.constants.LastFullSyncKey
+import com.metrolist.music.R
 import com.metrolist.music.constants.SYNC_COOLDOWN
 import com.metrolist.music.db.MusicDatabase
 import com.metrolist.music.db.entities.ArtistEntity
@@ -155,7 +157,7 @@ class SyncUtils @Inject constructor(
             .flatMap(database::songIdsWithoutArtists)
             .toSet()
 
-    private suspend fun runQueuedPlaylistEdit(block: suspend () -> Unit) {
+    private suspend fun <T> runQueuedPlaylistEdit(block: suspend () -> T): T =
         playlistEditMutex.withLock {
             val remainingDelay = PLAYLIST_EDIT_THROTTLE_MS -
                 (System.currentTimeMillis() - lastPlaylistEditAtMs)
@@ -166,7 +168,6 @@ class SyncUtils @Inject constructor(
                 lastPlaylistEditAtMs = System.currentTimeMillis()
             }
         }
-    }
 
     init {
         context.dataStore.data
@@ -1753,22 +1754,49 @@ class SyncUtils @Inject constructor(
         }
     }
 
-    suspend fun addToPlaylist(
+    // Runs on syncScope, not on the caller's scope: the menu that starts an upload is dismissed
+    // long before a throttled batch finishes, and dismissing it cancels a composition scope.
+    fun addSongsToPlaylist(
         browseId: String,
         playlistId: String,
-        songId: String,
-    ): Boolean {
+        playlistName: String,
+        songIds: List<String>,
+    ) {
+        if (songIds.isEmpty()) return
         markPlaylistModifying(playlistId)
-        return try {
-            runQueuedPlaylistEdit {
-                YouTube.addToPlaylist(browseId, songId).getOrThrow()
+        syncScope.launch {
+            var failedCount = 0
+            try {
+                songIds.forEach { songId ->
+                    // withRetry stays outside the queue so a backoff never holds playlistEditMutex.
+                    withRetry {
+                        runQueuedPlaylistEdit {
+                            YouTube.addToPlaylist(browseId, songId).getOrThrow()
+                        }
+                    }.onSuccess { setVideoId ->
+                        if (setVideoId != null) {
+                            database.updatePlaylistSongSetVideoId(playlistId, songId, setVideoId)
+                        }
+                    }.onFailure { e ->
+                        failedCount++
+                        Timber.e(e, "Failed to add song $songId to playlist $browseId")
+                    }
+                }
+            } finally {
+                unmarkPlaylistModifying(playlistId)
             }
-            true
-        } catch (e: Exception) {
-            Timber.e(e, "Failed to add song $songId to playlist $browseId")
-            false
-        } finally {
-            unmarkPlaylistModifying(playlistId)
+
+            if (failedCount > 0) {
+                val message = context.resources.getQuantityString(
+                    R.plurals.playlist_upload_failed,
+                    failedCount,
+                    failedCount,
+                    playlistName,
+                )
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(context, message, Toast.LENGTH_LONG).show()
+                }
+            }
         }
     }
 

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -976,4 +976,8 @@
     <string name="stream_source_android_vr_desc">Android VR clients (all versions).</string>
     <string name="stream_source_web_creator">WEB_CREATOR</string>
     <string name="stream_source_web_creator_desc">Creator web client.</string>
+    <plurals name="playlist_upload_failed">
+        <item quantity="one">%1$d song was not added to YouTube in %2$s</item>
+        <item quantity="other">%1$d songs were not added to YouTube in %2$s</item>
+    </plurals>
 </resources>

--- a/app/src/test/kotlin/com/metrolist/music/db/PlaylistOccurrenceTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/db/PlaylistOccurrenceTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.db
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.metrolist.music.db.entities.PlaylistEntity
+import com.metrolist.music.db.entities.SongEntity
+import java.time.LocalDateTime
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * A playlist may hold the same song twice, which the duplicate warning's "add anyway" leaves
+ * behind on purpose. A setVideoId names one of those two items on YouTube rather than the song,
+ * so each row has to be able to carry its own.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class PlaylistOccurrenceTest {
+    private lateinit var database: InternalDatabase
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        database = Room.inMemoryDatabaseBuilder(context, InternalDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        database.runInTransaction {
+            database.dao.insert(
+                PlaylistEntity(
+                    id = PLAYLIST_ID,
+                    name = "Playlist",
+                    bookmarkedAt = LocalDateTime.of(2026, 1, 1, 0, 0),
+                ),
+            )
+            database.dao.insert(SongEntity(id = SONG_ID, title = "Song"))
+        }
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    private fun playlist() = database.dao.playlistBlocking(PLAYLIST_ID)!!
+
+    @Test
+    fun `adding a song twice gives each row its own id`() {
+        val first = database.dao.addSongsToPlaylist(playlist(), listOf(SONG_ID to null))
+        val second = database.dao.addSongsToPlaylist(playlist(), listOf(SONG_ID to null))
+
+        assertEquals(1, first.size)
+        assertEquals(1, second.size)
+        assertEquals(listOf(SONG_ID), first.map { it.first })
+        assertEquals(2, listOf(first.single().second, second.single().second).distinct().size)
+    }
+
+    @Test
+    fun `confirming one copy leaves the other alone`() {
+        val first = database.dao.addSongsToPlaylist(playlist(), listOf(SONG_ID to null)).single()
+        val second = database.dao.addSongsToPlaylist(playlist(), listOf(SONG_ID to null)).single()
+
+        database.dao.updatePlaylistSongSetVideoId(second.second, "svi_second")
+
+        val confirmed = database.dao.playlistSongSetVideoIds(PLAYLIST_ID, SONG_ID)
+        assertEquals(listOf("svi_second"), confirmed)
+        val maps = database.dao.playlistSongsBlocking(PLAYLIST_ID).map { it.map }
+        assertEquals("svi_second", maps.single { it.id.toLong() == second.second }.setVideoId)
+        assertEquals(null, maps.single { it.id.toLong() == first.second }.setVideoId)
+    }
+
+    @Test
+    fun `both copies can be confirmed separately`() {
+        val first = database.dao.addSongsToPlaylist(playlist(), listOf(SONG_ID to null)).single()
+        val second = database.dao.addSongsToPlaylist(playlist(), listOf(SONG_ID to null)).single()
+
+        database.dao.updatePlaylistSongSetVideoId(first.second, "svi_first")
+        database.dao.updatePlaylistSongSetVideoId(second.second, "svi_second")
+
+        assertEquals(
+            listOf("svi_first", "svi_second"),
+            database.dao.playlistSongSetVideoIds(PLAYLIST_ID, SONG_ID).sorted(),
+        )
+    }
+
+    private companion object {
+        const val PLAYLIST_ID = "playlist"
+        const val SONG_ID = "song"
+    }
+}

--- a/app/src/test/kotlin/com/metrolist/music/utils/PlaylistUploadsTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/utils/PlaylistUploadsTest.kt
@@ -1,0 +1,98 @@
+package com.metrolist.music.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PlaylistUploadsTest {
+    @Test
+    fun `a copy that was not there before means the upload landed`() {
+        assertEquals(
+            UploadOutcome.Landed("svi_new"),
+            reconcileUpload(
+                knownSetVideoIds = listOf("svi_old"),
+                remoteSetVideoIds = listOf("svi_old", "svi_new"),
+            ),
+        )
+    }
+
+    @Test
+    fun `a playlist holding no more copies than before means it never arrived`() {
+        assertEquals(
+            UploadOutcome.DidNotLand,
+            reconcileUpload(
+                knownSetVideoIds = listOf("svi_old"),
+                remoteSetVideoIds = listOf("svi_old"),
+            ),
+        )
+    }
+
+    @Test
+    fun `a song already in the playlist is not mistaken for this upload`() {
+        // Presence proves nothing: "add anyway" exists so a playlist can hold a song twice.
+        assertEquals(
+            UploadOutcome.DidNotLand,
+            reconcileUpload(
+                knownSetVideoIds = listOf("svi_old"),
+                remoteSetVideoIds = listOf("svi_old"),
+            ),
+        )
+    }
+
+    @Test
+    fun `a first copy of a song the playlist did not hold is claimed`() {
+        assertEquals(
+            UploadOutcome.Landed("svi_first"),
+            reconcileUpload(
+                knownSetVideoIds = emptyList(),
+                remoteSetVideoIds = listOf("svi_first"),
+            ),
+        )
+    }
+
+    @Test
+    fun `a second copy of a song the playlist already held twice is claimed`() {
+        assertEquals(
+            UploadOutcome.Landed("svi_c"),
+            reconcileUpload(
+                knownSetVideoIds = listOf("svi_a", "svi_b"),
+                remoteSetVideoIds = listOf("svi_a", "svi_b", "svi_c"),
+            ),
+        )
+    }
+
+    @Test
+    fun `two copies appearing at once land without naming either`() {
+        // Pointing the row at the wrong one would have it name an item it did not create.
+        assertEquals(
+            UploadOutcome.Landed(null),
+            reconcileUpload(
+                knownSetVideoIds = emptyList(),
+                remoteSetVideoIds = listOf("svi_a", "svi_b"),
+            ),
+        )
+    }
+
+    @Test
+    fun `a copy this device never recorded does not hide the new one`() {
+        // Another device may have added a copy this one never confirmed; the count still grew by
+        // one more than it can account for, so the upload landed.
+        assertEquals(
+            UploadOutcome.Landed(null),
+            reconcileUpload(
+                knownSetVideoIds = listOf("svi_a"),
+                remoteSetVideoIds = listOf("svi_a", "svi_elsewhere", "svi_new"),
+            ),
+        )
+    }
+
+    @Test
+    fun `a playlist that lost copies is not read as a landing`() {
+        assertEquals(
+            UploadOutcome.DidNotLand,
+            reconcileUpload(
+                knownSetVideoIds = listOf("svi_a", "svi_b"),
+                remoteSetVideoIds = listOf("svi_a"),
+            ),
+        )
+    }
+}

--- a/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
@@ -35,6 +35,7 @@ import com.metrolist.innertube.models.oddElements
 import com.metrolist.innertube.models.splitBySeparator
 import com.metrolist.innertube.utils.parseTime
 import com.metrolist.innertube.models.response.AccountMenuResponse
+import com.metrolist.innertube.models.response.AddItemYouTubePlaylistResponse
 import com.metrolist.innertube.models.response.BrowseResponse
 import com.metrolist.innertube.models.response.CreatePlaylistResponse
 import com.metrolist.innertube.models.response.EditPlaylistResponse
@@ -2982,8 +2983,10 @@ object YouTube {
     suspend fun addToPlaylist(
         playlistId: String,
         videoId: String,
-    ) = runCatching {
+    ): Result<String?> = runCatching {
         innerTube.addToPlaylist(WEB_REMIX, playlistId, videoId)
+            .body<AddItemYouTubePlaylistResponse>()
+            .firstSetVideoId
     }
 
     suspend fun addPlaylistToPlaylist(

--- a/innertube/src/main/kotlin/com/metrolist/innertube/models/response/AddItemYouTubePlaylistResponse.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/models/response/AddItemYouTubePlaylistResponse.kt
@@ -1,0 +1,23 @@
+package com.metrolist.innertube.models.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AddItemYouTubePlaylistResponse(
+    val status: String? = null,
+    val playlistEditResults: List<PlaylistEditResult> = emptyList()
+) {
+    val firstSetVideoId: String?
+        get() = playlistEditResults.firstOrNull()?.playlistEditVideoAddedResultData?.setVideoId
+
+    @Serializable
+    data class PlaylistEditResult(
+        val playlistEditVideoAddedResultData: PlaylistEditVideoAddedResultData,
+    ) {
+        @Serializable
+        data class PlaylistEditVideoAddedResultData(
+            val setVideoId: String,
+            val videoId: String
+        )
+    }
+}

--- a/innertube/src/main/kotlin/com/metrolist/innertube/models/response/AddItemYouTubePlaylistResponse.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/models/response/AddItemYouTubePlaylistResponse.kt
@@ -2,22 +2,33 @@ package com.metrolist.innertube.models.response
 
 import kotlinx.serialization.Serializable
 
+/**
+ * The answer to adding a song to a playlist.
+ *
+ * Every field is optional on purpose. This model is only read to learn the `setVideoId` of the
+ * item that was added, which is a bonus rather than the point: the add either happened or it did
+ * not, and that is already settled by the time the body is parsed. A required field missing from a
+ * shape YouTube changed would turn a successful add into a failure, and a failure is what makes
+ * the caller ask again, which is how the song ends up in the playlist twice.
+ */
 @Serializable
 data class AddItemYouTubePlaylistResponse(
     val status: String? = null,
     val playlistEditResults: List<PlaylistEditResult> = emptyList()
 ) {
     val firstSetVideoId: String?
-        get() = playlistEditResults.firstOrNull()?.playlistEditVideoAddedResultData?.setVideoId
+        get() = playlistEditResults.firstNotNullOfOrNull {
+            it.playlistEditVideoAddedResultData?.setVideoId
+        }
 
     @Serializable
     data class PlaylistEditResult(
-        val playlistEditVideoAddedResultData: PlaylistEditVideoAddedResultData,
+        val playlistEditVideoAddedResultData: PlaylistEditVideoAddedResultData? = null,
     ) {
         @Serializable
         data class PlaylistEditVideoAddedResultData(
-            val setVideoId: String,
-            val videoId: String
+            val setVideoId: String? = null,
+            val videoId: String? = null
         )
     }
 }

--- a/innertube/src/test/kotlin/com/metrolist/innertube/models/response/AddItemYouTubePlaylistResponseTest.kt
+++ b/innertube/src/test/kotlin/com/metrolist/innertube/models/response/AddItemYouTubePlaylistResponseTest.kt
@@ -37,4 +37,49 @@ class AddItemYouTubePlaylistResponseTest {
 
         assertNull(response.firstSetVideoId)
     }
+
+    @Test
+    fun `an edit result with no added data still parses`() {
+        // A shape YouTube changed must not turn an add that happened into a failure, because a
+        // failure is what makes the caller ask again.
+        val response = json.decodeFromString<AddItemYouTubePlaylistResponse>(
+            """{"playlistEditResults":[{}]}""",
+        )
+
+        assertNull(response.firstSetVideoId)
+    }
+
+    @Test
+    fun `added data with no ids still parses`() {
+        val response = json.decodeFromString<AddItemYouTubePlaylistResponse>(
+            """{"playlistEditResults":[{"playlistEditVideoAddedResultData":{}}]}""",
+        )
+
+        assertNull(response.firstSetVideoId)
+    }
+
+    @Test
+    fun `an empty body still parses`() {
+        val response = json.decodeFromString<AddItemYouTubePlaylistResponse>("{}")
+
+        assertNull(response.status)
+        assertNull(response.firstSetVideoId)
+    }
+
+    @Test
+    fun `a setVideoId later in the results is still found`() {
+        val response = json.decodeFromString<AddItemYouTubePlaylistResponse>(
+            """
+            {
+              "playlistEditResults": [
+                {},
+                {"playlistEditVideoAddedResultData": {"videoId": "VID456"}},
+                {"playlistEditVideoAddedResultData": {"setVideoId": "SVID789", "videoId": "VID456"}}
+              ]
+            }
+            """.trimIndent(),
+        )
+
+        assertEquals("SVID789", response.firstSetVideoId)
+    }
 }

--- a/innertube/src/test/kotlin/com/metrolist/innertube/models/response/AddItemYouTubePlaylistResponseTest.kt
+++ b/innertube/src/test/kotlin/com/metrolist/innertube/models/response/AddItemYouTubePlaylistResponseTest.kt
@@ -1,0 +1,40 @@
+package com.metrolist.innertube.models.response
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AddItemYouTubePlaylistResponseTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `setVideoId is read from the first edit result`() {
+        val response = json.decodeFromString<AddItemYouTubePlaylistResponse>(
+            """
+            {
+              "status": "STATUS_SUCCEEDED",
+              "playlistEditResults": [
+                {
+                  "playlistEditVideoAddedResultData": {
+                    "setVideoId": "SVID123",
+                    "videoId": "VID456"
+                  }
+                }
+              ]
+            }
+            """.trimIndent(),
+        )
+
+        assertEquals("SVID123", response.firstSetVideoId)
+    }
+
+    @Test
+    fun `an edit response without results parses to a null setVideoId`() {
+        val response = json.decodeFromString<AddItemYouTubePlaylistResponse>(
+            """{"status":"STATUS_SUCCEEDED"}""",
+        )
+
+        assertNull(response.firstSetVideoId)
+    }
+}


### PR DESCRIPTION
## Problem

Songs added to a local playlist do not reliably reach the mirrored YouTube playlist, especially when
several are added at once. A later sync, seeing them only locally, then deletes them from the
device — so the songs are lost in both places.

Separately, adding an **album** to a synced playlist puts every song on YouTube **twice**.

## Cause

Three defects compound.

**1. Fire-and-forget uploads, at eight call sites.** `SongMenu`, `SelectionSongsMenu`, `PlayerMenu`,
`QueueMenu` and `YouTubeSongMenu` each fire an independent `YouTube.addToPlaylist` from inside their
`onGetSong` callback — whose documented job is only to insert song rows — in parallel with the
dialog's own upload, bypassing the edit throttle and discarding the result.

`AlbumMenu`, `YouTubeAlbumMenu` and `YouTubePlaylistMenu` do the same with `addPlaylistToPlaylist`,
over the very id set the dialog then uploads one at a time. That is the duplicate-album case above:
one bulk request plus one per-song loop, over the same songs.

**2. Uploads die with the dialog.** `AddToPlaylistDialog` writes the local rows first, then uploads
song by song on `rememberCoroutineScope()`. Every upload passes through the 500 ms playlist-edit
throttle, so thirty songs take at least fifteen seconds. When the host menu leaves composition the
scope is cancelled and the remaining uploads never happen — but the local rows are already
committed. That mismatch is exactly what the next sync deletes.

**3. `setVideoId` is never recorded.** `YouTube.addToPlaylist` returns the raw response without
parsing it, so the app cannot tell a row that YouTube accepted from one it never saw.

## Solution

**Delete all eight fire-and-forget uploads**, leaving the dialog's single upload path. The `insert`
calls stay. Removing the bulk album request costs a fifty-song album roughly twenty-five seconds of
throttled per-song uploads in the background instead of one immediate request; that is accepted,
because the uploads now survive dismissal so their duration stops being the user's problem, and the
throttle exists because YouTube rate-limits playlist edits. Album songs gain `setVideoId`
persistence as a by-product.

**Upload on `syncScope`.** New `SyncUtils.addSongsToPlaylist(browseId, playlistId, playlistName,
songIds)` launches on the application-lifetime `SupervisorJob` scope instead of the caller's
composition scope, mirroring its neighbour `scheduleRemoveFromPlaylist`. It processes ids
sequentially through the existing throttle and wraps each in `withRetry`. The suspending single-song
`addToPlaylist` is deleted; the dialog was its only caller.

`withRetry` goes **outside** `runQueuedPlaylistEdit`, not inside: inverted, the 1 s and 2 s backoffs
would elapse while holding `playlistEditMutex` and stall every playlist edit in the app for up to
three seconds. `runQueuedPlaylistEdit` becomes generic so the block can return the parsed
`setVideoId`; its four existing callers infer `Unit` and are untouched.

The batch is marked with `markPlaylistModifying` once for the whole list rather than once per song,
which incidentally closes a real gap: today the playlist is unmarked between consecutive songs, so a
sync can interleave with an upload in progress.

Because uploads now outlive the dialog, the dialog returns to the obvious order: local writes,
uploads, dismiss.

**Parse and persist `setVideoId`.** The response model already existed with the right shape and was
unused. Since it had never been deserialised against a real response its non-null fields were a
hazard — a missing `playlistEditResults` would throw, `runCatching` would report failure for a song
that was in fact added, and the retry would duplicate it on YouTube — so that field defaults to
empty and `status` becomes nullable. Persistence uses one new query and **no schema change**; its
subselect fills the first unconfirmed row, which is what the "add anyway" case needs.

Two benefits: `scheduleRemoveFromPlaylist` no longer has to refetch an entire playlist from YouTube
to discover a `setVideoId`, and `setVideoId IS NULL` becomes a meaningful "not confirmed on YouTube"
signal.

**Report failures.** Uploads that fail after all retries raise a `Toast` naming the playlist instead
of only reaching `Timber.e`. One new plural string.

Deliberately out of scope: uploads do not survive the process being killed. Making them durable
would need either WorkManager, which is not a dependency here, or a persisted queue table, which
would be a schema change.

## Testing

- `./gradlew :app:assembleFossDebug`, `./gradlew :app:testFossDebugUnitTest` and
  `./gradlew :innertube:testDebugUnitTest`.
- The hardened response model is covered by unit tests, including a response with
  `playlistEditResults` absent, which is the case that used to turn a successful add into a retry.
- On device, signed in, against a disposable playlist:
  - seven songs added from `SelectionSongsMenu` with the menu dismissed immediately — the dialog was
    gone two seconds in, the throttled batch needs three and a half, and all seven rows ended with a
    non-null `setVideoId`, which can only come from YouTube's reply. Every upload landed after the
    scope that used to own it was gone.
  - the same playlist reported 7 remote songs, not 14, which is the duplicate upload removed.
  - with the network down, one upload logged three attempts at 1 s and 2 s backoffs and then
    reported "1 song was not added to YouTube" rather than failing silently.

Note: `:app:testFossDebugUnitTest` has 4 pre-existing failures in `YouTubeUtilsTest` (thumbnail URL
rewriting) that are present on `main` and unrelated to this change.

## Related Issues

<!-- none -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added batch playlist uploads for faster multi-song additions.
  * Added retry handling and clearer notifications when songs fail to upload.
  * Playlist additions now sync returned video identifiers automatically.
  * Added artist-name alias support and improved multi-artist editing.
  * Improved handling of incomplete playlist responses and duplicate entries.

* **Bug Fixes**
  * Ensured playlist changes finish syncing before dialogs close.
  * Improved library synchronization while preserving downloaded songs and artist mappings.

* **Tests**
  * Added coverage for playlist upload reconciliation, response parsing, and duplicate entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->