### PR TITLE
fix(ui): prevent cover from failing to display for some playlists on Library page

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/YouTubeUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/YouTubeUtils.kt
@@ -9,13 +9,18 @@ package com.metrolist.music.ui.utils
 
 import kotlin.math.roundToInt
 
+private val GOOGLEUSERCONTENT_SIZE_PATTERN =
+    Regex("https://(?:lh3|yt3)\\.googleusercontent\\.com/.*=w(\\d+)-h(\\d+).*")
+private val YTIMG_DEFAULT_IMAGE_PATTERN =
+    Regex("/(?:default|mqdefault|hqdefault|sddefault)\\.jpg")
+
 fun String.resize(
     width: Int? = null,
     height: Int? = null,
 ): String {
     if (width == null && height == null) return this
 
-    "https://(?:lh3|yt3)\\.googleusercontent\\.com/.*=w(\\d+)-h(\\d+).*".toRegex()
+    GOOGLEUSERCONTENT_SIZE_PATTERN
         .matchEntire(this)
         ?.groupValues
         ?.let { group ->
@@ -35,7 +40,7 @@ fun String.resize(
     }
 
     if (startsWith("https://i.ytimg.com/") && maxOf(width ?: 0, height ?: 0) >= 544) {
-        return replace(Regex("/(?:default|mqdefault|hqdefault|sddefault)\\.jpg"), "/maxresdefault.jpg")
+        return replace(YTIMG_DEFAULT_IMAGE_PATTERN, "/maxresdefault.jpg")
     }
 
     return this

--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/YouTubeUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/YouTubeUtils.kt
@@ -10,7 +10,9 @@ package com.metrolist.music.ui.utils
 import kotlin.math.roundToInt
 
 private val GOOGLEUSERCONTENT_SIZE_PATTERN =
-    Regex("https://(?:lh3|yt3)\\.googleusercontent\\.com/.*=w(\\d+)-h(\\d+).*")
+    Regex("^(https://(?:lh3|yt3)\\.googleusercontent\\.com/[^?]*?)=w(\\d+)-h(\\d+)[^?]*(\\?.*)?$")
+private val GGPHT_SIZE_PATTERN =
+    Regex("^(https://yt3\\.ggpht\\.com/[^?=]+)=(?:s\\d+|w\\d+-h\\d+)[^?]*(\\?.*)?$")
 private val YTIMG_DEFAULT_IMAGE_PATTERN =
     Regex("/(?:default|mqdefault|hqdefault|sddefault)\\.jpg")
 
@@ -24,18 +26,20 @@ fun String.resize(
         .matchEntire(this)
         ?.groupValues
         ?.let { group ->
-            val (originalWidth, originalHeight) = group.drop(1).map(String::toInt)
+            val originalWidth = group[2].toInt()
+            val originalHeight = group[3].toInt()
+            val query = group[4]
             val targetWidth = width ?: ((height!!.toDouble() * originalWidth) / originalHeight).roundToInt()
             val targetHeight = height ?: ((width!!.toDouble() * originalHeight) / originalWidth).roundToInt()
-            return "${substringBefore("=w")}=w${targetWidth.coerceAtLeast(1)}-h${targetHeight.coerceAtLeast(1)}-p-l90-rj"
+            return "${group[1]}=w${targetWidth.coerceAtLeast(1)}-h${targetHeight.coerceAtLeast(1)}-p-l90-rj$query"
         }
 
-    if (startsWith("https://yt3.ggpht.com/") && '=' in this) {
-        val baseUrl = substringBefore('=')
+    GGPHT_SIZE_PATTERN.matchEntire(this)?.groupValues?.let { group ->
+        val query = group[2]
         return if (width != null && height != null) {
-            "$baseUrl=w$width-h$height-p-l90-rj"
+            "${group[1]}=w$width-h$height-p-l90-rj$query"
         } else {
-            "$baseUrl=s${width ?: height}"
+            "${group[1]}=s${width ?: height}$query"
         }
     }
 

--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/YouTubeUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/YouTubeUtils.kt
@@ -7,26 +7,36 @@
 
 package com.metrolist.music.ui.utils
 
+import kotlin.math.roundToInt
+
 fun String.resize(
     width: Int? = null,
     height: Int? = null,
 ): String {
     if (width == null && height == null) return this
-    // Match BOTH lh3 and yt3 googleusercontent: YouTube migrated music/album art from
-    // lh3.googleusercontent.com to yt3.googleusercontent.com. Both serve the same =wW-hH resize
-    // params; matching only lh3 silently no-ops on the new host, so the player upscales the raw
-    // ~60px thumbnail (blurry). Verified live: a yt3 URL + =w544-h544 returns a sharp full-size image.
+
     "https://(?:lh3|yt3)\\.googleusercontent\\.com/.*=w(\\d+)-h(\\d+).*".toRegex()
-        .matchEntire(this)?.groupValues?.let { group ->
-        val (W, H) = group.drop(1).map { it.toInt() }
-        var w = width
-        var h = height
-        if (w != null && h == null) h = (w / W) * H
-        if (w == null && h != null) w = (h / H) * W
-        return "${split("=w")[0]}=w$w-h$h-p-l90-rj"
+        .matchEntire(this)
+        ?.groupValues
+        ?.let { group ->
+            val (originalWidth, originalHeight) = group.drop(1).map(String::toInt)
+            val targetWidth = width ?: ((height!!.toDouble() * originalWidth) / originalHeight).roundToInt()
+            val targetHeight = height ?: ((width!!.toDouble() * originalHeight) / originalWidth).roundToInt()
+            return "${substringBefore("=w")}=w${targetWidth.coerceAtLeast(1)}-h${targetHeight.coerceAtLeast(1)}-p-l90-rj"
+        }
+
+    if (startsWith("https://yt3.ggpht.com/") && '=' in this) {
+        val baseUrl = substringBefore('=')
+        return if (width != null && height != null) {
+            "$baseUrl=w$width-h$height-p-l90-rj"
+        } else {
+            "$baseUrl=s${width ?: height}"
+        }
     }
-    if (this matches "https://yt3\\.ggpht\\.com/.*=s(\\d+)".toRegex()) {
-        return "$this-s${width ?: height}"
+
+    if (startsWith("https://i.ytimg.com/") && maxOf(width ?: 0, height ?: 0) >= 544) {
+        return replace(Regex("/(?:default|mqdefault|hqdefault|sddefault)\\.jpg"), "/maxresdefault.jpg")
     }
+
     return this
 }

--- a/app/src/test/kotlin/com/metrolist/music/ui/utils/YouTubeUtilsTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/ui/utils/YouTubeUtilsTest.kt
@@ -9,7 +9,7 @@ class YouTubeUtilsTest {
     fun `lh3 googleusercontent is rewritten to the requested size`() {
         val url = "https://lh3.googleusercontent.com/abc=w120-h120-l90-rj"
         assertEquals(
-            "https://lh3.googleusercontent.com/abc=w544-h544-l90-rj",
+            "https://lh3.googleusercontent.com/abc=w544-h544-p-l90-rj",
             url.resize(544, 544),
         )
     }
@@ -20,7 +20,7 @@ class YouTubeUtilsTest {
         // matching this host, resize() would no-op and the player upscales the 60px image → blur.
         val url = "https://yt3.googleusercontent.com/_zDuDZFnSKmuQwDX=w60-h60-l90-rj"
         assertEquals(
-            "https://yt3.googleusercontent.com/_zDuDZFnSKmuQwDX=w544-h544-l90-rj",
+            "https://yt3.googleusercontent.com/_zDuDZFnSKmuQwDX=w544-h544-p-l90-rj",
             url.resize(544, 544),
         )
     }
@@ -31,6 +31,15 @@ class YouTubeUtilsTest {
         assertEquals(
             "https://i.ytimg.com/vi/abc/maxresdefault.jpg?sqp=-oaymwE",
             url.resize(544, 544),
+        )
+    }
+
+    @Test
+    fun `single dimension preserves googleusercontent aspect ratio`() {
+        val url = "https://lh3.googleusercontent.com/abc=w120-h60-l90-rj"
+        assertEquals(
+            "https://lh3.googleusercontent.com/abc=w300-h150-p-l90-rj",
+            url.resize(width = 300),
         )
     }
 

--- a/app/src/test/kotlin/com/metrolist/music/ui/utils/YouTubeUtilsTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/ui/utils/YouTubeUtilsTest.kt
@@ -57,4 +57,28 @@ class YouTubeUtilsTest {
             url.resize(544, 544),
         )
     }
+
+    @Test
+    fun `googleusercontent resize preserves query parameters`() {
+        val url = "https://lh3.googleusercontent.com/abc=w120-h120-l90-rj?token=a=b"
+        assertEquals(
+            "https://lh3.googleusercontent.com/abc=w544-h544-p-l90-rj?token=a=b",
+            url.resize(544, 544),
+        )
+    }
+
+    @Test
+    fun `ggpht resize preserves query parameters`() {
+        val url = "https://yt3.ggpht.com/abc=s88?token=a=b"
+        assertEquals(
+            "https://yt3.ggpht.com/abc=w544-h544-p-l90-rj?token=a=b",
+            url.resize(544, 544),
+        )
+    }
+
+    @Test
+    fun `ggpht query without resize suffix remains unchanged`() {
+        val url = "https://yt3.ggpht.com/abc?token=a=b"
+        assertEquals(url, url.resize(544, 544))
+    }
 }


### PR DESCRIPTION
## Problem

#4157 reports playlist covers missing from the Library even when artwork can still appear after opening the playlist. The Library thumbnail path resizes stored playlist/song artwork before loading it, so malformed CDN resize URLs can fail there while another screen using the original or differently sized URL still works.

The `resize()` implementation merged in #4048 currently does not match its own regression tests:

- `yt3.ggpht.com/...=s88` becomes the invalid `...=s88-s544` form;
- large `i.ytimg.com` requests are not upgraded as expected by the existing test;
- one-sided Google image requests use integer division and can produce an invalid zero dimension;
- Google-hosted square artwork must retain the `-p` crop parameter when rebuilding the URL.

For a real `lh3.googleusercontent.com` image, requesting `w544-h544` without `-p` returned a `544x454` image, while `w544-h544-p` returned the expected `544x544` square. Keeping `-p` also prevents circular artist consumers of the same utility from being stretched or clipped; that is regression prevention, not the primary issue addressed by this PR.

## Solution

- Rebuild ggpht resize parameters from the base URL instead of appending a second size suffix.
- Preserve the `-p` square-crop parameter for Google-hosted artwork.
- Upgrade large ytimg requests to `maxresdefault.jpg` as required by the existing test.
- Calculate a missing dimension with floating-point aspect-ratio math and clamp it to at least 1 pixel.
- Precompile the URL patterns because `resize()` is called frequently in scrolling lists.
- Add regression coverage for a one-sided aspect-ratio request.

This PR intentionally does not change playlist synchronization, database rows, or Library UI. The duplicate-playlist issue in #4101 was already addressed by #4147.

## Testing

Before the fix:

- `YouTubeUtilsTest`: 4 of 5 tests failed on current `main`.

After the fix:

- `YouTubeUtilsTest`: 6 of 6 passed.
- Full FOSS unit test suite: 56 of 56 passed.
- `:app:assembleFossDebug`: passed.
- Verified on an Android 16 device that Library and Search artwork remains correctly cropped after the resize fix.

Fixes #4157


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image resizing for Googleusercontent, Ggpht, and YouTube thumbnail URLs.
  * Preserved query parameters and aspect ratios when resizing images.
  * Ensured resized dimensions remain valid and supported single-dimension requests.
  * Updated large YouTube thumbnail requests to use higher-resolution images.
  * Left image URLs unchanged when no resize information is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->