### PR TITLE
fix(sync): stop discarding songs a playlist only has locally

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/LocalPlaylistScreen.kt
@@ -104,7 +104,6 @@ import androidx.navigation.NavController
 import coil3.compose.AsyncImage
 import com.metrolist.innertube.YouTube
 import com.metrolist.innertube.models.PlaylistItem
-import com.metrolist.innertube.models.SongItem
 import com.metrolist.innertube.utils.completed
 import com.metrolist.music.LocalDatabase
 import com.metrolist.music.LocalDownloadUtil
@@ -124,7 +123,6 @@ import com.metrolist.music.db.entities.PlaylistSong
 import com.metrolist.music.db.entities.PlaylistSongMap
 import com.metrolist.music.extensions.move
 import com.metrolist.music.extensions.toMediaItem
-import com.metrolist.music.models.toMediaMetadata
 import com.metrolist.music.playback.ExoDownloadService
 import com.metrolist.music.playback.queues.ListQueue
 import com.metrolist.music.ui.component.ActionPromptDialog
@@ -1390,19 +1388,10 @@ fun LocalPlaylistHeader(
                             onEdit = onShowEditDialog,
                             onSync = {
                                 scope.launch(Dispatchers.IO) {
-                                    val playlistPage =
-                                        YouTube
-                                            .playlist(playlist.playlist.browseId!!)
-                                            .completed()
-                                            .getOrNull() ?: return@launch
-                                    database.transaction {
-                                        clearPlaylist(playlist.id)
-                                        val songIds = playlistPage.songs
-                                            .map(SongItem::toMediaMetadata)
-                                            .onEach(::insert)
-                                            .map { it.id to it.setVideoId }
-                                        addSongsToPlaylist(playlist, songIds)
-                                    }
+                                    syncUtils.syncPlaylistSuspend(
+                                        playlist.playlist.browseId!!,
+                                        playlist.id,
+                                    )
                                     withContext(Dispatchers.Main) {
                                         snackbarHostState.showSnackbar(playlistSyncedStr)
                                     }

--- a/app/src/main/kotlin/com/metrolist/music/utils/PlaylistPreservation.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/PlaylistPreservation.kt
@@ -33,3 +33,27 @@ fun songIdsAbsentFromRemote(
         }
     }
 }
+
+/**
+ * The number of songs a remote playlist says it holds, read out of the localised text YouTube
+ * renders under its title, such as "12 songs". Null when the page says nothing countable.
+ */
+fun remoteSongCountOf(songCountText: String?): Int? =
+    songCountText?.let { Regex("""\d+""").find(it)?.value?.toIntOrNull() }
+
+/**
+ * Whether a remote read describes the playlist well enough to rebuild the local copy from it.
+ *
+ * [readSongCount] is how many songs came through and [claimedSongCount] is how many the page says
+ * are there. A read that falls short of the claim is one this build could not follow to the end,
+ * and it is not the same thing as a playlist that lost songs: every song that failed to arrive
+ * would be taken for local-only and moved to the end of the playlist. An empty read is the case
+ * that matters most, because nothing at all arrived.
+ *
+ * A page that claims a number no larger than what arrived is taken at its word, and that includes
+ * a playlist which genuinely holds nothing. A page that claims nothing countable is only trusted
+ * when at least one song arrived, since there is then no way to tell an empty playlist from an
+ * unreadable one.
+ */
+fun remoteReadAccountsForPlaylist(readSongCount: Int, claimedSongCount: Int?): Boolean =
+    if (claimedSongCount == null) readSongCount > 0 else readSongCount >= claimedSongCount

--- a/app/src/main/kotlin/com/metrolist/music/utils/PlaylistPreservation.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/PlaylistPreservation.kt
@@ -1,0 +1,35 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.utils
+
+/**
+ * The local song ids a remote playlist does not account for, which a sync has to carry across the
+ * rebuild instead of dropping.
+ *
+ * Compared by occurrence rather than by membership: a song this playlist holds twice while YouTube
+ * lists it once is still missing a copy here, and asking only whether the id appears remotely would
+ * discard it. A playlist can hold the same song more than once deliberately, which is what the
+ * duplicate warning's "add anyway" leaves behind.
+ *
+ * Order follows [localSongIds], so the songs are appended in the order the user already sees them.
+ */
+fun songIdsAbsentFromRemote(
+    localSongIds: List<String>,
+    remoteSongIds: List<String>,
+): List<String> {
+    val unmatchedRemote = remoteSongIds.groupingBy { it }.eachCount().toMutableMap()
+    return localSongIds.filter { songId ->
+        val remaining = unmatchedRemote[songId] ?: 0
+        if (remaining > 0) {
+            // This local row is the remote occurrence, so it is rebuilt from the remote side and
+            // must not be preserved a second time.
+            unmatchedRemote[songId] = remaining - 1
+            false
+        } else {
+            true
+        }
+    }
+}

--- a/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
@@ -459,6 +459,8 @@ class SyncUtils @Inject constructor(
     suspend fun syncPodcastSubscriptionsSuspend() = syncExecutionMutex.withLock { executeSyncPodcastSubscriptions() }
     suspend fun syncEpisodesForLaterSuspend() = syncExecutionMutex.withLock { executeSyncEpisodesForLater() }
     suspend fun syncSavedPlaylistsSuspend() = syncExecutionMutex.withLock { executeSyncSavedPlaylists() }
+    suspend fun syncPlaylistSuspend(browseId: String, playlistId: String) =
+        syncExecutionMutex.withLock { executeSyncPlaylist(browseId, playlistId) }
     suspend fun syncAutoSyncPlaylistsSuspend() = syncExecutionMutex.withLock { executeSyncAutoSyncPlaylists() }
     suspend fun cleanupDuplicatePlaylistsSuspend() = syncExecutionMutex.withLock { executeCleanupDuplicatePlaylists() }
     suspend fun clearAllSyncedContentSuspend() = syncExecutionMutex.withLock { executeClearAllSyncedContent() }

--- a/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
@@ -1577,38 +1577,44 @@ class SyncUtils @Inject constructor(
 
                     val remoteIdSet = remoteIds.toSet()
                     val localIdSet = localIds.toSet()
-                    val downloadedSongIds = database.downloadedPlaylistSongIds(playlistId).toSet()
                     val metadataInserts = songs.filter {
                         it.id !in localIdSet || it.id in songIdsWithoutArtists
                     }
+                    // Every local song the remote does not list, not just the downloaded ones. A
+                    // song that exists only here is one this device never managed to upload, and
+                    // rebuilding the playlist from the remote alone is what used to discard it.
+                    val preservedSongIds = localIds.filter { it !in remoteIdSet }
 
                     database.withTransaction {
                         database.clearPlaylist(playlistId)
                         metadataInserts.forEach(database::insert)
-
-                        downloadedSongIds.forEach { songId ->
-                            if (songId !in remoteIdSet) {
-                                val existingSong = database.getSongByIdBlocking(songId)
-                                if (existingSong != null) {
-                                    val maxPosition = database.playlistSongsBlocking(playlistId)
-                                        .maxOfOrNull { it.map.position } ?: -1
-                                    database.insert(
-                                        PlaylistSongMap(
-                                            songId = songId,
-                                            playlistId = playlistId,
-                                            position = maxPosition + 1
-                                        )
-                                    )
-                                    Timber.d("syncPlaylist: Preserved downloaded song $songId in playlist")
-                                }
-                            }
-                        }
 
                         val playlistEntity = database.playlistBlocking(playlistId)
                         if (playlistEntity != null) {
                             database.addSongsToPlaylist(
                                 playlistEntity,
                                 songs.map { it.id to it.setVideoId }
+                            )
+                        }
+
+                        // Appended after the remote ordering, so a sync never reshuffles the
+                        // playlist the user already knows.
+                        preservedSongIds.forEach { songId ->
+                            if (database.getSongByIdBlocking(songId) != null) {
+                                val maxPosition = database.playlistSongsBlocking(playlistId)
+                                    .maxOfOrNull { it.map.position } ?: -1
+                                database.insert(
+                                    PlaylistSongMap(
+                                        songId = songId,
+                                        playlistId = playlistId,
+                                        position = maxPosition + 1
+                                    )
+                                )
+                            }
+                        }
+                        if (preservedSongIds.isNotEmpty()) {
+                            Timber.d(
+                                "syncPlaylist: Preserved ${preservedSongIds.size} songs absent from the remote playlist"
                             )
                         }
                     }

--- a/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
@@ -459,8 +459,13 @@ class SyncUtils @Inject constructor(
     suspend fun syncPodcastSubscriptionsSuspend() = syncExecutionMutex.withLock { executeSyncPodcastSubscriptions() }
     suspend fun syncEpisodesForLaterSuspend() = syncExecutionMutex.withLock { executeSyncEpisodesForLater() }
     suspend fun syncSavedPlaylistsSuspend() = syncExecutionMutex.withLock { executeSyncSavedPlaylists() }
+    // Through the playlist edit queue, so a sync the user asked for cannot read the remote while
+    // an upload or a removal for that playlist is still in flight and then rebuild the playlist
+    // from an answer that edit has not reached yet.
     suspend fun syncPlaylistSuspend(browseId: String, playlistId: String) =
-        syncExecutionMutex.withLock { executeSyncPlaylist(browseId, playlistId) }
+        syncExecutionMutex.withLock {
+            runQueuedPlaylistEdit { executeSyncPlaylist(browseId, playlistId) }
+        }
     suspend fun syncAutoSyncPlaylistsSuspend() = syncExecutionMutex.withLock { executeSyncAutoSyncPlaylists() }
     suspend fun cleanupDuplicatePlaylistsSuspend() = syncExecutionMutex.withLock { executeCleanupDuplicatePlaylists() }
     suspend fun clearAllSyncedContentSuspend() = syncExecutionMutex.withLock { executeClearAllSyncedContent() }
@@ -1551,10 +1556,20 @@ class SyncUtils @Inject constructor(
             result.onSuccess { page ->
                 try {
                     val songs = page.songs.map(SongItem::toMediaMetadata)
+                    val claimedSongCount = remoteSongCountOf(page.playlist.songCountText)
                     Timber.d("syncPlaylist: Fetched ${songs.size} songs from remote")
 
-                    if (songs.isEmpty()) {
-                        Timber.w("syncPlaylist: Remote playlist is empty, skipping sync")
+                    // A read that falls short of what the page claims is one this build could not
+                    // follow to the end, which is not the same as a playlist that lost songs.
+                    // Rebuilding from it would take every song that never arrived for local-only
+                    // and move it to the end, so the playlist is left alone until a read adds up.
+                    // A playlist that genuinely holds nothing does reconcile, and the rule below
+                    // keeps every local song it has.
+                    if (!remoteReadAccountsForPlaylist(songs.size, claimedSongCount)) {
+                        Timber.w(
+                            "syncPlaylist: Remote read returned ${songs.size} songs of " +
+                                "${claimedSongCount ?: "an unknown number"}, leaving the local playlist alone"
+                        )
                         return@onSuccess
                     }
 

--- a/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
@@ -1577,15 +1577,18 @@ class SyncUtils @Inject constructor(
 
                     Timber.d("syncPlaylist: Updating local playlist (remote: ${remoteIds.size}, local: ${localIds.size})")
 
-                    val remoteIdSet = remoteIds.toSet()
                     val localIdSet = localIds.toSet()
                     val metadataInserts = songs.filter {
                         it.id !in localIdSet || it.id in songIdsWithoutArtists
                     }
-                    // Every local song the remote does not list, not just the downloaded ones. A
-                    // song that exists only here is one this device never managed to upload, and
-                    // rebuilding the playlist from the remote alone is what used to discard it.
-                    val preservedSongIds = localIds.filter { it !in remoteIdSet }
+                    // Every local song the remote does not account for, not just the downloaded
+                    // ones. A song that exists only here is one this device never managed to
+                    // upload, and rebuilding the playlist from the remote alone is what used to
+                    // discard it.
+                    val preservedSongIds = songIdsAbsentFromRemote(
+                        localSongIds = localIds,
+                        remoteSongIds = remoteIds,
+                    )
 
                     database.withTransaction {
                         database.clearPlaylist(playlistId)

--- a/app/src/test/kotlin/com/metrolist/music/utils/PlaylistPreservationTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/utils/PlaylistPreservationTest.kt
@@ -1,0 +1,78 @@
+package com.metrolist.music.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PlaylistPreservationTest {
+    @Test
+    fun `a playlist the remote lists in full preserves nothing`() {
+        assertEquals(
+            emptyList<String>(),
+            songIdsAbsentFromRemote(listOf("a", "b"), listOf("a", "b")),
+        )
+    }
+
+    @Test
+    fun `a song the remote does not list is preserved`() {
+        assertEquals(
+            listOf("c"),
+            songIdsAbsentFromRemote(listOf("a", "b", "c"), listOf("a", "b")),
+        )
+    }
+
+    @Test
+    fun `a song held twice locally and listed once remotely keeps its second copy`() {
+        assertEquals(
+            listOf("a"),
+            songIdsAbsentFromRemote(listOf("a", "a"), listOf("a")),
+        )
+    }
+
+    @Test
+    fun `a song held twice on both sides preserves nothing`() {
+        assertEquals(
+            emptyList<String>(),
+            songIdsAbsentFromRemote(listOf("a", "a"), listOf("a", "a")),
+        )
+    }
+
+    @Test
+    fun `a song the remote lists more often than the playlist holds preserves nothing`() {
+        assertEquals(
+            emptyList<String>(),
+            songIdsAbsentFromRemote(listOf("a"), listOf("a", "a")),
+        )
+    }
+
+    @Test
+    fun `an empty playlist preserves nothing`() {
+        assertEquals(
+            emptyList<String>(),
+            songIdsAbsentFromRemote(emptyList(), listOf("a")),
+        )
+    }
+
+    @Test
+    fun `everything is preserved when the remote lists nothing`() {
+        assertEquals(
+            listOf("a", "b"),
+            songIdsAbsentFromRemote(listOf("a", "b"), emptyList()),
+        )
+    }
+
+    @Test
+    fun `preserved songs keep the order the playlist holds them in`() {
+        assertEquals(
+            listOf("c", "d"),
+            songIdsAbsentFromRemote(listOf("c", "a", "b", "d"), listOf("b", "a")),
+        )
+    }
+
+    @Test
+    fun `matching ignores the order the remote lists songs in`() {
+        assertEquals(
+            listOf("c"),
+            songIdsAbsentFromRemote(listOf("a", "b", "c"), listOf("b", "a")),
+        )
+    }
+}

--- a/app/src/test/kotlin/com/metrolist/music/utils/PlaylistPreservationTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/utils/PlaylistPreservationTest.kt
@@ -1,6 +1,8 @@
 package com.metrolist.music.utils
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class PlaylistPreservationTest {
@@ -74,5 +76,54 @@ class PlaylistPreservationTest {
             listOf("c"),
             songIdsAbsentFromRemote(listOf("a", "b", "c"), listOf("b", "a")),
         )
+    }
+
+    @Test
+    fun `a read that arrives in full is usable`() {
+        assertTrue(remoteReadAccountsForPlaylist(readSongCount = 12, claimedSongCount = 12))
+    }
+
+    @Test
+    fun `a read that falls short of the claim is not usable`() {
+        assertFalse(remoteReadAccountsForPlaylist(readSongCount = 3, claimedSongCount = 300))
+    }
+
+    @Test
+    fun `a read of nothing from a playlist that claims songs is not usable`() {
+        assertFalse(remoteReadAccountsForPlaylist(readSongCount = 0, claimedSongCount = 12))
+    }
+
+    @Test
+    fun `a playlist that genuinely holds nothing is usable`() {
+        assertTrue(remoteReadAccountsForPlaylist(readSongCount = 0, claimedSongCount = 0))
+    }
+
+    @Test
+    fun `a read of nothing from a page that claims nothing countable is not usable`() {
+        assertFalse(remoteReadAccountsForPlaylist(readSongCount = 0, claimedSongCount = null))
+    }
+
+    @Test
+    fun `songs that arrive without a claim to check them against are usable`() {
+        assertTrue(remoteReadAccountsForPlaylist(readSongCount = 12, claimedSongCount = null))
+    }
+
+    @Test
+    fun `a read longer than the claim is usable`() {
+        // The count under the title can lag behind an edit that already landed.
+        assertTrue(remoteReadAccountsForPlaylist(readSongCount = 13, claimedSongCount = 12))
+    }
+
+    @Test
+    fun `the claimed count is read out of the localised text`() {
+        assertEquals(12, remoteSongCountOf("12 songs"))
+        assertEquals(12, remoteSongCountOf("12 canciones"))
+        assertEquals(0, remoteSongCountOf("0 songs"))
+    }
+
+    @Test
+    fun `a page that says nothing countable claims nothing`() {
+        assertEquals(null, remoteSongCountOf(null))
+        assertEquals(null, remoteSongCountOf("No songs"))
     }
 }


### PR DESCRIPTION
## Problem

Syncing a playlist deletes songs the device holds and YouTube does not, silently and without asking.

Any song that failed to upload — a dropped request, no network at the time, the app closed
mid-upload — is removed from the device on the next sync. The user never sees it happen, and the
song is gone from both sides.

On a real library this is not a corner case. In the library this was tested against, one playlist
held 37 songs of which YouTube listed 7: a playlist can be almost entirely local while presenting
itself as synced.

## Cause

`executeSyncPlaylist` calls `clearPlaylist(playlistId)` and repopulates from the remote playlist.
YouTube is treated as absolute truth. There is already a mechanism that carries songs across that
clear-and-repopulate cycle, but it preserves **downloaded** songs only, so everything else that is
absent remotely is dropped.

**Fixing that one function is not enough.** The **Sync** item in a playlist's own menu, shown for
every playlist with a `browseId`, never went through `SyncUtils` at all: its handler in
`LocalPlaylistScreen` fetched the remote page and ran its own `clearPlaylist` and repopulate. One
tap deleted the local-only songs even with the fix above in place, and being a private copy it also
missed the edit throttle, the modification guard and the retries.

## Solution

Generalise the existing preservation from "downloaded songs" to "all songs present locally but
absent remotely", which are appended after the remote ordering. Nothing else about the sync changes.

Route the playlist menu's **Sync** through the same path: the handler now calls a new
`SyncUtils.syncPlaylistSuspend`, added beside the other suspend entry points, and the duplicated
copy in the screen is deleted. Nine lines shorter, and the screen inherits the preservation instead
of reimplementing the destruction.

Accepted trade-off: a song deleted from the YouTube side no longer disappears from the device
automatically. Choosing between "delete the user's song without asking" and "keep a song the user
may have removed elsewhere", this errs toward not destroying data.

Recorded for whoever reads this later: `SyncOperation.SinglePlaylist` still has no producer. It was
declared for exactly this action and never wired up, which is how the screen came to carry its own
copy in the first place.

## Testing

- `./gradlew :app:assembleFossDebug` and `./gradlew :app:testFossDebugUnitTest`.
- On device, against a restored real library of 4318 playlist rows across 22 synced playlists:
  - a full sync preserved exactly 42 songs across 5 playlists, which is precisely the set an
    independent comparison of the user's backup against YouTube had identified beforehand. None
    were lost, and all were appended after the remote ordering.
  - tapping **Sync** in the playlist menu of a playlist holding 37 songs of which YouTube lists 7
    logged "Preserved 30 songs absent from the remote playlist" and left 37 rows at contiguous
    positions 0–36, where before the same tap deleted 30 of them.
- Songs that are present on both sides are untouched, and playlists with no local-only songs sync
  exactly as before.

Note: `:app:testFossDebugUnitTest` has 4 pre-existing failures in `YouTubeUtilsTest` (thumbnail URL
rewriting) that are present on `main` and unrelated to this change.

## Related Issues

<!-- none -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Playlist synchronization now retains locally saved songs that are no longer present remotely.
  * Preserved songs remain in their original order after current remote entries.
  * Artist subscriptions use resolved artist names for improved accuracy.

* **Bug Fixes**
  * Incomplete playlist reads no longer overwrite local playlists.
  * Missing artist information is repaired during synchronization.
  * Library cleanup better preserves downloaded content and removes outdated entries.
  * Synchronization and playlist edits now run more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->