### PR TITLE
fix: authenticate YouTube Music search requests

### DIFF
--- a/innertube/build.gradle.kts
+++ b/innertube/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     }
     implementation(libs.timber)
     testImplementation(libs.junit)
+    testImplementation(libs.ktor.client.mock)
 
     coreLibraryDesugaring(libs.desugaring)
 }

--- a/innertube/src/main/kotlin/com/metrolist/innertube/InnerTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/InnerTube.kt
@@ -11,6 +11,7 @@ import com.metrolist.innertube.utils.parseCookieString
 import com.metrolist.innertube.utils.sha1
 import io.ktor.client.*
 import io.ktor.client.call.body
+import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.okhttp.*
 import io.ktor.client.plugins.*
 import io.ktor.client.plugins.compression.*
@@ -35,8 +36,12 @@ import kotlin.io.encoding.ExperimentalEncodingApi
  * For making HTTP requests, not parsing response.
  */
 @OptIn(ExperimentalEncodingApi::class)
-class InnerTube {
-    private var httpClient = createClient()
+class InnerTube internal constructor(
+    private val engineFactory: InnerTube.() -> HttpClientEngine,
+) {
+    constructor() : this({ createEngine() })
+
+    private var httpClient = createClient(engineFactory(this))
 
     private companion object {
         const val PLAYBACK_TELEMETRY_VER = "2"
@@ -63,7 +68,7 @@ class InnerTube {
         set(value) {
             field = value
             httpClient.close()
-            httpClient = createClient()
+            httpClient = createClient(engineFactory(this))
         }
     
     var proxyAuth: String? = null
@@ -71,7 +76,53 @@ class InnerTube {
     var useLoginForBrowse: Boolean = false
 
     @OptIn(ExperimentalSerializationApi::class)
-    private fun createClient() = HttpClient(OkHttp) {
+    private fun createEngine() = OkHttp.create {
+        config {
+            // Connection pool settings for better connection reuse
+            connectionPool(
+                okhttp3.ConnectionPool(
+                    10, // maxIdleConnections
+                    5, // keepAliveDuration
+                    java.util.concurrent.TimeUnit.MINUTES
+                )
+            )
+            
+            // Timeout configurations
+            connectTimeout(30, java.util.concurrent.TimeUnit.SECONDS)
+            readTimeout(60, java.util.concurrent.TimeUnit.SECONDS)
+            writeTimeout(60, java.util.concurrent.TimeUnit.SECONDS)
+            
+            // Enable HTTP/2 for better performance
+            protocols(listOf(okhttp3.Protocol.HTTP_2, okhttp3.Protocol.HTTP_1_1))
+            
+            // Retry on connection failure
+            retryOnConnectionFailure(true)
+            
+            // Cache configuration for better performance
+            cache(
+                okhttp3.Cache(
+                    directory = java.io.File(System.getProperty("java.io.tmpdir"), "http_cache"),
+                    maxSize = 50L * 1024L * 1024L // 50 MB
+                )
+            )
+            
+            // Apply proxy configuration
+            this@InnerTube.proxy?.let { proxyConfig ->
+                proxy(proxyConfig)
+            }
+            
+            // Apply proxy authentication
+            this@InnerTube.proxyAuth?.let { auth ->
+                proxyAuthenticator { _, response ->
+                    response.request.newBuilder()
+                        .header("Proxy-Authorization", auth)
+                        .build()
+                }
+            }
+        }
+    }
+
+    private fun createClient(engine: HttpClientEngine) = HttpClient(engine) {
         expectSuccess = true
 
         install(ContentNegotiation) {
@@ -88,51 +139,6 @@ class InnerTube {
         }
 
         // Enhanced network configuration for better performance
-        engine {
-            config {
-                // Connection pool settings for better connection reuse
-                connectionPool(
-                    okhttp3.ConnectionPool(
-                        10, // maxIdleConnections
-                        5, // keepAliveDuration
-                        java.util.concurrent.TimeUnit.MINUTES
-                    )
-                )
-                
-                // Timeout configurations
-                connectTimeout(30, java.util.concurrent.TimeUnit.SECONDS)
-                readTimeout(60, java.util.concurrent.TimeUnit.SECONDS)
-                writeTimeout(60, java.util.concurrent.TimeUnit.SECONDS)
-                
-                // Enable HTTP/2 for better performance
-                protocols(listOf(okhttp3.Protocol.HTTP_2, okhttp3.Protocol.HTTP_1_1))
-                
-                // Retry on connection failure
-                retryOnConnectionFailure(true)
-                
-                // Cache configuration for better performance
-                cache(
-                    okhttp3.Cache(
-                        directory = java.io.File(System.getProperty("java.io.tmpdir"), "http_cache"),
-                        maxSize = 50L * 1024L * 1024L // 50 MB
-                    )
-                )
-                
-                // Apply proxy configuration
-                this@InnerTube.proxy?.let { proxyConfig ->
-                    proxy(proxyConfig)
-                }
-                
-                // Apply proxy authentication
-                this@InnerTube.proxyAuth?.let { auth ->
-                    proxyAuthenticator { _, response ->
-                        response.request.newBuilder()
-                            .header("Proxy-Authorization", auth)
-                            .build()
-                    }
-                }
-            }
-        }
 
         // Request timeout configuration
         install(HttpTimeout) {
@@ -212,7 +218,7 @@ class InnerTube {
         continuation: String? = null,
     ) = withRetry {
         httpClient.post("search") {
-            ytClient(client, setLogin = false)
+            ytClient(client, setLogin = true)
             setBody(
                 SearchBody(
                     context = client.toContext(

--- a/innertube/src/test/kotlin/com/metrolist/innertube/InnerTubeSearchTest.kt
+++ b/innertube/src/test/kotlin/com/metrolist/innertube/InnerTubeSearchTest.kt
@@ -1,0 +1,117 @@
+package com.metrolist.innertube
+
+import com.metrolist.innertube.models.YouTubeClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandleScope
+import io.ktor.client.engine.mock.MockRequestHandler
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.OutgoingContent
+import io.ktor.http.headersOf
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class InnerTubeSearchTest {
+    @Test
+    fun `search attaches credentials for a signed-in login-capable client`() = runBlocking {
+        val innerTube = innerTube { request ->
+            assertEquals(HttpMethod.Post, request.method)
+            assertEquals("/youtubei/v1/search", request.url.encodedPath)
+            assertEquals("continuation-token", request.url.parameters["continuation"])
+            assertEquals("continuation-token", request.url.parameters["ctoken"])
+            assertEquals("false", request.url.parameters["prettyPrint"])
+            assertEquals(YouTubeClient.WEB_REMIX.clientId, request.headers["X-YouTube-Client-Name"])
+            assertEquals("visitor-data", request.headers["X-Goog-Visitor-Id"])
+            assertEquals(SIGNED_IN_COOKIE, request.headers[HttpHeaders.Cookie])
+            assertTrue(
+                request.headers[HttpHeaders.Authorization]
+                    ?.matches(Regex("SAPISIDHASH \\d+_[0-9a-f]{40}")) == true,
+            )
+
+            val body = (request.body as OutgoingContent.ByteArrayContent).bytes().decodeToString()
+            assertTrue(body.contains("\"query\":\"authenticated search\""))
+            assertTrue(body.contains("\"params\":\"search-params\""))
+            assertTrue(body.contains("\"visitorData\":\"visitor-data\""))
+
+            okResponse()
+        }.apply {
+            visitorData = "visitor-data"
+            cookie = SIGNED_IN_COOKIE
+        }
+
+        innerTube.search(
+            client = YouTubeClient.WEB_REMIX,
+            query = "authenticated search",
+            params = "search-params",
+            continuation = "continuation-token",
+        )
+
+        Unit
+    }
+
+    @Test
+    fun `search remains anonymous when no cookie is configured`() = runBlocking {
+        val innerTube = innerTube { request ->
+            assertEquals(YouTubeClient.WEB_REMIX.clientId, request.headers["X-YouTube-Client-Name"])
+            assertEquals(YouTubeClient.WEB_REMIX.clientVersion, request.headers["X-YouTube-Client-Version"])
+            assertEquals("visitor-data", request.headers["X-Goog-Visitor-Id"])
+            assertNull(request.headers[HttpHeaders.Cookie])
+            assertNull(request.headers[HttpHeaders.Authorization])
+
+            val body = (request.body as OutgoingContent.ByteArrayContent).bytes().decodeToString()
+            assertTrue(body.contains("\"query\":\"anonymous search\""))
+            assertTrue(body.contains("\"visitorData\":\"visitor-data\""))
+
+            okResponse()
+        }.apply {
+            visitorData = "visitor-data"
+        }
+
+        innerTube.search(
+            client = YouTubeClient.WEB_REMIX,
+            query = "anonymous search",
+        )
+
+        Unit
+    }
+
+    @Test
+    fun `search omits credentials for a client that does not support login`() = runBlocking {
+        val innerTube = innerTube { request ->
+            assertEquals(YouTubeClient.WEB.clientId, request.headers["X-YouTube-Client-Name"])
+            assertEquals("visitor-data", request.headers["X-Goog-Visitor-Id"])
+            assertNull(request.headers[HttpHeaders.Cookie])
+            assertNull(request.headers[HttpHeaders.Authorization])
+            okResponse()
+        }.apply {
+            visitorData = "visitor-data"
+            cookie = SIGNED_IN_COOKIE
+        }
+
+        innerTube.search(
+            client = YouTubeClient.WEB,
+            query = "unsupported login search",
+        )
+
+        Unit
+    }
+
+    private fun innerTube(handler: MockRequestHandler) = InnerTube { MockEngine(handler) }
+
+    private fun MockRequestHandleScope.okResponse() = respond(
+        content = ByteReadChannel("{}"),
+        status = HttpStatusCode.OK,
+        headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+    )
+
+    private companion object {
+        const val SIGNED_IN_COOKIE = "SAPISID=test-sapisid; HSID=test-hsid"
+    }
+}


### PR DESCRIPTION
## Problem

Restore authenticated search requests by routing `InnerTube.search` through the existing login-capable `ytClient` behavior, so signed-in users send their cookie and SAPISID authorization header while logged-out users continue to make valid anonymous requests. Keep the search body, visitor-data handling, retry behavior, parsing, view model, and UI unchanged; no Android-version branch is warranted because the thread's concrete diagnosis is the request's authentication state. Add the Ktor mock-client test dependency to the `innertube` module and a request-level regression test that exercises the production `search` path against a mock transport, using the narrowest production-consumed client-construction seam needed to observe outgoing headers.

Closes #3878

## Cause

Not applicable to this change.

## Solution

-

## Testing

Not applicable to this change.

## Related Issues

- Closes #
- Related to #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving available authenticated accounts.
  * Added configurable request origin and referrer handling.

* **Bug Fixes**
  * Improved signed-in search requests with the appropriate authentication context.
  * Enhanced network client handling when proxy settings change.
  * Preserved anonymous search behavior for users without saved login information.

* **Tests**
  * Added coverage for authenticated, anonymous, and login-ineligible search scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->