### PR TITLE
fix(build): use the innertubex release that carries the playlist APIs

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ timber = "5.0.1"
 materialKolor = "5.0.0"
 kuromojiIpadic = "0.9.0"
 extractor = "3cd3341"
-innertubex = "v0.1.1"
+innertubex = "v0.1.2"
 tinypinyin = "2.0.3"
 protobuf = "4.35.1"
 


### PR DESCRIPTION
## Problem

`main` does not compile. A clean checkout of 9c991782e fails with six errors in `:innertube`:

```
InnerTube.kt:280:20 Unresolved reference 'addPlaylistToPlaylist'.
InnerTube.kt:311:20 Unresolved reference 'setPlaylistThumbnail'.
InnerTube.kt:316:20 Unresolved reference 'removePlaylistThumbnail'.
InnerTube.kt:327:41 Argument type mismatch: actual type is 'ByteArray', but 'Long' was expected.
InnerTube.kt:327:47 Argument type mismatch: actual type is '((Float) -> Unit)?', but '() -> ByteReadChannel' was expected.
InnerTube.kt:331:14 Unresolved reference 'deletePrivatelyOwnedEntity'.
```

## Cause

`libs.versions.toml` pins `innertubex = "v0.1.1"`, and those methods are not in that release. Reading the published artifact confirms it:

```
$ javap -cp innertubex-android-v0.1.1-api.jar com.metrolist.innertubex.InnerTube
  ...
  public final Object uploadSong(String, byte[], Continuation<? super HttpResponse>);
  public final Object uploadSong(String, long, Function0<? extends ByteReadChannel>, Continuation<? super HttpResponse>);
  public final Object addToPlaylist(YouTubeClient, String, String, Continuation<? super HttpResponse>);
  public final Object createPlaylist(YouTubeClient, String, Continuation<? super HttpResponse>);
  public final Object removePlaylistSong(YouTubeClient, String, String, String, Continuation<? super HttpResponse>);
  ...
```

No `addPlaylistToPlaylist`, no `setPlaylistThumbnail`, no `removePlaylistThumbnail`, no `deletePrivatelyOwnedEntity`, and the `uploadSong` overloads take a length and a channel factory rather than a `ByteArray` and a progress callback.

`innertubex` v0.1.2, released about an hour and three quarters after 9c991782e, is the one that adds them — its commit is titled "feat: add playlist and library mutation APIs for v0.1.2". The pin was simply left behind. The `mavenLocal()` entry added in the same commit is why this does not show up locally when the library has been built and installed by hand.

## Solution

- Move the `innertubex` pin from `v0.1.1` to `v0.1.2`. One line, nothing else.

## Testing

- `./gradlew :app:assembleFossDebug` on a clean checkout of `main`: fails with the six errors above. With this change: succeeds.
- `./gradlew :app:testFossDebugUnitTest` and `./gradlew :innertube:testDebugUnitTest`: green.

## Related Issues

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the InnertubeX dependency to version 0.1.2 for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->