### PR TITLE
fix: repair migrations, artist aliases, and Android Auto

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/App.kt
+++ b/app/src/main/kotlin/com/metrolist/music/App.kt
@@ -31,6 +31,7 @@ import com.metrolist.music.di.ApplicationScope
 import com.metrolist.music.extensions.toEnum
 import com.metrolist.music.extensions.toInetSocketAddress
 import com.metrolist.music.utils.CrashHandler
+import com.metrolist.music.utils.ArtistNameAliases
 import com.metrolist.music.utils.YTPlayerUtils
 import com.metrolist.music.utils.cipher.CipherDeobfuscator
 import com.metrolist.music.utils.dataStore
@@ -69,6 +70,7 @@ class App :
 
         // Install crash handler first
         CrashHandler.install(this)
+        ArtistNameAliases.initialize(this)
 
         // preferencesDataStore uses filesDir/datastore; proactive mkdir reduces failures on odd ROM states
         try {

--- a/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
@@ -199,6 +199,7 @@ import com.metrolist.music.ui.utils.resetHeightOffset
 import com.metrolist.music.utils.ReleaseInfo
 import com.metrolist.music.utils.SearchRoutes
 import com.metrolist.music.utils.SyncUtils
+import com.metrolist.music.utils.ArtistNameAliases
 import com.metrolist.music.utils.Updater
 import com.metrolist.music.utils.dataStore
 import com.metrolist.music.utils.safeDataStoreEdit
@@ -993,6 +994,7 @@ class MainActivity : ComponentActivity() {
                     }
 
                 val baseBg = if (pureBlack) Color.Black else MaterialTheme.colorScheme.surfaceContainer
+                val artistNameAliases by ArtistNameAliases.aliases.collectAsStateWithLifecycle()
 
                 CompositionLocalProvider(
                     LocalDatabase provides database,
@@ -1005,6 +1007,7 @@ class MainActivity : ComponentActivity() {
                     LocalSyncUtils provides syncUtils,
                     LocalListenTogetherManager provides listenTogetherManager,
                     LocalChangelogState provides showChangelog,
+                    LocalArtistNameAliases provides artistNameAliases,
                 ) {
                     if (showChangelog.value) {
                         ChangelogScreen(onDismiss = { showChangelog.value = false })
@@ -1657,4 +1660,5 @@ val LocalDownloadUtil = staticCompositionLocalOf<DownloadUtil> { error("No Downl
 val LocalSyncUtils = staticCompositionLocalOf<SyncUtils> { error("No SyncUtils provided") }
 val LocalListenTogetherManager = staticCompositionLocalOf<com.metrolist.music.listentogether.ListenTogetherManager?> { null }
 val LocalChangelogState = staticCompositionLocalOf<MutableState<Boolean>> { error("No LocalChangelogState provided") }
+val LocalArtistNameAliases = staticCompositionLocalOf<Map<String, String>> { emptyMap() }
 val LocalIsPlayerExpanded = compositionLocalOf { false }

--- a/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
@@ -56,6 +56,7 @@ import com.metrolist.music.extensions.toSQLiteQuery
 import com.metrolist.music.models.MediaMetadata
 import com.metrolist.music.models.toMediaMetadata
 import com.metrolist.music.ui.utils.resize
+import com.metrolist.music.utils.ArtistNameAliases
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -1648,6 +1649,21 @@ interface DatabaseDao {
     @Query("SELECT * FROM artist WHERE id = :id LIMIT 1")
     fun getArtistById(id: String): ArtistEntity?
 
+    @Query(
+        """
+        UPDATE artist SET name = :name
+        WHERE id = :artistId
+           OR (:channelId IS NOT NULL AND (id = :channelId OR channelId = :channelId))
+           OR name = :originalName
+        """,
+    )
+    fun renameArtist(
+        artistId: String,
+        channelId: String?,
+        originalName: String,
+        name: String,
+    )
+
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     fun insert(song: SongEntity): Long
 
@@ -1752,7 +1768,7 @@ interface DatabaseDao {
                 ArtistEntity(
                     id = artist.id ?: artistByName(artist.name)?.id
                     ?: ArtistEntity.generateArtistId(),
-                    name = artist.name,
+                    name = ArtistNameAliases.resolve(artist.id, artist.name),
                 )
             }?.onEach(::insert)
             ?.mapIndexed { index, artist ->
@@ -1823,7 +1839,7 @@ interface DatabaseDao {
     ) {
         update(
             artist.copy(
-                name = artistPage.artist.title,
+                name = ArtistNameAliases.resolve(artist.id, artistPage.artist.title),
                 thumbnailUrl = artistPage.artist.thumbnail?.resize(1080, 1080),
                 lastUpdateTime = LocalDateTime.now()
             )
@@ -1875,7 +1891,7 @@ interface DatabaseDao {
                     ArtistEntity(
                         id = artist.id ?: artistByName(artist.name)?.id
                         ?: ArtistEntity.generateArtistId(),
-                        name = artist.name,
+                        name = ArtistNameAliases.resolve(artist.id, artist.name),
                     )
                 }.onEach(::insert)
                 .mapIndexed { index, artist ->

--- a/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
@@ -797,6 +797,16 @@ interface DatabaseDao {
 
     @Transaction
     @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
+    @Query(
+        "SELECT *, (SELECT COUNT(1) FROM song_artist_map JOIN song " +
+            "ON song_artist_map.songId = song.id WHERE artistId = artist.id " +
+            "AND song.inLibrary IS NOT NULL) AS songCount FROM artist " +
+            "WHERE songCount > 0 ORDER BY rowId LIMIT :limit OFFSET :offset",
+    )
+    suspend fun artistsByCreateDateAsc(limit: Int, offset: Int): List<Artist>
+
+    @Transaction
+    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
     @Query("SELECT *, (SELECT COUNT(1) FROM song_artist_map JOIN song ON song_artist_map.songId = song.id WHERE artistId = artist.id AND song.inLibrary IS NOT NULL) AS songCount FROM artist WHERE songCount > 0 ORDER BY name")
     fun artistsByNameAsc(): Flow<List<Artist>>
 
@@ -898,6 +908,15 @@ interface DatabaseDao {
     @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
     @Query("SELECT * FROM album WHERE EXISTS(SELECT * FROM song WHERE song.albumId = album.id AND song.inLibrary IS NOT NULL) ORDER BY rowId")
     fun albumsByCreateDateAsc(): Flow<List<Album>>
+
+    @Transaction
+    @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
+    @Query(
+        "SELECT * FROM album WHERE EXISTS(SELECT * FROM song " +
+            "WHERE song.albumId = album.id AND song.inLibrary IS NOT NULL) " +
+            "ORDER BY rowId LIMIT :limit OFFSET :offset",
+    )
+    suspend fun albumsByCreateDateAsc(limit: Int, offset: Int): List<Album>
 
     @Transaction
     @SuppressWarnings(RoomWarnings.QUERY_MISMATCH)
@@ -1105,6 +1124,16 @@ interface DatabaseDao {
     @Transaction
     @Query("SELECT *, (SELECT COUNT(*) FROM playlist_song_map WHERE playlistId = playlist.id) AS songCount FROM playlist WHERE bookmarkedAt IS NOT NULL ORDER BY rowId")
     fun playlistsByCreateDateAsc(): Flow<List<Playlist>>
+
+    @Transaction
+    @Query(
+        "SELECT *, (SELECT COUNT(*) FROM playlist_song_map WHERE playlistId = playlist.id) AS songCount " +
+            "FROM playlist WHERE bookmarkedAt IS NOT NULL ORDER BY rowId LIMIT :limit OFFSET :offset",
+    )
+    suspend fun playlistsByCreateDateAsc(limit: Int, offset: Int): List<Playlist>
+
+    @Query("SELECT browseId FROM playlist WHERE bookmarkedAt IS NOT NULL AND browseId IS NOT NULL")
+    suspend fun bookmarkedPlaylistBrowseIds(): List<String>
 
     @Transaction
     @Query(

--- a/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
@@ -130,6 +130,10 @@ interface DatabaseDao {
     fun songsByCreateDateAsc(): Flow<List<Song>>
 
     @Transaction
+    @Query("SELECT * FROM song WHERE inLibrary IS NOT NULL ORDER BY inLibrary, rowId LIMIT :limit OFFSET :offset")
+    suspend fun songsByCreateDateAsc(limit: Int, offset: Int): List<Song>
+
+    @Transaction
     @Query("SELECT * FROM song WHERE inLibrary IS NOT NULL ORDER BY title")
     fun songsByNameAsc(): Flow<List<Song>>
 
@@ -179,6 +183,10 @@ interface DatabaseDao {
     @Transaction
     @Query("SELECT * FROM song WHERE liked ORDER BY likedDate")
     fun likedSongsByCreateDateAsc(): Flow<List<Song>>
+
+    @Transaction
+    @Query("SELECT * FROM song WHERE liked ORDER BY likedDate DESC, rowId DESC LIMIT :limit OFFSET :offset")
+    suspend fun likedSongsByCreateDateDesc(limit: Int, offset: Int): List<Song>
 
     @Transaction
     @Query("SELECT * FROM song WHERE liked ORDER BY title")
@@ -231,8 +239,23 @@ interface DatabaseDao {
     fun albumSongs(albumId: String): Flow<List<Song>>
 
     @Transaction
+    @Query(
+        "SELECT song.* FROM song JOIN song_album_map ON song.id = song_album_map.songId " +
+            "WHERE song_album_map.albumId = :albumId " +
+            "ORDER BY song_album_map.`index`, song.rowId LIMIT :limit OFFSET :offset",
+    )
+    suspend fun albumSongs(albumId: String, limit: Int, offset: Int): List<Song>
+
+    @Transaction
     @Query("SELECT * FROM playlist_song_map WHERE playlistId = :playlistId ORDER BY position")
     fun playlistSongs(playlistId: String): Flow<List<PlaylistSong>>
+
+    @Transaction
+    @Query(
+        "SELECT * FROM playlist_song_map WHERE playlistId = :playlistId " +
+            "ORDER BY position, id LIMIT :limit OFFSET :offset",
+    )
+    suspend fun playlistSongs(playlistId: String, limit: Int, offset: Int): List<PlaylistSong>
 
     @Transaction
     @Query(
@@ -251,6 +274,14 @@ interface DatabaseDao {
         "SELECT song.* FROM song_artist_map JOIN song ON song_artist_map.songId = song.id WHERE artistId = :artistId AND inLibrary IS NOT NULL ORDER BY inLibrary",
     )
     fun artistSongsByCreateDateAsc(artistId: String): Flow<List<Song>>
+
+    @Transaction
+    @Query(
+        "SELECT song.* FROM song_artist_map JOIN song ON song_artist_map.songId = song.id " +
+            "WHERE artistId = :artistId AND inLibrary IS NOT NULL " +
+            "ORDER BY inLibrary, song.rowId LIMIT :limit OFFSET :offset",
+    )
+    suspend fun artistSongsByCreateDateAsc(artistId: String, limit: Int, offset: Int): List<Song>
 
     @Transaction
     @Query(
@@ -701,6 +732,9 @@ interface DatabaseDao {
     @Transaction
     @Query("SELECT * FROM song WHERE id IN (:songIds)")
     suspend fun getSongsByIds(songIds: List<String>): List<Song>
+
+    @Query("SELECT id FROM song WHERE id IN (:songIds)")
+    suspend fun existingSongIds(songIds: List<String>): List<String>
 
 
     @Transaction

--- a/app/src/main/kotlin/com/metrolist/music/db/MusicDatabase.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/MusicDatabase.kt
@@ -352,6 +352,26 @@ private class BackupCallback(
 
 // ===== Migrations =====
 
+private fun addIsUploadedColumnIfMissing(
+    db: SupportSQLiteDatabase,
+    tableName: String,
+) {
+    var columnExists = false
+    db.query("PRAGMA table_info('$tableName')").use { cursor ->
+        val nameIndex = cursor.getColumnIndex("name")
+        while (cursor.moveToNext()) {
+            if (nameIndex >= 0 && cursor.getString(nameIndex) == "isUploaded") {
+                columnExists = true
+                break
+            }
+        }
+    }
+
+    if (!columnExists) {
+        db.execSQL("ALTER TABLE `$tableName` ADD COLUMN `isUploaded` INTEGER NOT NULL DEFAULT 0")
+    }
+}
+
 val MIGRATION_1_2 =
     object : Migration(1, 2) {
         override fun migrate(db: SupportSQLiteDatabase) {
@@ -592,21 +612,8 @@ val MIGRATION_21_24 =
             }
 
             // From 23→24: Add isUploaded
-            var hasIsUploaded = false
-            db.query("PRAGMA table_info('song')").use { cursor ->
-                val nameIndex = cursor.getColumnIndex("name")
-                while (cursor.moveToNext()) {
-                    val colName = if (nameIndex >= 0) cursor.getString(nameIndex) else null
-                    if (colName == "isUploaded") {
-                        hasIsUploaded = true
-                        break
-                    }
-                }
-            }
-
-            if (!hasIsUploaded) {
-                db.execSQL("ALTER TABLE `song` ADD COLUMN `isUploaded` INTEGER NOT NULL DEFAULT 0")
-            }
+            addIsUploadedColumnIfMissing(db, "song")
+            addIsUploadedColumnIfMissing(db, "album")
         }
     }
 
@@ -614,21 +621,8 @@ val MIGRATION_22_24 =
     object : Migration(22, 24) {
         override fun migrate(db: SupportSQLiteDatabase) {
             // From 23→24: Add isUploaded
-            var hasIsUploaded = false
-            db.query("PRAGMA table_info('song')").use { cursor ->
-                val nameIndex = cursor.getColumnIndex("name")
-                while (cursor.moveToNext()) {
-                    val colName = if (nameIndex >= 0) cursor.getString(nameIndex) else null
-                    if (colName == "isUploaded") {
-                        hasIsUploaded = true
-                        break
-                    }
-                }
-            }
-
-            if (!hasIsUploaded) {
-                db.execSQL("ALTER TABLE `song` ADD COLUMN `isUploaded` INTEGER NOT NULL DEFAULT 0")
-            }
+            addIsUploadedColumnIfMissing(db, "song")
+            addIsUploadedColumnIfMissing(db, "album")
         }
     }
 
@@ -804,21 +798,8 @@ class Migration22To23 : AutoMigrationSpec {
 
 class Migration23To24 : AutoMigrationSpec {
     override fun onPostMigrate(db: SupportSQLiteDatabase) {
-        var hasIsUploaded = false
-        db.query("PRAGMA table_info('song')").use { cursor ->
-            val nameIndex = cursor.getColumnIndex("name")
-            while (cursor.moveToNext()) {
-                val colName = if (nameIndex >= 0) cursor.getString(nameIndex) else null
-                if (colName == "isUploaded") {
-                    hasIsUploaded = true
-                    break
-                }
-            }
-        }
-
-        if (!hasIsUploaded) {
-            db.execSQL("ALTER TABLE `song` ADD COLUMN `isUploaded` INTEGER NOT NULL DEFAULT 0")
-        }
+        addIsUploadedColumnIfMissing(db, "song")
+        addIsUploadedColumnIfMissing(db, "album")
     }
 }
 

--- a/app/src/main/kotlin/com/metrolist/music/db/MusicDatabase.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/MusicDatabase.kt
@@ -352,15 +352,17 @@ private class BackupCallback(
 
 // ===== Migrations =====
 
-private fun addIsUploadedColumnIfMissing(
+private fun addColumnIfMissing(
     db: SupportSQLiteDatabase,
     tableName: String,
+    columnName: String,
+    columnDefinition: String,
 ) {
     var columnExists = false
     db.query("PRAGMA table_info('$tableName')").use { cursor ->
         val nameIndex = cursor.getColumnIndex("name")
         while (cursor.moveToNext()) {
-            if (nameIndex >= 0 && cursor.getString(nameIndex) == "isUploaded") {
+            if (nameIndex >= 0 && cursor.getString(nameIndex) == columnName) {
                 columnExists = true
                 break
             }
@@ -368,8 +370,18 @@ private fun addIsUploadedColumnIfMissing(
     }
 
     if (!columnExists) {
-        db.execSQL("ALTER TABLE `$tableName` ADD COLUMN `isUploaded` INTEGER NOT NULL DEFAULT 0")
+        db.execSQL("ALTER TABLE `$tableName` ADD COLUMN `$columnName` $columnDefinition")
     }
+}
+
+private fun addVersion24ColumnsIfMissing(db: SupportSQLiteDatabase) {
+    addColumnIfMissing(db, "song", "libraryAddToken", "TEXT")
+    addColumnIfMissing(db, "song", "libraryRemoveToken", "TEXT")
+    addColumnIfMissing(db, "song", "romanizeLyrics", "INTEGER NOT NULL DEFAULT true")
+    addColumnIfMissing(db, "song", "isDownloaded", "INTEGER NOT NULL DEFAULT 0")
+    addColumnIfMissing(db, "song", "isUploaded", "INTEGER NOT NULL DEFAULT false")
+    addColumnIfMissing(db, "album", "isUploaded", "INTEGER NOT NULL DEFAULT false")
+    addColumnIfMissing(db, "playlist", "thumbnailUrl", "TEXT")
 }
 
 val MIGRATION_1_2 =
@@ -587,42 +599,14 @@ val MIGRATION_1_2 =
 val MIGRATION_21_24 =
     object : Migration(21, 24) {
         override fun migrate(db: SupportSQLiteDatabase) {
-            // Combine all changes from 21→22→23→24
-
-            // From 21→22: Add columns
-            try {
-                db.execSQL("ALTER TABLE song ADD COLUMN libraryAddToken TEXT DEFAULT ''")
-            } catch (e: Exception) {
-                Timber.tag("Migration").w("Column libraryAddToken may already exist")
-            }
-            try {
-                db.execSQL("ALTER TABLE song ADD COLUMN libraryRemoveToken TEXT DEFAULT ''")
-            } catch (e: Exception) {
-                Timber.tag("Migration").w("Column libraryRemoveToken may already exist")
-            }
-            try {
-                db.execSQL("ALTER TABLE song ADD COLUMN romanizeLyrics INTEGER NOT NULL DEFAULT 1")
-            } catch (e: Exception) {
-                Timber.tag("Migration").w("Column romanizeLyrics may already exist")
-            }
-            try {
-                db.execSQL("ALTER TABLE song ADD COLUMN isDownloaded INTEGER NOT NULL DEFAULT 0")
-            } catch (e: Exception) {
-                Timber.tag("Migration").w("Column isDownloaded may already exist")
-            }
-
-            // From 23→24: Add isUploaded
-            addIsUploadedColumnIfMissing(db, "song")
-            addIsUploadedColumnIfMissing(db, "album")
+            addVersion24ColumnsIfMissing(db)
         }
     }
 
 val MIGRATION_22_24 =
     object : Migration(22, 24) {
         override fun migrate(db: SupportSQLiteDatabase) {
-            // From 23→24: Add isUploaded
-            addIsUploadedColumnIfMissing(db, "song")
-            addIsUploadedColumnIfMissing(db, "album")
+            addVersion24ColumnsIfMissing(db)
         }
     }
 
@@ -798,8 +782,7 @@ class Migration22To23 : AutoMigrationSpec {
 
 class Migration23To24 : AutoMigrationSpec {
     override fun onPostMigrate(db: SupportSQLiteDatabase) {
-        addIsUploadedColumnIfMissing(db, "song")
-        addIsUploadedColumnIfMissing(db, "album")
+        addVersion24ColumnsIfMissing(db)
     }
 }
 

--- a/app/src/main/kotlin/com/metrolist/music/extensions/MediaItemExt.kt
+++ b/app/src/main/kotlin/com/metrolist/music/extensions/MediaItemExt.kt
@@ -13,79 +13,63 @@ import com.metrolist.innertube.models.SongItem
 import com.metrolist.music.db.entities.Song
 import com.metrolist.music.models.MediaMetadata
 import com.metrolist.music.models.toMediaMetadata
-import com.metrolist.music.ui.utils.resize
+import com.metrolist.music.utils.ArtistNameAliases
 
 val MediaItem.metadata: MediaMetadata?
     get() = localConfiguration?.tag as? MediaMetadata
 
-fun Song.toMediaItem() = MediaItem.Builder()
-    .setMediaId(song.id)
-    .setUri(song.id)
-    .setCustomCacheKey(song.id)
-    .setTag(toMediaMetadata())
-    .setMediaMetadata(
-        androidx.media3.common.MediaMetadata.Builder()
-            .setTitle(song.title)
-            .setSubtitle(orderedArtists.joinToString { it.name })
-            .setArtist(orderedArtists.joinToString { it.name })
-            .setArtworkUri(song.thumbnailUrl?.toUri())
-            .setAlbumTitle(song.albumName)
-            .setAlbumArtist(orderedArtists.firstOrNull()?.name)
-            .setDisplayTitle(song.title)
-            .setMediaType(MEDIA_TYPE_MUSIC)
-            .setIsBrowsable(false)
-            .setIsPlayable(true)
-            .setExtras(Bundle().apply {
-                putString("artwork_uri", song.thumbnailUrl)
-            })
-            .build()
-    )
-    .build()
+fun Song.toMediaItem() = toMediaMetadata().toMediaItem()
 
-fun SongItem.toMediaItem() = MediaItem.Builder()
-    .setMediaId(id)
-    .setUri(id)
-    .setCustomCacheKey(id)
-    .setTag(toMediaMetadata())
-    .setMediaMetadata(
-        androidx.media3.common.MediaMetadata.Builder()
-            .setTitle(title)
-            .setSubtitle(artists.joinToString { it.name })
-            .setArtist(artists.joinToString { it.name })
-            .setArtworkUri(thumbnail.resize(1080, 1080).toUri())
-            .setAlbumTitle(album?.name)
-            .setAlbumArtist(artists.firstOrNull()?.name)
-            .setDisplayTitle(title)
-            .setMediaType(MEDIA_TYPE_MUSIC)
-            .setIsBrowsable(false)
-            .setIsPlayable(true)
-            .setExtras(Bundle().apply {
-                putString("artwork_uri", thumbnail.resize(1080, 1080))
-            })
-            .build()
-    )
-    .build()
+fun SongItem.toMediaItem() = toMediaMetadata().toMediaItem()
 
-fun MediaMetadata.toMediaItem() = MediaItem.Builder()
-    .setMediaId(id)
-    .setUri(id)
-    .setCustomCacheKey(id)
-    .setTag(this)
-    .setMediaMetadata(
-        androidx.media3.common.MediaMetadata.Builder()
-            .setTitle(title)
-            .setSubtitle(artists.joinToString { it.name })
-            .setArtist(artists.joinToString { it.name })
-            .setArtworkUri(thumbnailUrl?.toUri())
-            .setAlbumTitle(album?.title)
-            .setAlbumArtist(artists.firstOrNull()?.name)
-            .setDisplayTitle(title)
-            .setMediaType(MEDIA_TYPE_MUSIC)
-            .setIsBrowsable(false)
-            .setIsPlayable(true)
-            .setExtras(Bundle().apply {
-                thumbnailUrl?.let { putString("artwork_uri", it) }
-            })
-            .build()
-    )
-    .build()
+fun MediaMetadata.toMediaItem(): MediaItem {
+    val resolvedMetadata = withResolvedArtistNameAliases()
+    val artistNames = resolvedMetadata.artists.joinToString { it.name }
+    return MediaItem.Builder()
+        .setMediaId(resolvedMetadata.id)
+        .setUri(resolvedMetadata.id)
+        .setCustomCacheKey(resolvedMetadata.id)
+        .setTag(resolvedMetadata)
+        .setMediaMetadata(
+            androidx.media3.common.MediaMetadata.Builder()
+                .setTitle(resolvedMetadata.title)
+                .setSubtitle(artistNames)
+                .setArtist(artistNames)
+                .setArtworkUri(resolvedMetadata.thumbnailUrl?.toUri())
+                .setAlbumTitle(resolvedMetadata.album?.title)
+                .setAlbumArtist(resolvedMetadata.artists.firstOrNull()?.name)
+                .setDisplayTitle(resolvedMetadata.title)
+                .setMediaType(MEDIA_TYPE_MUSIC)
+                .setIsBrowsable(false)
+                .setIsPlayable(true)
+                .setExtras(Bundle().apply {
+                    resolvedMetadata.thumbnailUrl?.let { putString("artwork_uri", it) }
+                })
+                .build(),
+        ).build()
+}
+
+fun MediaMetadata.withResolvedArtistNameAliases(): MediaMetadata {
+    val resolvedArtists =
+        artists.map { artist ->
+            artist.copy(name = ArtistNameAliases.resolve(artist.id, artist.name))
+        }
+    return if (resolvedArtists == artists) this else copy(artists = resolvedArtists)
+}
+
+fun MediaItem.withResolvedArtistNameAliases(): MediaItem {
+    val currentMetadata = metadata ?: return this
+    val resolvedMetadata = currentMetadata.withResolvedArtistNameAliases()
+    if (resolvedMetadata === currentMetadata) return this
+
+    val artistNames = resolvedMetadata.artists.joinToString { it.name }
+    return buildUpon()
+        .setTag(resolvedMetadata)
+        .setMediaMetadata(
+            mediaMetadata.buildUpon()
+                .setSubtitle(artistNames)
+                .setArtist(artistNames)
+                .setAlbumArtist(resolvedMetadata.artists.firstOrNull()?.name)
+                .build(),
+        ).build()
+}

--- a/app/src/main/kotlin/com/metrolist/music/models/MediaMetadata.kt
+++ b/app/src/main/kotlin/com/metrolist/music/models/MediaMetadata.kt
@@ -12,6 +12,7 @@ import com.metrolist.innertube.models.WatchEndpoint.WatchEndpointMusicSupportedC
 import com.metrolist.music.db.entities.Song
 import com.metrolist.music.db.entities.SongEntity
 import com.metrolist.music.ui.utils.resize
+import com.metrolist.music.utils.ArtistNameAliases
 import java.io.Serializable
 import java.time.LocalDateTime
 
@@ -90,7 +91,7 @@ fun Song.toMediaMetadata() =
         orderedArtists.map {
             MediaMetadata.Artist(
                 id = it.id,
-                name = it.name,
+                name = ArtistNameAliases.resolve(it.id, it.name),
             )
         },
         duration = song.duration,
@@ -126,7 +127,7 @@ fun SongItem.toMediaMetadata() =
         artists.map {
             MediaMetadata.Artist(
                 id = it.id,
-                name = it.name,
+                name = ArtistNameAliases.resolve(it.id, it.name),
             )
         },
         duration = duration ?: -1,
@@ -159,7 +160,7 @@ fun EpisodeItem.toMediaMetadata() =
         artists = listOfNotNull(author).map {
             MediaMetadata.Artist(
                 id = it.id,
-                name = it.name,
+                name = ArtistNameAliases.resolve(it.id, it.name),
             )
         },
         duration = duration ?: -1,

--- a/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
@@ -23,7 +23,6 @@ import androidx.media3.session.MediaSession.MediaItemsWithStartPosition
 import androidx.media3.session.SessionCommand
 import androidx.media3.session.SessionError
 import androidx.media3.session.SessionResult
-import coil3.imageLoader
 import com.google.common.collect.ImmutableList
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
@@ -183,6 +182,10 @@ constructor(
     ): ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> =
         scope.future(Dispatchers.IO) {
             try {
+                loadLocalSongChildren(parentId, page, pageSize)?.let { children ->
+                    return@future LibraryResult.ofItemList(children, params)
+                }
+
                 val children = when (parentId) {
                     MusicService.ROOT -> {
                         val sectionsRaw = context.dataStore.get(
@@ -245,11 +248,6 @@ constructor(
                             rootItems
                         }
                     }
-
-
-                    MusicService.SONG -> database.songsByCreateDateAsc().first()
-                        .map { it.toMediaItem(parentId) }
-
                     MusicService.ARTIST ->
                         database.artistsByCreateDateAsc().first().map { artist ->
                             browsableMediaItem(
@@ -356,65 +354,6 @@ constructor(
 
                     else ->
                         when {
-                            parentId.startsWith("${MusicService.ARTIST}/") ->
-                                database.artistSongsByCreateDateAsc(parentId.removePrefix("${MusicService.ARTIST}/"))
-                                    .first().map {
-                                    it.toMediaItem(parentId)
-                                }
-
-                            parentId.startsWith("${MusicService.ALBUM}/") ->
-                                database.albumSongs(parentId.removePrefix("${MusicService.ALBUM}/"))
-                                    .first().map {
-                                    it.toMediaItem(parentId)
-                                }
-
-                            parentId.startsWith("${MusicService.PLAYLIST}/") -> {
-                                val playlistId = parentId.removePrefix("${MusicService.PLAYLIST}/")
-                                val songs = when (playlistId) {
-                                    PlaylistEntity.LIKED_PLAYLIST_ID -> database.likedSongs(
-                                        SongSortType.CREATE_DATE,
-                                        true
-                                    )
-
-                                    PlaylistEntity.DOWNLOADED_PLAYLIST_ID -> {
-                                        val downloads = downloadUtil.downloads.value
-                                        database
-                                            .allSongs()
-                                            .flowOn(Dispatchers.IO)
-                                            .map { songs ->
-                                                songs.filter {
-                                                    downloads[it.id]?.state == Download.STATE_COMPLETED
-                                                }
-                                            }.map { songs ->
-                                                songs
-                                                    .map { it to downloads[it.id] }
-                                                    .sortedBy { it.second?.updateTimeMs ?: 0L }
-                                                    .map { it.first }
-                                            }
-                                    }
-
-                                    else ->
-                                        database.playlistSongs(playlistId).map { list ->
-                                            list.map { it.song }
-                                        }
-                                }.first()
-
-                                // Add shuffle item at the top
-                                listOf(
-                                    MediaItem.Builder()
-                                        .setMediaId("$parentId/${MusicService.SHUFFLE_ACTION}")
-                                        .setMediaMetadata(
-                                            MediaMetadata.Builder()
-                                                .setTitle(context.getString(R.string.shuffle))
-                                                .setArtworkUri(drawableUri(R.drawable.shuffle))
-                                                .setIsPlayable(true)
-                                                .setIsBrowsable(false)
-                                                .setMediaType(MediaMetadata.MEDIA_TYPE_MUSIC)
-                                                .build()
-                                        ).build()
-                                ) + songs.map { it.toMediaItem(parentId) }
-                            }
-
                             parentId.startsWith("${MusicService.YOUTUBE_PLAYLIST}/") -> {
                                 val playlistId = parentId.removePrefix("${MusicService.YOUTUBE_PLAYLIST}/")
                                 try {
@@ -472,6 +411,95 @@ constructor(
                 LibraryResult.ofItemList(emptyList(), params)
             }
         }
+
+    private suspend fun loadLocalSongChildren(
+        parentId: String,
+        page: Int,
+        pageSize: Int,
+    ): List<MediaItem>? {
+        val request = androidAutoPageRequest(page, pageSize)
+        return when {
+            parentId == MusicService.SONG ->
+                database.songsByCreateDateAsc(request.limit, request.offset)
+                    .map { it.toMediaItem(parentId) }
+
+            parentId.startsWith("${MusicService.ARTIST}/") ->
+                database.artistSongsByCreateDateAsc(
+                    parentId.removePrefix("${MusicService.ARTIST}/"),
+                    request.limit,
+                    request.offset,
+                ).map { it.toMediaItem(parentId) }
+
+            parentId.startsWith("${MusicService.ALBUM}/") ->
+                database.albumSongs(
+                    parentId.removePrefix("${MusicService.ALBUM}/"),
+                    request.limit,
+                    request.offset,
+                ).map { it.toMediaItem(parentId) }
+
+            parentId.startsWith("${MusicService.PLAYLIST}/") ->
+                loadPlaylistChildren(parentId, request)
+
+            else -> null
+        }
+    }
+
+    private suspend fun loadPlaylistChildren(
+        parentId: String,
+        request: AndroidAutoPageRequest,
+    ): List<MediaItem> {
+        val playlistId = parentId.removePrefix("${MusicService.PLAYLIST}/")
+        val includeShuffle = request.offset == 0 && request.limit > 0
+        val songRequest = request.afterLeadingItems(1)
+        val songs = when {
+            songRequest.limit == 0 -> emptyList()
+            playlistId == PlaylistEntity.LIKED_PLAYLIST_ID ->
+                database.likedSongsByCreateDateDesc(songRequest.limit, songRequest.offset)
+
+            playlistId == PlaylistEntity.DOWNLOADED_PLAYLIST_ID -> {
+                val downloads = downloadUtil.downloads.value
+                val completedSongIds = downloads.entries
+                    .asSequence()
+                    .filter { it.value.state == Download.STATE_COMPLETED }
+                    .sortedBy { it.value.updateTimeMs }
+                    .map { it.key }
+                    .toList()
+                val existingSongIds = completedSongIds
+                    .chunked(MAX_ANDROID_AUTO_PAGE_SIZE)
+                    .flatMapTo(mutableSetOf()) { database.existingSongIds(it) }
+                val songIds = completedSongIds.asSequence()
+                    .filter(existingSongIds::contains)
+                    .drop(songRequest.offset)
+                    .take(songRequest.limit)
+                    .toList()
+                val songsById = database.getSongsByIds(songIds).associateBy { it.id }
+                songIds.mapNotNull(songsById::get)
+            }
+
+            else ->
+                database.playlistSongs(playlistId, songRequest.limit, songRequest.offset)
+                    .map { it.song }
+        }
+
+        return buildList {
+            if (includeShuffle) {
+                add(
+                    MediaItem.Builder()
+                        .setMediaId("$parentId/${MusicService.SHUFFLE_ACTION}")
+                        .setMediaMetadata(
+                            MediaMetadata.Builder()
+                                .setTitle(context.getString(R.string.shuffle))
+                                .setArtworkUri(drawableUri(R.drawable.shuffle))
+                                .setIsPlayable(true)
+                                .setIsBrowsable(false)
+                                .setMediaType(MediaMetadata.MEDIA_TYPE_MUSIC)
+                                .build()
+                        ).build()
+                )
+            }
+            addAll(songs.map { it.toMediaItem(parentId) })
+        }
+    }
 
     override fun onGetItem(
         session: MediaLibrarySession,
@@ -860,21 +888,6 @@ constructor(
         ).build()
 
     private fun Song.toMediaItem(path: String, isPlayable: Boolean = true, isBrowsable: Boolean = false): MediaItem {
-        val artworkBytes = try {
-            song.thumbnailUrl?.let { url ->
-                context.imageLoader.enqueue(
-                    coil3.request.ImageRequest.Builder(context)
-                        .data(url)
-                        .build()
-                )
-                context.imageLoader.diskCache?.openSnapshot(url)?.use { snapshot ->
-                    snapshot.data.toFile().readBytes()
-                }
-            }
-        } catch (e: Exception) {
-            null
-        }
-
         return MediaItem
             .Builder()
             .setMediaId("$path/$id")
@@ -888,7 +901,7 @@ constructor(
                      .setArtist(artists.joinToArtistString(getArtistSeparator(context)) {
                          ArtistNameAliases.resolve(it.id, it.name)
                      })
-                     .setArtworkData(artworkBytes, MediaMetadata.PICTURE_TYPE_ILLUSTRATION)
+                     .setArtworkUri(song.thumbnailUrl?.toUri())
                     .setIsPlayable(isPlayable)
                     .setIsBrowsable(isBrowsable)
                     .setMediaType(MediaMetadata.MEDIA_TYPE_MUSIC)
@@ -916,4 +929,32 @@ internal fun <T> List<T>.paginate(
     val fromIndex = (page.toLong() * pageSize).coerceAtMost(size.toLong()).toInt()
     val toIndex = (fromIndex.toLong() + pageSize).coerceAtMost(size.toLong()).toInt()
     return subList(fromIndex, toIndex)
+}
+
+internal const val MAX_ANDROID_AUTO_PAGE_SIZE = 500
+
+internal data class AndroidAutoPageRequest(
+    val offset: Int,
+    val limit: Int,
+) {
+    fun afterLeadingItems(count: Int): AndroidAutoPageRequest {
+        val leadingItemsOnPage = (count - offset).coerceIn(0, limit)
+        return AndroidAutoPageRequest(
+            offset = (offset - count).coerceAtLeast(0),
+            limit = limit - leadingItemsOnPage,
+        )
+    }
+}
+
+internal fun androidAutoPageRequest(
+    page: Int,
+    pageSize: Int,
+): AndroidAutoPageRequest {
+    val safePage = page.coerceAtLeast(0)
+    val safePageSize = pageSize.coerceAtLeast(0)
+    val effectivePageSize = safePageSize.coerceAtMost(MAX_ANDROID_AUTO_PAGE_SIZE)
+    return AndroidAutoPageRequest(
+        offset = (safePage.toLong() * effectivePageSize).coerceAtMost(Int.MAX_VALUE.toLong()).toInt(),
+        limit = effectivePageSize,
+    )
 }

--- a/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
@@ -45,6 +45,7 @@ import com.metrolist.music.extensions.toMediaItem
 import com.metrolist.music.extensions.toggleRepeatMode
 import com.metrolist.music.models.toMediaMetadata
 import com.metrolist.music.utils.dataStore
+import com.metrolist.music.utils.ArtistNameAliases
 import com.metrolist.music.utils.get
 import com.metrolist.music.utils.getArtistSeparator
 import com.metrolist.music.utils.joinToArtistString
@@ -429,8 +430,12 @@ constructor(
                                             .setMediaMetadata(
                                                 MediaMetadata.Builder()
                                                     .setTitle(songItem.title)
-                                                    .setSubtitle(songItem.artists.joinToArtistString(getArtistSeparator(context)) { it.name })
-                                                    .setArtist(songItem.artists.joinToArtistString(getArtistSeparator(context)) { it.name })
+                                                    .setSubtitle(songItem.artists.joinToArtistString(getArtistSeparator(context)) {
+                                                        ArtistNameAliases.resolve(it.id, it.name)
+                                                    })
+                                                    .setArtist(songItem.artists.joinToArtistString(getArtistSeparator(context)) {
+                                                        ArtistNameAliases.resolve(it.id, it.name)
+                                                    })
                                                     .setArtworkUri(songItem.thumbnail.toUri())
                                                     .setIsPlayable(true)
                                                     .setIsBrowsable(false)
@@ -539,8 +544,12 @@ constructor(
                                 .setMediaMetadata(
                                     MediaMetadata.Builder()
                                         .setTitle(songItem.title)
-                                        .setSubtitle(songItem.artists.joinToArtistString(getArtistSeparator(context)) { it.name })
-                                        .setArtist(songItem.artists.joinToArtistString(getArtistSeparator(context)) { it.name })
+                                        .setSubtitle(songItem.artists.joinToArtistString(getArtistSeparator(context)) {
+                                            ArtistNameAliases.resolve(it.id, it.name)
+                                        })
+                                        .setArtist(songItem.artists.joinToArtistString(getArtistSeparator(context)) {
+                                            ArtistNameAliases.resolve(it.id, it.name)
+                                        })
                                         .setArtworkUri(songItem.thumbnail.toUri())
                                         .setIsPlayable(true)
                                         .setIsBrowsable(true)
@@ -861,8 +870,12 @@ constructor(
                  MediaMetadata
                      .Builder()
                      .setTitle(song.title)
-                     .setSubtitle(artists.joinToArtistString(getArtistSeparator(context)) { it.name })
-                     .setArtist(artists.joinToArtistString(getArtistSeparator(context)) { it.name })
+                     .setSubtitle(artists.joinToArtistString(getArtistSeparator(context)) {
+                         ArtistNameAliases.resolve(it.id, it.name)
+                     })
+                     .setArtist(artists.joinToArtistString(getArtistSeparator(context)) {
+                         ArtistNameAliases.resolve(it.id, it.name)
+                     })
                      .setArtworkData(artworkBytes, MediaMetadata.PICTURE_TYPE_ILLUSTRATION)
                     .setIsPlayable(isPlayable)
                     .setIsBrowsable(isBrowsable)

--- a/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
@@ -182,7 +182,7 @@ constructor(
     ): ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> =
         scope.future(Dispatchers.IO) {
             try {
-                loadLocalSongChildren(parentId, page, pageSize)?.let { children ->
+                loadLocalChildren(parentId, page, pageSize)?.let { children ->
                     return@future LibraryResult.ofItemList(children, params)
                 }
 
@@ -248,64 +248,6 @@ constructor(
                             rootItems
                         }
                     }
-                    MusicService.ARTIST ->
-                        database.artistsByCreateDateAsc().first().map { artist ->
-                            browsableMediaItem(
-                                "${MusicService.ARTIST}/${artist.id}",
-                                artist.artist.name,
-                                context.resources.getQuantityString(
-                                    R.plurals.n_song,
-                                    artist.songCount,
-                                    artist.songCount
-                                ),
-                                artist.artist.thumbnailUrl?.toUri(),
-                                MediaMetadata.MEDIA_TYPE_ARTIST,
-                            )
-                        }
-
-                    MusicService.ALBUM ->
-                        database.albumsByCreateDateAsc().first().map { album ->
-                            browsableMediaItem(
-                                "${MusicService.ALBUM}/${album.id}",
-                                album.album.title,
-                                album.artists.joinToString {
-                                    it.name
-                                },
-                                album.album.thumbnailUrl?.toUri(),
-                                MediaMetadata.MEDIA_TYPE_ALBUM,
-                            )
-                        }
-
-                    MusicService.PLAYLIST -> {
-                        val likedSongCount = database.likedSongsCount().first()
-                        val downloadedSongCount = downloadUtil.downloads.value.size
-
-                        listOf(
-                            browsableMediaItem(
-                                "${MusicService.PLAYLIST}/${PlaylistEntity.LIKED_PLAYLIST_ID}",
-                                context.getString(R.string.liked_songs),
-                                context.resources.getQuantityString(R.plurals.n_song, likedSongCount, likedSongCount),
-                                drawableUri(R.drawable.favorite),
-                                MediaMetadata.MEDIA_TYPE_PLAYLIST,
-                            ),
-                            browsableMediaItem(
-                                "${MusicService.PLAYLIST}/${PlaylistEntity.DOWNLOADED_PLAYLIST_ID}",
-                                context.getString(R.string.downloaded_songs),
-                                context.resources.getQuantityString(R.plurals.n_song, downloadedSongCount, downloadedSongCount),
-                                drawableUri(R.drawable.download),
-                                MediaMetadata.MEDIA_TYPE_PLAYLIST,
-                            ),
-                        ) + database.playlistsByCreateDateAsc().first().map { playlist ->
-                            browsableMediaItem(
-                                "${MusicService.PLAYLIST}/${playlist.id}",
-                                playlist.playlist.name,
-                                context.resources.getQuantityString(R.plurals.n_song, playlist.songCount, playlist.songCount),
-                                playlist.thumbnails.firstOrNull()?.toUri(),
-                                MediaMetadata.MEDIA_TYPE_PLAYLIST,
-                            )
-                        }
-                    }
-
                     MusicService.YOUTUBE_PLAYLIST -> {
                         if (!context.dataStore.get(AndroidAutoYouTubePlaylistsKey, false)) {
                             emptyList()
@@ -326,9 +268,7 @@ constructor(
 
                                 // Drop playlists already saved to the local library,
                                 // which are exposed under MusicService.PLAYLIST.
-                                val savedBrowseIds = database.playlistsByCreateDateAsc()
-                                    .first()
-                                    .mapNotNullTo(mutableSetOf()) { it.playlist.browseId }
+                                val savedBrowseIds = database.bookmarkedPlaylistBrowseIds().toSet()
 
                                 val playlists = allSections
                                     .flatMap { it.items }
@@ -412,13 +352,44 @@ constructor(
             }
         }
 
-    private suspend fun loadLocalSongChildren(
+    private suspend fun loadLocalChildren(
         parentId: String,
         page: Int,
         pageSize: Int,
     ): List<MediaItem>? {
         val request = androidAutoPageRequest(page, pageSize)
         return when {
+            parentId == MusicService.ARTIST ->
+                database.artistsByCreateDateAsc(request.limit, request.offset).map { artist ->
+                    browsableMediaItem(
+                        "${MusicService.ARTIST}/${artist.id}",
+                        ArtistNameAliases.resolve(artist.id, artist.artist.name),
+                        context.resources.getQuantityString(
+                            R.plurals.n_song,
+                            artist.songCount,
+                            artist.songCount,
+                        ),
+                        artist.artist.thumbnailUrl?.toUri(),
+                        MediaMetadata.MEDIA_TYPE_ARTIST,
+                    )
+                }
+
+            parentId == MusicService.ALBUM ->
+                database.albumsByCreateDateAsc(request.limit, request.offset).map { album ->
+                    browsableMediaItem(
+                        "${MusicService.ALBUM}/${album.id}",
+                        album.album.title,
+                        album.artists.joinToString {
+                            ArtistNameAliases.resolve(it.id, it.name)
+                        },
+                        album.album.thumbnailUrl?.toUri(),
+                        MediaMetadata.MEDIA_TYPE_ALBUM,
+                    )
+                }
+
+            parentId == MusicService.PLAYLIST ->
+                loadPlaylistContainers(request)
+
             parentId == MusicService.SONG ->
                 database.songsByCreateDateAsc(request.limit, request.offset)
                     .map { it.toMediaItem(parentId) }
@@ -441,6 +412,52 @@ constructor(
                 loadPlaylistChildren(parentId, request)
 
             else -> null
+        }
+    }
+
+    private suspend fun loadPlaylistContainers(request: AndroidAutoPageRequest): List<MediaItem> {
+        val builtInItems =
+            if (request.offset < 2 && request.limit > 0) {
+                val likedSongCount = database.likedSongsCount().first()
+                val downloadedSongCount = downloadUtil.downloads.value.size
+                listOf(
+                    browsableMediaItem(
+                        "${MusicService.PLAYLIST}/${PlaylistEntity.LIKED_PLAYLIST_ID}",
+                        context.getString(R.string.liked_songs),
+                        context.resources.getQuantityString(R.plurals.n_song, likedSongCount, likedSongCount),
+                        drawableUri(R.drawable.favorite),
+                        MediaMetadata.MEDIA_TYPE_PLAYLIST,
+                    ),
+                    browsableMediaItem(
+                        "${MusicService.PLAYLIST}/${PlaylistEntity.DOWNLOADED_PLAYLIST_ID}",
+                        context.getString(R.string.downloaded_songs),
+                        context.resources.getQuantityString(
+                            R.plurals.n_song,
+                            downloadedSongCount,
+                            downloadedSongCount,
+                        ),
+                        drawableUri(R.drawable.download),
+                        MediaMetadata.MEDIA_TYPE_PLAYLIST,
+                    ),
+                ).drop(request.offset).take(request.limit)
+            } else {
+                emptyList()
+            }
+        val playlistRequest = request.afterLeadingItems(2)
+        val playlists =
+            if (playlistRequest.limit == 0) {
+                emptyList()
+            } else {
+                database.playlistsByCreateDateAsc(playlistRequest.limit, playlistRequest.offset)
+            }
+        return builtInItems + playlists.map { playlist ->
+            browsableMediaItem(
+                "${MusicService.PLAYLIST}/${playlist.id}",
+                playlist.playlist.name,
+                context.resources.getQuantityString(R.plurals.n_song, playlist.songCount, playlist.songCount),
+                playlist.thumbnails.firstOrNull()?.toUri(),
+                MediaMetadata.MEDIA_TYPE_PLAYLIST,
+            )
         }
     }
 

--- a/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
@@ -151,12 +151,26 @@ constructor(
                         MediaMetadata
                             .Builder()
                             .setIsPlayable(false)
-                            .setIsBrowsable(false)
+                            .setIsBrowsable(true)
                             .setMediaType(MediaMetadata.MEDIA_TYPE_FOLDER_MIXED)
                             .build(),
                     ).build(),
                 params,
             ),
+        )
+
+    override fun onSubscribe(
+        session: MediaLibrarySession,
+        browser: MediaSession.ControllerInfo,
+        parentId: String,
+        params: MediaLibraryService.LibraryParams?,
+    ): ListenableFuture<LibraryResult<Void>> =
+        Futures.immediateFuture(
+            if (isBrowsableMediaId(parentId)) {
+                LibraryResult.ofVoid(params)
+            } else {
+                LibraryResult.ofError(SessionError.ERROR_BAD_VALUE, params)
+            },
         )
 
     override fun onGetChildren(
@@ -169,8 +183,7 @@ constructor(
     ): ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> =
         scope.future(Dispatchers.IO) {
             try {
-            LibraryResult.ofItemList(
-                when (parentId) {
+                val children = when (parentId) {
                     MusicService.ROOT -> {
                         val sectionsRaw = context.dataStore.get(
                             AndroidAutoSectionsOrderKey,
@@ -452,9 +465,8 @@ constructor(
 
                             else -> emptyList()
                         }
-                },
-                params,
-            )
+                }
+                LibraryResult.ofItemList(children.paginate(page, pageSize), params)
             } catch (e: Exception) {
                 reportException(e)
                 LibraryResult.ofItemList(emptyList(), params)
@@ -509,7 +521,7 @@ constructor(
                     searchResults.add(song.toMediaItem(
                         path = "${MusicService.SEARCH}/$query",
                         isPlayable = true,
-                        isBrowsable = true
+                        isBrowsable = false,
                     ))
                 }
 
@@ -552,7 +564,7 @@ constructor(
                                         })
                                         .setArtworkUri(songItem.thumbnail.toUri())
                                         .setIsPlayable(true)
-                                        .setIsBrowsable(true)
+                                        .setIsBrowsable(false)
                                         .setMediaType(MediaMetadata.MEDIA_TYPE_MUSIC)
                                         .build()
                                 )
@@ -883,4 +895,25 @@ constructor(
                     .build(),
             ).build()
     }
+}
+
+internal fun isBrowsableMediaId(mediaId: String): Boolean =
+    mediaId == MusicService.ROOT ||
+        mediaId == MusicService.SONG ||
+        mediaId == MusicService.ARTIST ||
+        mediaId == MusicService.ALBUM ||
+        mediaId == MusicService.PLAYLIST ||
+        mediaId == MusicService.YOUTUBE_PLAYLIST ||
+        mediaId.startsWith("${MusicService.ARTIST}/") ||
+        mediaId.startsWith("${MusicService.ALBUM}/") ||
+        mediaId.startsWith("${MusicService.PLAYLIST}/") ||
+        mediaId.startsWith("${MusicService.YOUTUBE_PLAYLIST}/")
+
+internal fun <T> List<T>.paginate(
+    page: Int,
+    pageSize: Int,
+): List<T> {
+    val fromIndex = (page.toLong() * pageSize).coerceAtMost(size.toLong()).toInt()
+    val toIndex = (fromIndex.toLong() + pageSize).coerceAtMost(size.toLong()).toInt()
+    return subList(fromIndex, toIndex)
 }

--- a/app/src/main/kotlin/com/metrolist/music/playback/PlayerConnection.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/PlayerConnection.kt
@@ -29,6 +29,7 @@ import com.metrolist.music.extensions.getCurrentQueueIndex
 import com.metrolist.music.extensions.getQueueWindows
 import com.metrolist.music.extensions.metadata
 import com.metrolist.music.extensions.togglePlayPause
+import com.metrolist.music.extensions.withResolvedArtistNameAliases
 import com.metrolist.music.playback.MusicService.MusicBinder
 import com.metrolist.music.playback.queues.Queue
 import com.metrolist.music.utils.dataStore
@@ -251,6 +252,18 @@ class PlayerConnection(
             Timber.tag(TAG).e(e, "Error in playQueue")
             throw e
         }
+    }
+
+    fun refreshArtistNameAliases() {
+        val player = getPlayerOrNull() ?: return
+        repeat(player.mediaItemCount) { index ->
+            val mediaItem = player.getMediaItemAt(index)
+            val resolvedMediaItem = mediaItem.withResolvedArtistNameAliases()
+            if (resolvedMediaItem !== mediaItem) {
+                player.replaceMediaItem(index, resolvedMediaItem)
+            }
+        }
+        mediaMetadata.value = player.currentMetadata
     }
 
     fun startRadioSeamlessly() {

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
@@ -98,6 +98,7 @@ import com.metrolist.innertube.models.PodcastItem
 import com.metrolist.innertube.models.SongItem
 import com.metrolist.innertube.models.YTItem
 import com.metrolist.music.LocalDatabase
+import com.metrolist.music.LocalArtistNameAliases
 import com.metrolist.music.LocalDownloadUtil
 import com.metrolist.music.LocalNavController
 import com.metrolist.music.LocalPlayerConnection
@@ -123,6 +124,7 @@ import com.metrolist.music.ui.utils.resize
 import com.metrolist.music.utils.joinByBullet
 import com.metrolist.music.utils.joinToArtistString
 import com.metrolist.music.utils.makeTimeString
+import com.metrolist.music.utils.ArtistNameAliases
 import com.metrolist.music.utils.rememberEnumPreference
 import com.metrolist.music.utils.rememberPreference
 import com.metrolist.music.utils.reportException
@@ -155,7 +157,8 @@ fun ClickableArtistText(
 ) {
     val navController = LocalNavController.current
     val andString = stringResource(R.string.and)
-    val annotatedString = remember(artists, andString, color) {
+    val artistNameAliases = LocalArtistNameAliases.current
+    val annotatedString = remember(artists, andString, color, artistNameAliases) {
         buildAnnotatedString {
             artists.forEachIndexed { index, artist ->
                 withLink(
@@ -166,7 +169,7 @@ fun ClickableArtistText(
                         navController.navigate("artist/${artist.id}")
                     }
                 ) {
-                    append(artist.name)
+                    append(ArtistNameAliases.resolve(artistNameAliases, artist.id, artist.name))
                 }
                 if (index != artists.lastIndex) {
                     if (index == artists.lastIndex - 1) {
@@ -199,7 +202,8 @@ fun ClickableArtistText(
 ) {
     val navController = LocalNavController.current
     val andString = stringResource(R.string.and)
-    val annotatedString = remember(artists, andString, color) {
+    val artistNameAliases = LocalArtistNameAliases.current
+    val annotatedString = remember(artists, andString, color, artistNameAliases) {
         buildAnnotatedString {
             artists.forEachIndexed { index, artist ->
                 val artistId = artist.id
@@ -212,7 +216,7 @@ fun ClickableArtistText(
                             navController.navigate("artist/$artistId")
                         }
                     ) {
-                        append(artist.name)
+                        append(ArtistNameAliases.resolve(artistNameAliases, artistId, artist.name))
                     }
                 } else {
                     append(artist.name)
@@ -248,7 +252,8 @@ fun ClickableArtistText(
 ) {
     val navController = LocalNavController.current
     val andString = stringResource(R.string.and)
-    val annotatedString = remember(artists, andString, color) {
+    val artistNameAliases = LocalArtistNameAliases.current
+    val annotatedString = remember(artists, andString, color, artistNameAliases) {
         buildAnnotatedString {
             artists.forEachIndexed { index, artist ->
                 val artistId = artist.id
@@ -261,7 +266,7 @@ fun ClickableArtistText(
                             navController.navigate("artist/$artistId")
                         }
                     ) {
-                        append(artist.name)
+                        append(ArtistNameAliases.resolve(artistNameAliases, artistId, artist.name))
                     }
                 } else {
                     append(artist.name)
@@ -547,6 +552,7 @@ fun SongListItem(
     isSwipeable: Boolean = true,
     trailingContent: @Composable RowScope.() -> Unit = {},
 ) {
+    val artistNameAliases = LocalArtistNameAliases.current
     val swipeEnabled by rememberPreference(SwipeToSongKey, defaultValue = false)
 
     val content: @Composable () -> Unit = {
@@ -556,8 +562,10 @@ fun SongListItem(
                   badges()
                   if (subtitleOverride == null) {
                       Text(
-                          text = joinByBullet(
-                              song.orderedArtists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name },
+                           text = joinByBullet(
+                               song.orderedArtists.joinToArtistString(" ${stringResource(R.string.and)} ") {
+                                   ArtistNameAliases.resolve(artistNameAliases, it.id, it.name)
+                               },
                               makeTimeString(song.song.duration * 1000L)
                           ),
                           style = MaterialTheme.typography.bodySmall,
@@ -639,9 +647,12 @@ fun SongGridItem(
         )
     },
     subtitle = {
+        val artistNameAliases = LocalArtistNameAliases.current
         Text(
             text = joinByBullet(
-                song.orderedArtists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name },
+                song.orderedArtists.joinToArtistString(" ${stringResource(R.string.and)} ") {
+                    ArtistNameAliases.resolve(artistNameAliases, it.id, it.name)
+                },
                 makeTimeString(song.song.duration * 1000L)
             ),
             style = MaterialTheme.typography.bodyMedium,
@@ -1101,6 +1112,7 @@ fun MediaMetadataListItem(
     isPlaying: Boolean = false,
     trailingContent: @Composable RowScope.() -> Unit = {},
 ) {
+    val artistNameAliases = LocalArtistNameAliases.current
     ListItem(
         title = mediaMetadata.title,
         subtitle = {
@@ -1108,7 +1120,9 @@ fun MediaMetadataListItem(
             Text(
                 text = buildAnnotatedString {
                     val base = joinByBullet(
-                        mediaMetadata.artists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name },
+                        mediaMetadata.artists.joinToArtistString(" ${stringResource(R.string.and)} ") {
+                            ArtistNameAliases.resolve(artistNameAliases, it.id, it.name)
+                        },
                         makeTimeString(mediaMetadata.duration * 1000L)
                     )
                     append(base)
@@ -1177,17 +1191,52 @@ fun YouTubeListItem(
     },
 ) {
     val swipeEnabled by rememberPreference(SwipeToSongKey, defaultValue = false)
+    val artistNameAliases = LocalArtistNameAliases.current
+    val artistSeparator = " ${stringResource(R.string.and)} "
 
     val content: @Composable () -> Unit = {
         ListItem(
-            title = item.title,
+            title =
+                if (item is ArtistItem) {
+                    ArtistNameAliases.resolve(artistNameAliases, item.id, item.title)
+                } else {
+                    item.title
+                },
             subtitle = when (item) {
-                is SongItem -> joinByBullet(item.artists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name }, makeTimeString(item.duration?.times(1000L)))
-                is AlbumItem -> joinByBullet(item.artists?.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name }, item.year?.toString())
+                is SongItem ->
+                    joinByBullet(
+                        item.artists.joinToArtistString(artistSeparator) {
+                            ArtistNameAliases.resolve(artistNameAliases, it.id, it.name)
+                        },
+                        makeTimeString(item.duration?.times(1000L)),
+                    )
+
+                is AlbumItem ->
+                    joinByBullet(
+                        item.artists?.joinToArtistString(artistSeparator) {
+                            ArtistNameAliases.resolve(artistNameAliases, it.id, it.name)
+                        },
+                        item.year?.toString(),
+                    )
+
                 is ArtistItem -> null
-                is PlaylistItem -> joinByBullet(item.author?.name, item.songCountText)
-                is PodcastItem -> joinByBullet(item.author?.name, item.episodeCountText)
-                is EpisodeItem -> joinByBullet(item.author?.name, makeTimeString(item.duration?.times(1000L)))
+                is PlaylistItem ->
+                    joinByBullet(
+                        item.author?.let { ArtistNameAliases.resolve(artistNameAliases, it.id, it.name) },
+                        item.songCountText,
+                    )
+
+                is PodcastItem ->
+                    joinByBullet(
+                        item.author?.let { ArtistNameAliases.resolve(artistNameAliases, it.id, it.name) },
+                        item.episodeCountText,
+                    )
+
+                is EpisodeItem ->
+                    joinByBullet(
+                        item.author?.let { ArtistNameAliases.resolve(artistNameAliases, it.id, it.name) },
+                        makeTimeString(item.duration?.times(1000L)),
+                    )
             },
             badges = badges,
             thumbnailContent = {
@@ -1252,7 +1301,11 @@ fun YouTubeGridItem(
 ) = GridItem(
     title = {
         Text(
-            text = item.title,
+            text = if (item is ArtistItem) {
+                ArtistNameAliases.resolve(LocalArtistNameAliases.current, item.id, item.title)
+            } else {
+                item.title
+            },
             style = MaterialTheme.typography.bodyLarge,
             fontWeight = FontWeight.Bold,
             maxLines = 1,
@@ -1262,13 +1315,15 @@ fun YouTubeGridItem(
         )
     },
      subtitle = {
+         val artistNameAliases = LocalArtistNameAliases.current
+         val artistSeparator = " ${stringResource(R.string.and)} "
          val subtitle = when (item) {
-             is SongItem -> joinByBullet(item.artists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name }, makeTimeString(item.duration?.times(1000L)))
-             is AlbumItem -> joinByBullet(item.artists?.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name }, item.year?.toString())
+             is SongItem -> joinByBullet(item.artists.joinToArtistString(artistSeparator) { ArtistNameAliases.resolve(artistNameAliases, it.id, it.name) }, makeTimeString(item.duration?.times(1000L)))
+             is AlbumItem -> joinByBullet(item.artists?.joinToArtistString(artistSeparator) { ArtistNameAliases.resolve(artistNameAliases, it.id, it.name) }, item.year?.toString())
             is ArtistItem -> null
-            is PlaylistItem -> joinByBullet(item.author?.name, item.songCountText)
-            is PodcastItem -> joinByBullet(item.author?.name, item.episodeCountText)
-            is EpisodeItem -> joinByBullet(item.author?.name, makeTimeString(item.duration?.times(1000L)))
+            is PlaylistItem -> joinByBullet(item.author?.let { ArtistNameAliases.resolve(artistNameAliases, it.id, it.name) }, item.songCountText)
+            is PodcastItem -> joinByBullet(item.author?.let { ArtistNameAliases.resolve(artistNameAliases, it.id, it.name) }, item.episodeCountText)
+            is EpisodeItem -> joinByBullet(item.author?.let { ArtistNameAliases.resolve(artistNameAliases, it.id, it.name) }, makeTimeString(item.duration?.times(1000L)))
         }
         if (subtitle != null) {
             Text(

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
@@ -219,7 +219,7 @@ fun ClickableArtistText(
                         append(ArtistNameAliases.resolve(artistNameAliases, artistId, artist.name))
                     }
                 } else {
-                    append(artist.name)
+                    append(ArtistNameAliases.resolve(artistNameAliases, null, artist.name))
                 }
                 if (index != artists.lastIndex) {
                     if (index == artists.lastIndex - 1) {
@@ -269,7 +269,7 @@ fun ClickableArtistText(
                         append(ArtistNameAliases.resolve(artistNameAliases, artistId, artist.name))
                     }
                 } else {
-                    append(artist.name)
+                    append(ArtistNameAliases.resolve(artistNameAliases, null, artist.name))
                 }
                 if (index != artists.lastIndex) {
                     if (index == artists.lastIndex - 1) {

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/SongMenu.kt
@@ -96,6 +96,7 @@ import com.metrolist.music.ui.component.NewActionGrid
 import com.metrolist.music.ui.component.SongListItem
 import com.metrolist.music.ui.component.TextFieldDialog
 import com.metrolist.music.ui.utils.ShowMediaInfo
+import com.metrolist.music.utils.ArtistNameAliases
 import com.metrolist.music.viewmodels.CachePlaylistViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -211,13 +212,17 @@ fun SongMenu(
                 val newArtist = values[1]
 
                 coroutineScope.launch {
+                    val artist = song.artists.firstOrNull()
+                    if (artist != null) {
+                        ArtistNameAliases.set(context, artist.id, artist.channelId, artist.name, newArtist)
+                    }
                     database.query {
                         update(song.song.copy(title = newTitle))
-                        val artist = song.artists.firstOrNull()
                         if (artist != null) {
-                            update(artist.copy(name = newArtist))
+                            renameArtist(artist.id, artist.channelId, artist.name, newArtist)
                         }
                     }
+                    playerConnection.refreshArtistNameAliases()
 
                     showEditDialog = false
                     onDismiss()

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeAlbumMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeAlbumMenu.kt
@@ -60,6 +60,7 @@ import com.metrolist.innertube.YouTube
 import com.metrolist.music.LocalNavController
 import com.metrolist.innertube.models.AlbumItem
 import com.metrolist.music.LocalDatabase
+import com.metrolist.music.LocalArtistNameAliases
 import com.metrolist.music.LocalDownloadUtil
 import com.metrolist.music.LocalListenTogetherManager
 import com.metrolist.music.LocalPlayerConnection
@@ -78,6 +79,7 @@ import com.metrolist.music.ui.component.NewAction
 import com.metrolist.music.ui.component.NewActionGrid
 import com.metrolist.music.ui.component.SongListItem
 import com.metrolist.music.ui.component.YouTubeListItem
+import com.metrolist.music.utils.ArtistNameAliases
 import com.metrolist.music.utils.reportException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -98,6 +100,7 @@ fun YouTubeAlbumMenu(
     val isGuest = listenTogetherManager?.isInRoom == true && !listenTogetherManager.isHost
     val album by database.albumWithSongs(albumItem.id).collectAsStateWithLifecycle(initialValue = null)
     val isPinned by database.speedDialDao.isPinned(albumItem.id).collectAsStateWithLifecycle(initialValue = false)
+    val artistNameAliases = LocalArtistNameAliases.current
     val coroutineScope = rememberCoroutineScope()
 
     LaunchedEffect(Unit) {
@@ -231,7 +234,7 @@ fun YouTubeAlbumMenu(
                                 }.padding(horizontal = 24.dp),
                     ) {
                         Text(
-                            text = artist.name,
+                            text = ArtistNameAliases.resolve(artistNameAliases, artist.id, artist.name),
                             fontSize = 18.sp,
                             fontWeight = FontWeight.Bold,
                             maxLines = 1,
@@ -533,7 +536,13 @@ fun YouTubeAlbumMenu(
                         listOf(
                             Material3MenuItemData(
                                 title = { Text(text = stringResource(R.string.view_artist)) },
-                                description = { Text(text = artists.joinToString { it.name }) },
+                                description = {
+                                    Text(
+                                        text = artists.joinToString {
+                                            ArtistNameAliases.resolve(artistNameAliases, it.id, it.name)
+                                        },
+                                    )
+                                },
                                 icon = {
                                     Icon(
                                         painter = painterResource(R.drawable.artist),

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeArtistMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeArtistMenu.kt
@@ -43,6 +43,7 @@ import com.metrolist.music.ui.component.Material3MenuItemData
 import com.metrolist.music.ui.component.NewAction
 import com.metrolist.music.ui.component.NewActionGrid
 import com.metrolist.music.ui.component.YouTubeListItem
+import com.metrolist.music.utils.ArtistNameAliases
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import androidx.compose.runtime.rememberCoroutineScope
@@ -188,7 +189,7 @@ fun YouTubeArtistMenu(
                                     insert(
                                         ArtistEntity(
                                             id = artist.id,
-                                            name = artist.title,
+                                            name = ArtistNameAliases.resolve(artist.id, artist.title),
                                             channelId = artist.channelId,
                                             thumbnailUrl = artist.thumbnail,
                                         ).toggleLike()

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubePlaylistMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubePlaylistMenu.kt
@@ -62,6 +62,7 @@ import com.metrolist.innertube.models.PlaylistItem
 import com.metrolist.innertube.models.SongItem
 import com.metrolist.innertube.utils.completed
 import com.metrolist.music.LocalDatabase
+import com.metrolist.music.LocalArtistNameAliases
 import com.metrolist.music.LocalDownloadUtil
 import com.metrolist.music.LocalListenTogetherManager
 import com.metrolist.music.LocalPlayerConnection
@@ -84,6 +85,7 @@ import com.metrolist.music.ui.component.NewAction
 import com.metrolist.music.ui.component.NewActionGrid
 import com.metrolist.music.ui.component.YouTubeListItem
 import com.metrolist.music.ui.utils.resize
+import com.metrolist.music.utils.ArtistNameAliases
 import com.metrolist.music.utils.exportYouTubePlaylistAsCSV
 import com.metrolist.music.utils.exportYouTubePlaylistAsM3U
 import com.metrolist.music.utils.getExportFileUri
@@ -115,6 +117,7 @@ fun YouTubePlaylistMenu(
     val isGuest = listenTogetherManager?.isInRoom == true && !listenTogetherManager.isHost
     val dbPlaylist by database.playlistByBrowseId(playlist.id).collectAsStateWithLifecycle(initialValue = null)
     val isPinned by database.speedDialDao.isPinned(playlist.id).collectAsStateWithLifecycle(initialValue = false)
+    val artistNameAliases = LocalArtistNameAliases.current
 
     var showChoosePlaylistDialog by rememberSaveable { mutableStateOf(false) }
     var showImportPlaylistDialog by rememberSaveable { mutableStateOf(false) }
@@ -384,7 +387,9 @@ fun YouTubePlaylistMenu(
                         Text(
                             text =
                                 joinByBullet(
-                                    song.artists.joinToString { it.name },
+                                    song.artists.joinToString {
+                                        ArtistNameAliases.resolve(artistNameAliases, it.id, it.name)
+                                    },
                                     makeTimeString(song.duration * 1000L),
                                 ),
                         )

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeSongMenu.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/YouTubeSongMenu.kt
@@ -60,6 +60,7 @@ import com.metrolist.innertube.YouTube
 import com.metrolist.music.LocalNavController
 import com.metrolist.innertube.models.SongItem
 import com.metrolist.music.LocalDatabase
+import com.metrolist.music.LocalArtistNameAliases
 import com.metrolist.music.LocalDownloadUtil
 import com.metrolist.music.LocalListenTogetherManager
 import com.metrolist.music.LocalPlayerConnection
@@ -83,6 +84,7 @@ import com.metrolist.music.ui.component.NewAction
 import com.metrolist.music.ui.component.NewActionGrid
 import com.metrolist.music.ui.utils.ShowMediaInfo
 import com.metrolist.music.ui.utils.resize
+import com.metrolist.music.utils.ArtistNameAliases
 import com.metrolist.music.utils.joinByBullet
 import com.metrolist.music.utils.makeTimeString
 import kotlinx.coroutines.Dispatchers
@@ -109,10 +111,14 @@ fun YouTubeSongMenu(
     val syncUtils = LocalSyncUtils.current
     val listenTogetherManager = LocalListenTogetherManager.current
     val isPinned by database.speedDialDao.isPinned(song.id).collectAsStateWithLifecycle(initialValue = false)
-    val artists = remember {
+    val artistNameAliases = LocalArtistNameAliases.current
+    val artists = remember(song.artists, artistNameAliases) {
         song.artists.mapNotNull {
             it.id?.let { artistId ->
-                MediaMetadata.Artist(id = artistId, name = it.name)
+                MediaMetadata.Artist(
+                    id = artistId,
+                    name = ArtistNameAliases.resolve(artistNameAliases, artistId, it.name),
+                )
             }
         }
     }
@@ -197,7 +203,9 @@ fun YouTubeSongMenu(
         supportingContent = {  
             Text(  
                 text = joinByBullet(
-                    song.artists.joinToString { it.name },
+                    song.artists.joinToString {
+                        ArtistNameAliases.resolve(artistNameAliases, it.id, it.name)
+                    },
                     song.duration?.let { makeTimeString(it * 1000L) },
                 )
             )  
@@ -659,7 +667,13 @@ fun YouTubeSongMenu(
                         add(
                             Material3MenuItemData(
                                 title = { Text(text = stringResource(R.string.view_artist)) },
-                                description = { Text(text = song.artists.joinToString { it.name }) },
+                                description = {
+                                    Text(
+                                        text = song.artists.joinToString {
+                                            ArtistNameAliases.resolve(artistNameAliases, it.id, it.name)
+                                        },
+                                    )
+                                },
                                 icon = {
                                     Icon(
                                         painter = painterResource(R.drawable.artist),

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
@@ -106,6 +106,7 @@ import com.metrolist.innertube.models.YTItem
 import com.metrolist.innertube.utils.completed
 import com.metrolist.innertube.utils.parseCookieString
 import com.metrolist.music.LocalDatabase
+import com.metrolist.music.LocalArtistNameAliases
 import com.metrolist.music.LocalListenTogetherManager
 import com.metrolist.music.LocalPlayerAwareWindowInsets
 import com.metrolist.music.LocalPlayerConnection
@@ -160,6 +161,7 @@ import com.metrolist.music.ui.utils.SnapLayoutInfoProvider
 import com.metrolist.music.ui.utils.resize
 import com.metrolist.music.utils.joinByBullet
 import com.metrolist.music.utils.joinToArtistString
+import com.metrolist.music.utils.ArtistNameAliases
 import com.metrolist.music.utils.makeTimeString
 import com.metrolist.music.utils.rememberEnumPreference
 import com.metrolist.music.utils.rememberPreference
@@ -214,6 +216,7 @@ fun CommunityPlaylistCard(
     val isListenTogetherGuest = listenTogetherManager?.let { it.isInRoom && !it.isHost } ?: false
     val scope = rememberCoroutineScope()
     val isDark = isSystemInDarkTheme()
+    val artistNameAliases = LocalArtistNameAliases.current
 
     val containerColor =
         if (isDark) {
@@ -326,7 +329,10 @@ fun CommunityPlaylistCard(
                     )
                     Spacer(modifier = Modifier.height(4.dp))
                     Text(
-                        text = item.playlist.author?.name ?: "",
+                        text =
+                            item.playlist.author?.let {
+                                ArtistNameAliases.resolve(artistNameAliases, it.id, it.name)
+                            }.orEmpty(),
                         style = MaterialTheme.typography.bodyMedium,
                         color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f),
                         maxLines = 1,
@@ -369,7 +375,9 @@ fun CommunityPlaylistCard(
                                 overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
                             )
                             Text(
-                                text = song.artists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name },
+                                text = song.artists.joinToArtistString(" ${stringResource(R.string.and)} ") {
+                                    ArtistNameAliases.resolve(artistNameAliases, it.id, it.name)
+                                },
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f),
                                 maxLines = 1,
@@ -505,6 +513,7 @@ fun DailyDiscoverCard(
     val playCount by database.getLifetimePlayCount(dailyDiscover.recommendation.id).collectAsStateWithLifecycle(initialValue = 0)
     val menuState = LocalMenuState.current
     val haptic = LocalHapticFeedback.current
+    val artistNameAliases = LocalArtistNameAliases.current
 
     val song = dailyDiscover.recommendation as? SongItem
     val playsString = stringResource(R.string.plays)
@@ -584,7 +593,13 @@ fun DailyDiscoverCard(
                         Text(
                             text =
                                 buildString {
-                                    append((dailyDiscover.recommendation as? SongItem)?.artists?.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name } ?: "")
+                                    append(
+                                        (dailyDiscover.recommendation as? SongItem)
+                                            ?.artists
+                                            ?.joinToArtistString(" ${stringResource(R.string.and)} ") {
+                                                ArtistNameAliases.resolve(artistNameAliases, it.id, it.name)
+                                            }.orEmpty(),
+                                    )
                                     if (playCount > 0) {
                                         append(" | $playCount $playsString")
                                     }
@@ -611,7 +626,9 @@ fun DailyDiscoverCard(
                         text =
                             stringResource(
                                 messageRes,
-                                "${dailyDiscover.seed.title} • ${dailyDiscover.seed.artists.joinToArtistString(" ${stringResource(R.string.and)} ") { it.name }}",
+                                "${dailyDiscover.seed.title} • ${dailyDiscover.seed.artists.joinToArtistString(" ${stringResource(R.string.and)} ") {
+                                    ArtistNameAliases.resolve(artistNameAliases, it.id, it.name)
+                                }}",
                             ),
                         style = MaterialTheme.typography.bodySmall,
                         fontWeight = androidx.compose.ui.text.font.FontWeight.Medium,

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistScreen.kt
@@ -591,7 +591,7 @@ fun ArtistScreen(
                                                     } else {
                                                         playerConnection.playQueue(
                                                             ListQueue(
-                                                                title = libraryArtist?.artist?.name ?: "Unknown Artist",
+                                                                title = displayArtistName ?: "Unknown Artist",
                                                                 items = librarySongs.map { it.toMediaItem() },
                                                                 startIndex = index,
                                                             ),
@@ -910,7 +910,7 @@ fun ArtistScreen(
                             if (librarySongs.isNotEmpty()) {
                                 playerConnection.playQueue(
                                     ListQueue(
-                                        title = libraryArtist?.artist?.name ?: "Unknown Artist",
+                                        title = displayArtistName ?: "Unknown Artist",
                                         items = librarySongs.map { it.toMediaItem() },
                                     ),
                                 )

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/artist/ArtistScreen.kt
@@ -87,6 +87,7 @@ import com.metrolist.innertube.models.PodcastItem
 import com.metrolist.innertube.models.SongItem
 import com.metrolist.innertube.models.WatchEndpoint
 import com.metrolist.music.LocalDatabase
+import com.metrolist.music.LocalArtistNameAliases
 import com.metrolist.music.LocalListenTogetherManager
 import com.metrolist.music.LocalPlayerAwareWindowInsets
 import com.metrolist.music.LocalPlayerConnection
@@ -124,6 +125,7 @@ import com.metrolist.music.ui.utils.backToMain
 import com.metrolist.music.ui.utils.fadingEdge
 import com.metrolist.music.ui.utils.isScrollingUp
 import com.metrolist.music.ui.utils.resize
+import com.metrolist.music.utils.ArtistNameAliases
 import com.metrolist.music.utils.rememberPreference
 import com.metrolist.music.viewmodels.ArtistViewModel
 import com.valentinilk.shimmer.shimmer
@@ -148,6 +150,13 @@ fun ArtistScreen(
     val mediaMetadata by playerConnection.mediaMetadata.collectAsStateWithLifecycle()
     val artistPage = viewModel.artistPage
     val libraryArtist by viewModel.libraryArtist.collectAsStateWithLifecycle()
+    val artistNameAliases = LocalArtistNameAliases.current
+    val displayArtistName =
+        ArtistNameAliases.resolve(
+            artistNameAliases,
+            viewModel.artistId,
+            artistPage?.artist?.title ?: libraryArtist?.artist?.name.orEmpty(),
+        ).ifEmpty { null }
     val librarySongs by viewModel.librarySongs.collectAsStateWithLifecycle()
     val libraryAlbums by viewModel.libraryAlbums.collectAsStateWithLifecycle()
     val isChannelSubscribed by viewModel.isChannelSubscribed.collectAsStateWithLifecycle()
@@ -287,7 +296,6 @@ fun ArtistScreen(
             } else {
                 item(key = "header") {
                     val thumbnail = artistPage?.artist?.thumbnail ?: libraryArtist?.artist?.thumbnailUrl
-                    val artistName = artistPage?.artist?.title ?: libraryArtist?.artist?.name
 
                     Box {
                         // Artist Image with offset
@@ -344,7 +352,7 @@ fun ArtistScreen(
                             ) {
                                 // Artist Name
                                 Text(
-                                    text = artistName ?: "Unknown",
+                                    text = displayArtistName ?: "Unknown",
                                     style = MaterialTheme.typography.headlineLarge,
                                     fontWeight = FontWeight.Bold,
                                     maxLines = 1,
@@ -922,7 +930,7 @@ fun ArtistScreen(
                                             val songs = result.items.filterIsInstance<SongItem>().map { it.toMediaItem() }
                                             playerConnection.playQueue(
                                                 ListQueue(
-                                                    title = artistPage.artist.title,
+                                                    title = displayArtistName ?: artistPage.artist.title,
                                                     items = songs,
                                                 ),
                                             )
@@ -932,7 +940,7 @@ fun ArtistScreen(
                                             if (songs.isNotEmpty()) {
                                                 playerConnection.playQueue(
                                                     ListQueue(
-                                                        title = artistPage.artist.title,
+                                                        title = displayArtistName ?: artistPage.artist.title,
                                                         items = songs,
                                                     ),
                                                 )
@@ -945,7 +953,7 @@ fun ArtistScreen(
                                 val songs = songSection.items.filterIsInstance<SongItem>().map { it.toMediaItem() }
                                 playerConnection.playQueue(
                                     ListQueue(
-                                        title = artistPage.artist.title,
+                                        title = displayArtistName ?: artistPage.artist.title,
                                         items = songs,
                                     ),
                                 )
@@ -1005,7 +1013,7 @@ fun ArtistScreen(
     }
 
     TopAppBar(
-        title = { if (!transparentAppBar) Text(artistPage?.artist?.title.orEmpty()) },
+        title = { if (!transparentAppBar) Text(displayArtistName.orEmpty()) },
         navigationIcon = {
             IconButton(
                 onClick = navController::navigateUp,

--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/ShowMediaInfo.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/ShowMediaInfo.kt
@@ -126,7 +126,7 @@ fun ShowMediaInfo(videoId: String) {
                     val baseList = listOf(
                         stringResource(R.string.song_title) to (info?.title ?: song?.title),
                         stringResource(R.string.song_artists) to (
-                            song?.artists?.joinToString { it.name }
+                            song?.artists?.joinToString { ArtistNameAliases.resolve(it.id, it.name) }
                                 ?: info?.author?.let { ArtistNameAliases.resolve(null, it) }
                         ),
                         stringResource(R.string.media_id) to (song?.id ?: info?.videoId)

--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/ShowMediaInfo.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/ShowMediaInfo.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.metrolist.innertube.YouTube
 import com.metrolist.innertube.models.MediaInfo
+import com.metrolist.music.LocalArtistNameAliases
 import com.metrolist.music.LocalDatabase
 import com.metrolist.music.LocalPlayerConnection
 import com.metrolist.music.R
@@ -86,6 +87,7 @@ fun ShowMediaInfo(videoId: String) {
     val playerConnection = LocalPlayerConnection.current
     val currentStreamClient by playerConnection?.currentStreamClient?.collectAsState() ?: remember { mutableStateOf(null) }
     val context = LocalContext.current
+    val artistNameAliases = LocalArtistNameAliases.current
 
     val loudnessLevel by rememberEnumPreference(
         LoudnessLevelKey,
@@ -126,8 +128,11 @@ fun ShowMediaInfo(videoId: String) {
                     val baseList = listOf(
                         stringResource(R.string.song_title) to (info?.title ?: song?.title),
                         stringResource(R.string.song_artists) to (
-                            song?.artists?.joinToString { ArtistNameAliases.resolve(it.id, it.name) }
-                                ?: info?.author?.let { ArtistNameAliases.resolve(null, it) }
+                            song?.artists?.joinToString {
+                                ArtistNameAliases.resolve(artistNameAliases, it.id, it.name)
+                            } ?: info?.author?.let {
+                                ArtistNameAliases.resolve(artistNameAliases, null, it)
+                            }
                         ),
                         stringResource(R.string.media_id) to (song?.id ?: info?.videoId)
                     )

--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/ShowMediaInfo.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/ShowMediaInfo.kt
@@ -54,6 +54,7 @@ import com.metrolist.music.utils.cipher.PlayerDatesStore
 import com.metrolist.music.ui.component.Material3SettingsItem
 import com.metrolist.music.ui.component.shimmer.ShimmerHost
 import com.metrolist.music.ui.component.shimmer.TextPlaceholder
+import com.metrolist.music.utils.ArtistNameAliases
 import com.metrolist.music.utils.rememberEnumPreference
 import androidx.compose.ui.platform.LocalLocale
 
@@ -124,7 +125,10 @@ fun ShowMediaInfo(videoId: String) {
                 Column {
                     val baseList = listOf(
                         stringResource(R.string.song_title) to (info?.title ?: song?.title),
-                        stringResource(R.string.song_artists) to (info?.author ?: song?.artists?.joinToString { it.name }),
+                        stringResource(R.string.song_artists) to (
+                            song?.artists?.joinToString { it.name }
+                                ?: info?.author?.let { ArtistNameAliases.resolve(null, it) }
+                        ),
                         stringResource(R.string.media_id) to (song?.id ?: info?.videoId)
                     )
 

--- a/app/src/main/kotlin/com/metrolist/music/utils/ArtistNameAliases.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/ArtistNameAliases.kt
@@ -1,0 +1,103 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.utils
+
+import android.content.Context
+import android.content.SharedPreferences
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+object ArtistNameAliases {
+    const val BACKUP_FILENAME = "artist_name_aliases.json"
+    private const val PREFERENCES_NAME = "artist_name_aliases"
+
+    private val _aliases = MutableStateFlow<Map<String, String>>(emptyMap())
+    val aliases = _aliases.asStateFlow()
+
+    @Volatile
+    private var preferences: SharedPreferences? = null
+
+    fun initialize(context: Context) {
+        if (preferences != null) return
+
+        synchronized(this) {
+            if (preferences != null) return
+
+            val sharedPreferences =
+                context.applicationContext.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+            _aliases.value =
+                sharedPreferences.all.mapNotNull { (artistId, value) ->
+                    (value as? String)?.let { artistId to it }
+                }.toMap()
+            preferences = sharedPreferences
+        }
+    }
+
+    fun set(
+        context: Context,
+        artistId: String,
+        channelId: String?,
+        originalName: String,
+        name: String,
+    ) {
+        initialize(context)
+        val currentAliases = _aliases.value
+        val aliasKeys =
+            buildSet {
+                add(artistId)
+                channelId?.let(::add)
+                add(nameKey(originalName))
+                currentAliases.filterValues { it == originalName }.keys.forEach(::add)
+            }
+        preferences?.edit()?.apply {
+            aliasKeys.forEach { putString(it, name) }
+            apply()
+        }
+        _aliases.update { aliases -> aliases + aliasKeys.associateWith { name } }
+    }
+
+    fun resolve(
+        artistId: String?,
+        fallback: String,
+    ): String = resolve(_aliases.value, artistId, fallback)
+
+    fun resolve(
+        aliases: Map<String, String>,
+        artistId: String?,
+        fallback: String,
+    ): String {
+        var resolvedName = artistId?.let(aliases::get) ?: aliases[nameKey(fallback)] ?: fallback
+        var nextName = aliases[nameKey(resolvedName)] ?: return resolvedName
+        val visitedNames = mutableSetOf(resolvedName)
+        while (visitedNames.add(nextName)) {
+            resolvedName = nextName
+            nextName = aliases[nameKey(resolvedName)] ?: return resolvedName
+        }
+        return resolvedName
+    }
+
+    fun serialize(): String = Json.encodeToString(_aliases.value)
+
+    fun deserialize(serializedAliases: String): Map<String, String> = Json.decodeFromString(serializedAliases)
+
+    fun restore(
+        context: Context,
+        restoredAliases: Map<String, String>,
+    ) {
+        initialize(context)
+        preferences?.edit()?.apply {
+            clear()
+            restoredAliases.forEach(::putString)
+            commit()
+        }
+        _aliases.value = restoredAliases
+    }
+
+    private fun nameKey(name: String) = "name:$name"
+}

--- a/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/SyncUtils.kt
@@ -1065,7 +1065,7 @@ class SyncUtils @Inject constructor(
                                     insert(
                                         ArtistEntity(
                                             id = artist.id,
-                                            name = artist.title,
+                                            name = ArtistNameAliases.resolve(artist.id, artist.title),
                                             thumbnailUrl = artist.thumbnail,
                                             channelId = channelId,
                                             bookmarkedAt = LocalDateTime.now()
@@ -1074,11 +1074,12 @@ class SyncUtils @Inject constructor(
                                 } else {
                                     val existing = dbArtist
                                     val needsChannelIdUpdate = existing.channelId == null && channelId != null
+                                    val resolvedName = ArtistNameAliases.resolve(existing.id, artist.title)
                                     if (existing.bookmarkedAt == null || needsChannelIdUpdate ||
-                                        existing.name != artist.title || existing.thumbnailUrl != artist.thumbnail) {
+                                        existing.name != resolvedName || existing.thumbnailUrl != artist.thumbnail) {
                                         update(
                                             existing.copy(
-                                                name = artist.title,
+                                                name = resolvedName,
                                                 thumbnailUrl = artist.thumbnail,
                                                 channelId = channelId ?: existing.channelId,
                                                 bookmarkedAt = existing.bookmarkedAt ?: LocalDateTime.now(),

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/ArtistViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/ArtistViewModel.kt
@@ -33,6 +33,7 @@ import com.metrolist.music.db.entities.toArtistPage
 import com.metrolist.music.extensions.filterExplicit
 import com.metrolist.music.extensions.filterExplicitAlbums
 import com.metrolist.music.utils.SyncUtils
+import com.metrolist.music.utils.ArtistNameAliases
 import com.metrolist.music.utils.dataStore
 import com.metrolist.music.utils.get
 import com.metrolist.music.utils.reportException
@@ -229,7 +230,7 @@ class ArtistViewModel @Inject constructor(
                             if (existingArtist != null) {
                                 database.update(
                                     existingArtist.copy(
-                                        name = resolvedPage.artist.title,
+                                        name = ArtistNameAliases.resolve(existingArtist.id, resolvedPage.artist.title),
                                         channelId = resolvedPage.artist.channelId ?: existingArtist.channelId,
                                         thumbnailUrl = resolvedPage.artist.thumbnail ?: existingArtist.thumbnailUrl,
                                         cachedPageJson = cachedJson,
@@ -241,7 +242,7 @@ class ArtistViewModel @Inject constructor(
                                 database.insert(
                                     ArtistEntity(
                                         id = artistId,
-                                        name = apiArtist.title,
+                                        name = ArtistNameAliases.resolve(artistId, apiArtist.title),
                                         channelId = apiArtist.channelId,
                                         thumbnailUrl = apiArtist.thumbnail,
                                         cachedPageJson = cachedJson,
@@ -295,7 +296,7 @@ class ArtistViewModel @Inject constructor(
                     database.insert(
                         ArtistEntity(
                             id = artistId,
-                            name = it.title,
+                            name = ArtistNameAliases.resolve(artistId, it.title),
                             channelId = it.channelId,
                             thumbnailUrl = it.thumbnail,
                             bookmarkedAt = java.time.LocalDateTime.now(),

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/BackupRestoreViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/BackupRestoreViewModel.kt
@@ -41,6 +41,7 @@ import com.metrolist.music.playback.MusicService.Companion.PERSISTENT_AUTOMIX_FI
 import com.metrolist.music.playback.MusicService.Companion.PERSISTENT_PLAYER_STATE_FILE
 import com.metrolist.music.playback.MusicService.Companion.PERSISTENT_QUEUE_FILE
 import com.metrolist.music.utils.reportException
+import com.metrolist.music.utils.ArtistNameAliases
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
@@ -85,6 +86,8 @@ class BackupRestoreViewModel @Inject constructor(
                             outputStream.putNextEntry(ZipEntry(SETTINGS_FILENAME))
                             inputStream.copyTo(outputStream)
                         }
+                    outputStream.putNextEntry(ZipEntry(ArtistNameAliases.BACKUP_FILENAME))
+                    outputStream.write(ArtistNameAliases.serialize().encodeToByteArray())
                     runBlocking(Dispatchers.IO) {
                         database.checkpoint()
                     }
@@ -142,6 +145,7 @@ class BackupRestoreViewModel @Inject constructor(
 
                 var foundDb = false
                 var foundSettings = false
+                var restoredArtistNameAliases: Map<String, String>? = null
 
                 context.applicationContext.contentResolver.openInputStream(uri)?.use { raw ->
                     raw.zipInputStream().use { inputStream ->
@@ -152,6 +156,10 @@ class BackupRestoreViewModel @Inject constructor(
                                 SETTINGS_FILENAME -> {
                                     foundSettings = true
                                     tempSettings.outputStream().use { it.write(inputStream.readBytes()) }
+                                }
+                                ArtistNameAliases.BACKUP_FILENAME -> {
+                                    restoredArtistNameAliases =
+                                        ArtistNameAliases.deserialize(inputStream.readBytes().decodeToString())
                                 }
                                 InternalDatabase.DB_NAME -> {
                                     foundDb = true
@@ -309,6 +317,7 @@ class BackupRestoreViewModel @Inject constructor(
                     context.filesDir.resolve(PERSISTENT_QUEUE_FILE).delete()
                     context.filesDir.resolve(PERSISTENT_AUTOMIX_FILE).delete()
                     context.filesDir.resolve(PERSISTENT_PLAYER_STATE_FILE).delete()
+                    ArtistNameAliases.restore(context, restoredArtistNameAliases.orEmpty())
 
                     // 4. Restart — Room will open the swapped DB and run migrations if needed
                     val intent = context.packageManager.getLaunchIntentForPackage(context.packageName)?.apply {

--- a/app/src/test/kotlin/com/metrolist/music/db/AndroidAutoDatabasePaginationTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/db/AndroidAutoDatabasePaginationTest.kt
@@ -57,19 +57,45 @@ class AndroidAutoDatabasePaginationTest {
                     duration = 0,
                 ),
             )
-            database.dao.insert(PlaylistEntity(id = "playlist", name = "Playlist"))
+            database.dao.insert(
+                PlaylistEntity(
+                    id = "playlist",
+                    name = "Playlist",
+                    bookmarkedAt = libraryDate,
+                ),
+            )
             repeat(1_001) { index ->
                 val songId = "song-$index"
+                val artistId = "artist-$index"
+                val albumId = "album-$index"
+                database.dao.insert(ArtistEntity(id = artistId, name = "Artist $index"))
+                database.dao.insert(
+                    AlbumEntity(
+                        id = albumId,
+                        title = "Album $index",
+                        songCount = 1,
+                        duration = 0,
+                    ),
+                )
+                database.dao.insert(
+                    PlaylistEntity(
+                        id = "playlist-$index",
+                        name = "Playlist $index",
+                        bookmarkedAt = libraryDate,
+                    ),
+                )
                 database.dao.insert(
                     SongEntity(
                         id = songId,
                         title = "Song $index",
+                        albumId = albumId,
                         liked = true,
                         likedDate = libraryDate,
                         inLibrary = libraryDate,
                     ),
                 )
                 database.dao.insert(SongArtistMap(songId = songId, artistId = "artist", position = 0))
+                database.dao.insert(SongArtistMap(songId = songId, artistId = artistId, position = 1))
                 database.dao.insert(SongAlbumMap(songId = songId, albumId = "album", index = index / 2))
                 database.dao.insert(
                     PlaylistSongMap(
@@ -83,7 +109,11 @@ class AndroidAutoDatabasePaginationTest {
 
         database.dao.songsByCreateDateAsc(limit = 500, offset = 0).let { firstPage ->
             assertEquals(500, firstPage.size)
-            assertTrue(firstPage.all { it.artists.single().id == "artist" && it.album?.id == "album" })
+            assertTrue(
+                firstPage.all { song ->
+                    song.artists.any { it.id == "artist" } && song.album?.id == "album"
+                },
+            )
         }
         assertCompletePagination(
             id = { it.id },
@@ -107,9 +137,24 @@ class AndroidAutoDatabasePaginationTest {
             id = { it.song.id },
             loadPage = { limit, offset -> database.dao.playlistSongs("playlist", limit, offset) },
         )
+        assertCompletePagination(
+            expectedSize = 1_002,
+            id = { it.id },
+            loadPage = { limit, offset -> database.dao.artistsByCreateDateAsc(limit, offset) },
+        )
+        assertCompletePagination(
+            id = { it.id },
+            loadPage = { limit, offset -> database.dao.albumsByCreateDateAsc(limit, offset) },
+        )
+        assertCompletePagination(
+            expectedSize = 1_002,
+            id = { it.id },
+            loadPage = { limit, offset -> database.dao.playlistsByCreateDateAsc(limit, offset) },
+        )
     }
 
     private suspend fun <T> assertCompletePagination(
+        expectedSize: Int = 1_001,
         id: (T) -> String,
         loadPage: suspend (limit: Int, offset: Int) -> List<T>,
     ) {
@@ -118,7 +163,7 @@ class AndroidAutoDatabasePaginationTest {
                 addAll(loadPage(500, offset).map(id))
             }
         }
-        assertEquals(1_001, ids.size)
-        assertEquals(1_001, ids.toSet().size)
+        assertEquals(expectedSize, ids.size)
+        assertEquals(expectedSize, ids.toSet().size)
     }
 }

--- a/app/src/test/kotlin/com/metrolist/music/db/AndroidAutoDatabasePaginationTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/db/AndroidAutoDatabasePaginationTest.kt
@@ -1,0 +1,124 @@
+/*
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.db
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.metrolist.music.db.entities.AlbumEntity
+import com.metrolist.music.db.entities.ArtistEntity
+import com.metrolist.music.db.entities.PlaylistEntity
+import com.metrolist.music.db.entities.PlaylistSongMap
+import com.metrolist.music.db.entities.SongAlbumMap
+import com.metrolist.music.db.entities.SongArtistMap
+import com.metrolist.music.db.entities.SongEntity
+import java.time.LocalDateTime
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class AndroidAutoDatabasePaginationTest {
+    private lateinit var database: InternalDatabase
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        database = Room.inMemoryDatabaseBuilder(context, InternalDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun `song relation query stays below Room recursive fetch threshold`() = runBlocking {
+        val libraryDate = LocalDateTime.of(2026, 1, 1, 0, 0)
+        database.runInTransaction {
+            database.dao.insert(ArtistEntity(id = "artist", name = "Artist"))
+            database.dao.insert(
+                AlbumEntity(
+                    id = "album",
+                    title = "Album",
+                    songCount = 1_001,
+                    duration = 0,
+                ),
+            )
+            database.dao.insert(PlaylistEntity(id = "playlist", name = "Playlist"))
+            repeat(1_001) { index ->
+                val songId = "song-$index"
+                database.dao.insert(
+                    SongEntity(
+                        id = songId,
+                        title = "Song $index",
+                        liked = true,
+                        likedDate = libraryDate,
+                        inLibrary = libraryDate,
+                    ),
+                )
+                database.dao.insert(SongArtistMap(songId = songId, artistId = "artist", position = 0))
+                database.dao.insert(SongAlbumMap(songId = songId, albumId = "album", index = index / 2))
+                database.dao.insert(
+                    PlaylistSongMap(
+                        playlistId = "playlist",
+                        songId = songId,
+                        position = index / 2,
+                    ),
+                )
+            }
+        }
+
+        database.dao.songsByCreateDateAsc(limit = 500, offset = 0).let { firstPage ->
+            assertEquals(500, firstPage.size)
+            assertTrue(firstPage.all { it.artists.single().id == "artist" && it.album?.id == "album" })
+        }
+        assertCompletePagination(
+            id = { it.id },
+            loadPage = database.dao::songsByCreateDateAsc,
+        )
+        assertCompletePagination(
+            id = { it.id },
+            loadPage = database.dao::likedSongsByCreateDateDesc,
+        )
+        assertCompletePagination(
+            id = { it.id },
+            loadPage = { limit, offset ->
+                database.dao.artistSongsByCreateDateAsc("artist", limit, offset)
+            },
+        )
+        assertCompletePagination(
+            id = { it.id },
+            loadPage = { limit, offset -> database.dao.albumSongs("album", limit, offset) },
+        )
+        assertCompletePagination(
+            id = { it.song.id },
+            loadPage = { limit, offset -> database.dao.playlistSongs("playlist", limit, offset) },
+        )
+    }
+
+    private suspend fun <T> assertCompletePagination(
+        id: (T) -> String,
+        loadPage: suspend (limit: Int, offset: Int) -> List<T>,
+    ) {
+        val ids = buildList {
+            listOf(0, 500, 1_000).forEach { offset ->
+                addAll(loadPage(500, offset).map(id))
+            }
+        }
+        assertEquals(1_001, ids.size)
+        assertEquals(1_001, ids.toSet().size)
+    }
+}

--- a/app/src/test/kotlin/com/metrolist/music/db/MusicDatabaseMigrationTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/db/MusicDatabaseMigrationTest.kt
@@ -1,0 +1,127 @@
+/*
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.db
+
+import android.app.Application
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = Application::class)
+class MusicDatabaseMigrationTest {
+    @Test
+    fun `21 to 24 shortcut adds every version 24 column`() {
+        assertVersion24Columns(MIGRATION_21_24, sourceVersion = 21, playlistHasThumbnail = false)
+    }
+
+    @Test
+    fun `22 to 24 shortcut tolerates partially added columns`() {
+        assertVersion24Columns(MIGRATION_22_24, sourceVersion = 22, playlistHasThumbnail = true)
+    }
+
+    private fun assertVersion24Columns(
+        migration: Migration,
+        sourceVersion: Int,
+        playlistHasThumbnail: Boolean,
+    ) {
+        val context = ApplicationProvider.getApplicationContext<Application>()
+        val databaseName = "migration-$sourceVersion-to-24.db"
+        context.deleteDatabase(databaseName)
+
+        openHelper(
+            context = context,
+            name = databaseName,
+            version = sourceVersion,
+            onCreate = { db ->
+                db.execSQL("CREATE TABLE song (id TEXT NOT NULL PRIMARY KEY)")
+                db.execSQL("CREATE TABLE album (id TEXT NOT NULL PRIMARY KEY)")
+                db.execSQL(
+                    if (playlistHasThumbnail) {
+                        "CREATE TABLE playlist (id TEXT NOT NULL PRIMARY KEY, thumbnailUrl TEXT)"
+                    } else {
+                        "CREATE TABLE playlist (id TEXT NOT NULL PRIMARY KEY)"
+                    },
+                )
+            },
+        ).use { it.writableDatabase }
+
+        try {
+            openHelper(
+                context = context,
+                name = databaseName,
+                version = 24,
+                onUpgrade = { db, _, _ -> migration.migrate(db) },
+            ).use { helper ->
+                val db = helper.writableDatabase
+                val songColumns = db.columns("song")
+                val albumColumns = db.columns("album")
+                val playlistColumns = db.columns("playlist")
+
+                assertNull(songColumns.getValue("libraryAddToken").defaultValue)
+                assertNull(songColumns.getValue("libraryRemoveToken").defaultValue)
+                assertEquals("true", songColumns.getValue("romanizeLyrics").defaultValue)
+                assertEquals("0", songColumns.getValue("isDownloaded").defaultValue)
+                assertEquals("false", songColumns.getValue("isUploaded").defaultValue)
+                assertEquals("false", albumColumns.getValue("isUploaded").defaultValue)
+                assertTrue("thumbnailUrl" in playlistColumns)
+            }
+        } finally {
+            context.deleteDatabase(databaseName)
+        }
+    }
+
+    private fun openHelper(
+        context: Application,
+        name: String,
+        version: Int,
+        onCreate: (SupportSQLiteDatabase) -> Unit = {},
+        onUpgrade: (SupportSQLiteDatabase, Int, Int) -> Unit = { _, _, _ -> },
+    ): SupportSQLiteOpenHelper =
+        FrameworkSQLiteOpenHelperFactory().create(
+            SupportSQLiteOpenHelper.Configuration
+                .builder(context)
+                .name(name)
+                .callback(
+                    object : SupportSQLiteOpenHelper.Callback(version) {
+                        override fun onCreate(db: SupportSQLiteDatabase) = onCreate(db)
+
+                        override fun onUpgrade(
+                            db: SupportSQLiteDatabase,
+                            oldVersion: Int,
+                            newVersion: Int,
+                        ) = onUpgrade(db, oldVersion, newVersion)
+                    },
+                ).build(),
+        )
+
+    private fun SupportSQLiteDatabase.columns(tableName: String): Map<String, ColumnInfo> =
+        buildMap {
+            query("PRAGMA table_info('$tableName')").use { cursor ->
+                val nameIndex = cursor.getColumnIndexOrThrow("name")
+                val defaultValueIndex = cursor.getColumnIndexOrThrow("dflt_value")
+                while (cursor.moveToNext()) {
+                    put(
+                        cursor.getString(nameIndex),
+                        ColumnInfo(defaultValue = cursor.getString(defaultValueIndex)),
+                    )
+                }
+            }
+        }
+
+    private data class ColumnInfo(
+        val defaultValue: String?,
+    )
+}

--- a/app/src/test/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallbackTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallbackTest.kt
@@ -62,4 +62,20 @@ class MediaLibrarySessionCallbackTest {
             androidAutoPageRequest(page = 1, pageSize = 1_000).afterLeadingItems(1),
         )
     }
+
+    @Test
+    fun `playlist containers account for both built in playlists`() {
+        assertEquals(
+            AndroidAutoPageRequest(offset = 0, limit = 0),
+            androidAutoPageRequest(page = 0, pageSize = 1).afterLeadingItems(2),
+        )
+        assertEquals(
+            AndroidAutoPageRequest(offset = 0, limit = 0),
+            androidAutoPageRequest(page = 1, pageSize = 1).afterLeadingItems(2),
+        )
+        assertEquals(
+            AndroidAutoPageRequest(offset = 0, limit = 1),
+            androidAutoPageRequest(page = 2, pageSize = 1).afterLeadingItems(2),
+        )
+    }
 }

--- a/app/src/test/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallbackTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallbackTest.kt
@@ -30,4 +30,36 @@ class MediaLibrarySessionCallbackTest {
         assertEquals(listOf("five"), children.paginate(page = 2, pageSize = 2))
         assertEquals(emptyList<String>(), children.paginate(page = 3, pageSize = 2))
     }
+
+    @Test
+    fun `database pages are capped before loading relations`() {
+        assertEquals(
+            AndroidAutoPageRequest(offset = 0, limit = MAX_ANDROID_AUTO_PAGE_SIZE),
+            androidAutoPageRequest(page = 0, pageSize = Int.MAX_VALUE),
+        )
+        assertEquals(
+            AndroidAutoPageRequest(offset = MAX_ANDROID_AUTO_PAGE_SIZE, limit = MAX_ANDROID_AUTO_PAGE_SIZE),
+            androidAutoPageRequest(page = 1, pageSize = 1_000),
+        )
+        assertEquals(
+            AndroidAutoPageRequest(offset = 1_000, limit = MAX_ANDROID_AUTO_PAGE_SIZE),
+            androidAutoPageRequest(page = 2, pageSize = 500),
+        )
+    }
+
+    @Test
+    fun `playlist pages account for the leading shuffle action`() {
+        assertEquals(
+            AndroidAutoPageRequest(offset = 0, limit = 99),
+            androidAutoPageRequest(page = 0, pageSize = 100).afterLeadingItems(1),
+        )
+        assertEquals(
+            AndroidAutoPageRequest(offset = 99, limit = 100),
+            androidAutoPageRequest(page = 1, pageSize = 100).afterLeadingItems(1),
+        )
+        assertEquals(
+            AndroidAutoPageRequest(offset = 499, limit = MAX_ANDROID_AUTO_PAGE_SIZE),
+            androidAutoPageRequest(page = 1, pageSize = 1_000).afterLeadingItems(1),
+        )
+    }
 }

--- a/app/src/test/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallbackTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallbackTest.kt
@@ -1,0 +1,33 @@
+/*
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.playback
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MediaLibrarySessionCallbackTest {
+    @Test
+    fun `browse tree parents accept subscriptions`() {
+        assertTrue(isBrowsableMediaId(MusicService.ROOT))
+        assertTrue(isBrowsableMediaId(MusicService.ARTIST))
+        assertTrue(isBrowsableMediaId("${MusicService.ARTIST}/artist-id"))
+        assertTrue(isBrowsableMediaId("${MusicService.PLAYLIST}/playlist-id"))
+        assertFalse(isBrowsableMediaId("unknown"))
+        assertFalse(isBrowsableMediaId("${MusicService.SONG}/song-id"))
+    }
+
+    @Test
+    fun `children are limited to the requested page`() {
+        val children = listOf("one", "two", "three", "four", "five")
+
+        assertEquals(listOf("one", "two"), children.paginate(page = 0, pageSize = 2))
+        assertEquals(listOf("three", "four"), children.paginate(page = 1, pageSize = 2))
+        assertEquals(listOf("five"), children.paginate(page = 2, pageSize = 2))
+        assertEquals(emptyList<String>(), children.paginate(page = 3, pageSize = 2))
+    }
+}

--- a/app/src/test/kotlin/com/metrolist/music/utils/ArtistNameAliasesTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/utils/ArtistNameAliasesTest.kt
@@ -1,0 +1,57 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ArtistNameAliasesTest {
+    @Test
+    fun `artist id alias takes precedence over name alias`() {
+        val aliases =
+            mapOf(
+                "artist-id" to "ID alias",
+                "name:Original name" to "Name alias",
+            )
+
+        assertEquals(
+            "ID alias",
+            ArtistNameAliases.resolve(aliases, "artist-id", "Original name"),
+        )
+    }
+
+    @Test
+    fun `name alias applies when artist id is missing`() {
+        val aliases = mapOf("name:Original name" to "Renamed artist")
+
+        assertEquals(
+            "Renamed artist",
+            ArtistNameAliases.resolve(aliases, null, "Original name"),
+        )
+    }
+
+    @Test
+    fun `original name is retained when no alias exists`() {
+        assertEquals(
+            "Original name",
+            ArtistNameAliases.resolve(emptyMap(), "artist-id", "Original name"),
+        )
+    }
+
+    @Test
+    fun `chained renames resolve to the latest name`() {
+        val aliases =
+            mapOf(
+                "artist-id" to "First rename",
+                "name:First rename" to "Second rename",
+            )
+
+        assertEquals(
+            "Second rename",
+            ArtistNameAliases.resolve(aliases, "artist-id", "Original name"),
+        )
+    }
+}


### PR DESCRIPTION
## Problem
- upgrades from v12.1.0 could crash on missing columns in legacy shortcut migrations
- custom artist names did not consistently propagate to online and playback metadata
- Android Auto browse subscriptions failed, and large libraries could exhaust the heap while Room materialized complete relation sets

## Cause
- the legacy 21/22 to 24 shortcuts did not reconcile every column expected by later generated migrations
- artist names were stored in independent online, queue, and database snapshots without a shared persisted alias
- Media3 subscription validation only recognized song IDs, while Android Auto collection queries paginated after loading full Room relations

## Solution
- idempotently reconcile all required v24 columns before generated migrations continue
- persist artist ID, channel, and name aliases and resolve them across database, UI, playback, sync, Android Auto, and backup restore paths
- accept browse-tree subscriptions and page songs, artists, albums, and playlists in SQL before Room materializes relations
- use artwork URIs instead of retaining cached artwork byte arrays per Android Auto song

## Related Issues
- No linked GitHub issue; fixes user-reported upgrade and Android Auto crashes

## Testing
- `./gradlew :app:assembleFossDebug`
- focused artist alias, migration, Android Auto callback, and Room pagination tests
- 1,001-row relation tests cover stable page boundaries for songs, artists, albums, and playlists
- Build APKs workflow passed at `c1a13b089` before the review follow-up
- affected upgrade and Android Auto flows manually verified by users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added artist name aliases across browsing, playback, menus, search results, and library displays.
  * Artist renames now update saved content and queued media.
  * Artist aliases are included in backup and restore operations.
  * Improved paginated loading for libraries, playlists, albums, artists, and Android Auto browsing.

* **Bug Fixes**
  * Improved media artwork handling and metadata consistency.
  * Prevented missing or duplicate items during large-library pagination.
  * Improved database migration reliability and playlist browsing accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->