### PR TITLE
fix(db): stop loading the cached artist page once per song

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
@@ -1749,6 +1749,11 @@ interface DatabaseDao {
     @Query("SELECT * FROM artist WHERE id = :id LIMIT 1")
     fun getArtistById(id: String): ArtistEntity?
 
+    // Writes the one column rather than the whole row: callers reach this holding an artist that
+    // came from a relation, and those do not carry cachedPageJson.
+    @Query("UPDATE artist SET thumbnailUrl = :thumbnailUrl WHERE id = :artistId")
+    fun updateArtistThumbnail(artistId: String, thumbnailUrl: String)
+
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     fun insert(song: SongEntity): Long
 

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/Album.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/Album.kt
@@ -18,6 +18,18 @@ data class Album(
         entity = ArtistEntity::class,
         entityColumn = "id",
         parentColumn = "id",
+        // Every column but cachedPageJson: Room builds one ArtistEntity per pairing here, and the
+        // cached page would be copied into every one of them.
+        projection = [
+            "id",
+            "name",
+            "thumbnailUrl",
+            "channelId",
+            "lastUpdateTime",
+            "bookmarkedAt",
+            "isLocal",
+            "isPodcastChannel",
+        ],
         associateBy =
         Junction(
             value = AlbumArtistMap::class,

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/AlbumWithSongs.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/AlbumWithSongs.kt
@@ -18,6 +18,18 @@ data class AlbumWithSongs(
         entity = ArtistEntity::class,
         entityColumn = "id",
         parentColumn = "id",
+        // Every column but cachedPageJson: Room builds one ArtistEntity per pairing here, and the
+        // cached page would be copied into every one of them.
+        projection = [
+            "id",
+            "name",
+            "thumbnailUrl",
+            "channelId",
+            "lastUpdateTime",
+            "bookmarkedAt",
+            "isLocal",
+            "isPodcastChannel",
+        ],
         associateBy =
         Junction(
             value = AlbumArtistMap::class,

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/ArtistEntity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/ArtistEntity.kt
@@ -29,6 +29,10 @@ data class ArtistEntity(
     val isLocal: Boolean = false,
     @ColumnInfo(name = "isPodcastChannel", defaultValue = false.toString())
     val isPodcastChannel: Boolean = false,
+    // The artist page as YouTube returned it, so the screen has something to draw before the
+    // network answers. Read only by ArtistViewModel, for the single artist on screen. Relations
+    // that pull artists in bulk project the other columns explicitly, because Room builds one
+    // ArtistEntity per pairing and would otherwise hold one copy of this page per song.
     @ColumnInfo(name = "cachedPageJson")
     val cachedPageJson: String? = null
 ) {

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/Song.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/Song.kt
@@ -20,6 +20,18 @@ constructor(
         entity = ArtistEntity::class,
         entityColumn = "id",
         parentColumn = "id",
+        // Every column but cachedPageJson: Room builds one ArtistEntity per pairing here, and the
+        // cached page would be copied into every one of them.
+        projection = [
+            "id",
+            "name",
+            "thumbnailUrl",
+            "channelId",
+            "lastUpdateTime",
+            "bookmarkedAt",
+            "isLocal",
+            "isPodcastChannel",
+        ],
         associateBy =
             Junction(
                 value = SortedSongArtistMap::class,

--- a/app/src/main/kotlin/com/metrolist/music/db/entities/SongWithStats.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/SongWithStats.kt
@@ -18,6 +18,18 @@ data class SongWithStats(
         entity = ArtistEntity::class,
         parentColumn = "id",               // Song's primary key column
         entityColumn = "id",               // Artist's primary key column
+        // Every column but cachedPageJson: Room builds one ArtistEntity per pairing here, and the
+        // cached page would be copied into every one of them.
+        projection = [
+            "id",
+            "name",
+            "thumbnailUrl",
+            "channelId",
+            "lastUpdateTime",
+            "bookmarkedAt",
+            "isLocal",
+            "isPodcastChannel",
+        ],
         associateBy = Junction(
             value = SortedSongArtistMap::class,  // Junction table for the many-to-many relationship
             parentColumn = "songId",            // Foreign key to the Song table

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -3726,7 +3726,7 @@ class MusicService :
             if (thumbnail != null) {
                 Timber.tag("DiscordSvc").d("fetchArtistThumbnail: got thumbnail for %s", artist.name)
                 withContext(Dispatchers.IO) {
-                    database.update(artist.copy(thumbnailUrl = thumbnail))
+                    database.updateArtistThumbnail(artist.id, thumbnail)
                 }
                 database.getSongById(song.song.id)
             } else {

--- a/app/src/test/kotlin/com/metrolist/music/db/ArtistPageCacheTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/db/ArtistPageCacheTest.kt
@@ -1,0 +1,126 @@
+/*
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.db
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.metrolist.music.db.entities.AlbumArtistMap
+import com.metrolist.music.db.entities.AlbumEntity
+import com.metrolist.music.db.entities.ArtistEntity
+import com.metrolist.music.db.entities.SongAlbumMap
+import com.metrolist.music.db.entities.SongArtistMap
+import com.metrolist.music.db.entities.SongEntity
+import java.time.LocalDateTime
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The cached artist page is worth kilobytes per artist, and the relations that pull artists in
+ * bulk build one [ArtistEntity] per pairing. Reading a library of songs used to mean holding one
+ * copy of the page per song, so these lock down that the bulk reads leave it on disk while the
+ * artist screen still gets it.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class ArtistPageCacheTest {
+    private lateinit var database: InternalDatabase
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        database = Room.inMemoryDatabaseBuilder(context, InternalDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        database.runInTransaction {
+            database.dao.insert(
+                ArtistEntity(
+                    id = ARTIST_ID,
+                    name = "Artist",
+                    thumbnailUrl = "https://example.invalid/artist.jpg",
+                    channelId = "UCchannel",
+                    lastUpdateTime = UPDATED_AT,
+                    bookmarkedAt = BOOKMARKED_AT,
+                    isPodcastChannel = true,
+                    cachedPageJson = CACHED_PAGE,
+                ),
+            )
+            database.dao.insert(AlbumEntity(id = ALBUM_ID, title = "Album", songCount = 1, duration = 0))
+            database.dao.insert(SongEntity(id = SONG_ID, title = "Song", albumId = ALBUM_ID))
+            database.dao.insert(SongArtistMap(songId = SONG_ID, artistId = ARTIST_ID, position = 0))
+            database.dao.insert(SongAlbumMap(songId = SONG_ID, albumId = ALBUM_ID, index = 0))
+            database.dao.insert(AlbumArtistMap(albumId = ALBUM_ID, artistId = ARTIST_ID, order = 0))
+        }
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun `reading a song leaves the cached artist page on disk`() {
+        val artist = database.dao.getSongByIdBlocking(SONG_ID)!!.artists.single()
+
+        assertNull(artist.cachedPageJson)
+    }
+
+    @Test
+    fun `reading a song keeps every other artist column`() {
+        val artist = database.dao.getSongByIdBlocking(SONG_ID)!!.artists.single()
+
+        assertEquals(ARTIST_ID, artist.id)
+        assertEquals("Artist", artist.name)
+        assertEquals("https://example.invalid/artist.jpg", artist.thumbnailUrl)
+        assertEquals("UCchannel", artist.channelId)
+        assertEquals(UPDATED_AT, artist.lastUpdateTime)
+        assertEquals(BOOKMARKED_AT, artist.bookmarkedAt)
+        assertEquals(false, artist.isLocal)
+        assertEquals(true, artist.isPodcastChannel)
+    }
+
+    @Test
+    fun `reading an album leaves the cached artist page on disk`() = runBlocking {
+        val artist = database.dao.albumWithSongs(ALBUM_ID).first()!!.artists.single()
+
+        assertNull(artist.cachedPageJson)
+    }
+
+    @Test
+    fun `the artist screen still reads the cached page`() = runBlocking {
+        val artist = database.dao.artist(ARTIST_ID).first()!!.artist
+
+        assertEquals(CACHED_PAGE, artist.cachedPageJson)
+    }
+
+    @Test
+    fun `storing a thumbnail found while playing keeps the cached page`() {
+        database.dao.updateArtistThumbnail(ARTIST_ID, "https://example.invalid/fetched.jpg")
+
+        val artist = database.dao.getArtistById(ARTIST_ID)
+        assertNotNull(artist)
+        assertEquals("https://example.invalid/fetched.jpg", artist!!.thumbnailUrl)
+        assertEquals(CACHED_PAGE, artist.cachedPageJson)
+    }
+
+    private companion object {
+        const val ARTIST_ID = "UCartist"
+        const val ALBUM_ID = "album"
+        const val SONG_ID = "song"
+        const val CACHED_PAGE = """{"sections":[{"title":"Songs"}]}"""
+        val UPDATED_AT: LocalDateTime = LocalDateTime.of(2026, 1, 1, 0, 0)
+        val BOOKMARKED_AT: LocalDateTime = LocalDateTime.of(2026, 2, 2, 0, 0)
+    }
+}


### PR DESCRIPTION
## Problem

Opening a screen that lists songs can exhaust the heap. #4246 is an `OutOfMemoryError` whose top frame is `DatabaseDao_Impl.__fetchRelationshipartistAscomMetrolistMusicDbEntitiesArtistEntity`, on a device whose log reads `growth limit 268435456`, so 256 MiB. On a library of 12,311 songs the artist relations alone hold 198 MB.

## Cause

`ArtistEntity.cachedPageJson` stores the artist page as YouTube returned it, added in b1a7af405 (#3813). `Song.artists` and the sibling artist relations are `@Relation`s with no projection, so Room builds a fresh `ArtistEntity` for every pairing and hydrates that column into each one. The page is written once on disk and held once per row in memory: 441 KB across 27 rows becomes 198 MB across 5,821 live copies, each with its own string.

This is also what is blocking #4189. The review there asks for `mostPlayedSongs()` to stop loading unlimited full artist relations; that query returns `List<Song>`, so it goes through `Song.artists`.

## Solution

- `Song.artists`, `SongWithStats.artists`, `Album.artists` and `AlbumWithSongs.artists` now name their columns with `projection`, leaving `cachedPageJson` on disk. The field type stays `List<ArtistEntity>`, so no call site changes.
- Added `updateArtistThumbnail`, used by `MusicService.fetchArtistThumbnail`. That was the one path that took an artist out of a relation and wrote the whole row back, which would have blanked the column now that the relation no longer carries it.
- `ArtistViewModel` is untouched: it reads through `Artist`, which embeds the full row, and still gets the page.
- The column stays in the table and the entity still maps it, so there is no migration and no version bump. Dropping the field from the entity instead, with `ignoredColumns`, would change Room's identity hash and require both.

## Testing

- `./gradlew :app:assembleFossDebug` and `./gradlew :app:testFossDebugUnitTest`, 87 tests green.
- New `ArtistPageCacheTest`, 5 cases against an in-memory database, covering both halves: the bulk relations leave the column null, the artist screen's read still returns it, the other columns survive the projection, and the thumbnail write keeps the page. Reverting the projection in `Song.kt` makes the first case fail.
- Measured on a realme RMX2202, Android 14, `dalvik.vm.heapgrowthlimit=384m`, with a 12,311 song and 4,498 artist library, 27 of them holding a cached page. Same device, same library, same screen, the two builds installed one after the other. Opening Library and then Songs:

| | before | after |
|---|---:|---:|
| Java heap, `dumpsys meminfo` | 356.0 MB | 54.1 MB |
| live `ArtistEntity` holding the page | 5,821 | 23 |
| bytes of artist page retained | 198.2 MB | 0.8 MB |

The 23 that remain are the legitimate ones, one per artist read as a whole row rather than one per song. Before the change the heap sat at 93% of this device's 384 MB limit from opening a tab; #4246 is the same allocation path on a device with 256 MiB.

## Related Issues

- Closes #4246
- Related to #4247, the same session running out of heap and reported from whichever frame asked for the last bytes
- Related to #4113 and #4189. #4189 fixes `SongWithStats` by switching its relation to a lightweight type; this covers that relation too, plus `Song.artists`, which is what the review on #4189 asked for. Glad to drop the `SongWithStats` hunk if you would rather land #4189 first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artist data handling for songs and albums by preventing unnecessary cached page information from being duplicated.
  * Artist thumbnail updates now preserve cached artist page content.
  * Improved reliability when loading artist details, albums, and songs.
* **Tests**
  * Added coverage verifying artist page caching, thumbnail updates, and related artist information remain consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->