### PR TITLE
Fix empty artworks when loaded while offline

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -223,6 +223,12 @@
             android:enabled="true"
             android:exported="false" />
 
+        <provider
+            android:name="com.metrolist.music.playback.aa.ArtworkProvider"
+            android:authorities="${applicationId}.aa.artwork"
+            android:exported="true"
+            android:grantUriPermissions="false" />
+
         <activity
             android:name="com.yalantis.ucrop.UCropActivity"
             android:exported="false"

--- a/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
@@ -64,6 +64,7 @@ import javax.inject.Inject
 import com.metrolist.music.constants.AndroidAutoSectionsOrderKey
 import com.metrolist.music.constants.AndroidAutoYouTubePlaylistsKey
 import com.metrolist.music.constants.AutoRadioQueueKey
+import com.metrolist.music.playback.aa.ArtworkUriResolver
 import com.metrolist.music.playback.queues.ListQueue
 import com.metrolist.music.playback.queues.YouTubeQueue
 import com.metrolist.music.ui.screens.settings.AndroidAutoSection
@@ -77,6 +78,7 @@ constructor(
     @ApplicationContext val context: Context,
     val database: MusicDatabase,
     val downloadUtil: DownloadUtil,
+    val artworkUriResolver: ArtworkUriResolver,
 ) : MediaLibrarySession.Callback {
     private val scope = CoroutineScope(Dispatchers.Main) + Job()
     lateinit var service: MusicService
@@ -904,6 +906,11 @@ constructor(
                 .build(),
         ).build()
 
+    private fun safeArtworkUri(
+        url: String?,
+        @DrawableRes placeholder: Int = R.drawable.music_note,
+    ): Uri = artworkUriResolver.resolve(url, placeholder)
+
     private fun Song.toMediaItem(path: String, isPlayable: Boolean = true, isBrowsable: Boolean = false): MediaItem {
         return MediaItem
             .Builder()
@@ -918,7 +925,7 @@ constructor(
                      .setArtist(artists.joinToArtistString(getArtistSeparator(context)) {
                          ArtistNameAliases.resolve(it.id, it.name)
                      })
-                     .setArtworkUri(song.thumbnailUrl?.toUri())
+                     .setArtworkUri(safeArtworkUri(song.thumbnailUrl))
                     .setIsPlayable(isPlayable)
                     .setIsBrowsable(isBrowsable)
                     .setMediaType(MediaMetadata.MEDIA_TYPE_MUSIC)

--- a/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
@@ -70,7 +70,10 @@ import com.metrolist.music.playback.queues.YouTubeQueue
 import com.metrolist.music.ui.screens.settings.AndroidAutoSection
 import com.metrolist.music.ui.screens.settings.deserializeSections
 import com.metrolist.music.ui.screens.settings.serializeSections
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.time.Duration.Companion.milliseconds
 
 class MediaLibrarySessionCallback
 @Inject
@@ -87,6 +90,9 @@ constructor(
     var toggleLibrary: () -> Unit = {}
     var addToTargetPlaylist: () -> Unit = {}
 
+    private val pendingParentIds = ConcurrentHashMap.newKeySet<String>()
+    private var artworkNotifyJob: Job? = null
+
     fun release() {
         scope.cancel()
     }
@@ -95,6 +101,8 @@ constructor(
         session: MediaSession,
         controller: MediaSession.ControllerInfo,
     ): MediaSession.ConnectionResult {
+        setupArtworkReadyListener()
+
         val connectionResult = super.onConnect(session, controller)
         return MediaSession.ConnectionResult.accept(
             connectionResult.availableSessionCommands
@@ -908,8 +916,37 @@ constructor(
 
     private fun safeArtworkUri(
         url: String?,
+        parentId: String,
         @DrawableRes placeholder: Int = R.drawable.music_note,
-    ): Uri = artworkUriResolver.resolve(url, placeholder)
+    ): Uri {
+        val uri = artworkUriResolver.resolve(url, placeholder)
+        if (uri.scheme != ContentResolver.SCHEME_CONTENT &&
+            !url.isNullOrBlank() &&
+            parentId.startsWith("${MusicService.SEARCH}/")) {
+            return url.toUri()
+        }
+        if (uri.scheme == ContentResolver.SCHEME_ANDROID_RESOURCE) {
+            pendingParentIds.add(parentId)
+        }
+        return uri
+    }
+
+    private fun setupArtworkReadyListener() {
+        artworkUriResolver.setOnArtworkReadyListener {
+            artworkNotifyJob?.cancel()
+            artworkNotifyJob = scope.launch {
+                delay(2000.milliseconds)
+                if (!::service.isInitialized) return@launch
+                val toNotify = pendingParentIds.toList()
+                pendingParentIds.clear()
+                if (toNotify.isEmpty()) return@launch
+                val mediaLibrarySession = service.sessions.firstOrNull() as? MediaLibrarySession
+                toNotify.forEach { parentId ->
+                    mediaLibrarySession?.notifyChildrenChanged(parentId, MAX_ANDROID_AUTO_PAGE_SIZE, null)
+                }
+            }
+        }
+    }
 
     private fun Song.toMediaItem(path: String, isPlayable: Boolean = true, isBrowsable: Boolean = false): MediaItem {
         return MediaItem
@@ -925,7 +962,7 @@ constructor(
                      .setArtist(artists.joinToArtistString(getArtistSeparator(context)) {
                          ArtistNameAliases.resolve(it.id, it.name)
                      })
-                     .setArtworkUri(safeArtworkUri(song.thumbnailUrl))
+                     .setArtworkUri(safeArtworkUri(song.thumbnailUrl, path))
                     .setIsPlayable(isPlayable)
                     .setIsBrowsable(isBrowsable)
                     .setMediaType(MediaMetadata.MEDIA_TYPE_MUSIC)

--- a/app/src/main/kotlin/com/metrolist/music/playback/aa/ArtworkProvider.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/aa/ArtworkProvider.kt
@@ -27,11 +27,12 @@ class ArtworkProvider : ContentProvider() {
         private fun authority(context: Context): String =
             "${context.packageName}.aa.artwork"
 
-        fun uriFor(context: Context, url: String): Uri =
+        fun uriFor(context: Context, url: String, validationToken: String): Uri =
             Uri.Builder()
                 .scheme(ContentResolver.SCHEME_CONTENT)
                 .authority(authority(context))
                 .appendPath(encodeUrl(url))
+                .appendQueryParameter("v", validationToken)
                 .build()
 
         private fun encodeUrl(url: String): String =
@@ -90,6 +91,12 @@ class ArtworkProvider : ContentProvider() {
             if (!file.exists() || file.length() == 0L) {
                 throw FileNotFoundException("Artwork file is empty")
             }
+
+            val expected = uri.getQueryParameter("v")
+            if (expected != null && expected != "${file.length()}:${file.lastModified()}") {
+                throw FileNotFoundException("Artwork replaced after validation")
+            }
+
             return block(file)
         } finally {
             snapshot.close()

--- a/app/src/main/kotlin/com/metrolist/music/playback/aa/ArtworkProvider.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/aa/ArtworkProvider.kt
@@ -93,7 +93,8 @@ class ArtworkProvider : ContentProvider() {
             }
 
             val expected = uri.getQueryParameter("v")
-            if (expected != null && expected != "${file.length()}:${file.lastModified()}") {
+                ?: throw FileNotFoundException("Missing validation token")
+            if (expected != "${file.length()}:${file.lastModified()}") {
                 throw FileNotFoundException("Artwork replaced after validation")
             }
 
@@ -108,7 +109,7 @@ class ArtworkProvider : ContentProvider() {
             .d("openFile called: uri=$uri, mode=$mode, callingUid=${Binder.getCallingUid()}")
 
         enforceAllowedCaller()
-        if (!mode.startsWith("r")) {
+        if (mode != "r") {
             throw FileNotFoundException("Only read mode is supported")
         }
 
@@ -122,7 +123,7 @@ class ArtworkProvider : ContentProvider() {
             .d("openAssetFile called: uri=$uri, mode=$mode, callingUid=${Binder.getCallingUid()}")
 
         enforceAllowedCaller()
-        if (!mode.startsWith("r")) {
+        if (mode != "r") {
             throw FileNotFoundException("Only read mode is supported")
         }
 

--- a/app/src/main/kotlin/com/metrolist/music/playback/aa/ArtworkProvider.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/aa/ArtworkProvider.kt
@@ -1,0 +1,152 @@
+package com.metrolist.music.playback.aa
+
+import android.content.ContentProvider
+import android.content.ContentResolver
+import android.content.ContentValues
+import android.content.Context
+import android.content.res.AssetFileDescriptor
+import android.database.Cursor
+import android.net.Uri
+import android.os.Binder
+import android.os.ParcelFileDescriptor
+import android.util.Base64
+import coil3.imageLoader
+import timber.log.Timber
+import java.io.FileNotFoundException
+
+class ArtworkProvider : ContentProvider() {
+    override fun onCreate(): Boolean = true
+
+    companion object {
+        private val ALLOWED_PACKAGES = setOf(
+            "com.google.android.projection.gearhead", // Android Auto
+            "com.google.android.gms",                 // Google Play Services
+            "com.google.android.automotive",          // Android Automotive OS
+        )
+
+        private fun authority(context: Context): String =
+            "${context.packageName}.aa.artwork"
+
+        fun uriFor(context: Context, url: String): Uri =
+            Uri.Builder()
+                .scheme(ContentResolver.SCHEME_CONTENT)
+                .authority(authority(context))
+                .appendPath(encodeUrl(url))
+                .build()
+
+        private fun encodeUrl(url: String): String =
+            Base64.encodeToString(
+                url.toByteArray(Charsets.UTF_8),
+                Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING,
+            )
+
+        private fun decodeUrl(encoded: String): String =
+            try {
+                String(
+                    Base64.decode(
+                        encoded,
+                        Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING,
+                    ),
+                    Charsets.UTF_8,
+                )
+            } catch (_: IllegalArgumentException) {
+                throw FileNotFoundException("Invalid artwork key encoding")
+            }
+    }
+
+    private fun enforceAllowedCaller() {
+        val ctx = context ?: throw SecurityException("No context")
+        val callingUid = Binder.getCallingUid()
+
+        if (callingUid == android.os.Process.myUid()) return
+
+        val pm = ctx.packageManager
+        val callingPackages = pm.getPackagesForUid(callingUid) ?: emptyArray()
+
+        val isAllowed = callingPackages.any { pkg ->
+            pkg in ALLOWED_PACKAGES || pkg == ctx.packageName
+        }
+
+        if (!isAllowed) {
+            throw SecurityException(
+                "Caller ${callingPackages.joinToString()} is not allowed to access ArtworkProvider"
+            )
+        }
+    }
+
+    private fun <T> withArtworkFile(uri: Uri, block: (java.io.File) -> T): T {
+        val ctx = context ?: throw FileNotFoundException("No context")
+        val encoded = uri.lastPathSegment ?: throw FileNotFoundException("Missing artwork key")
+        val url = decodeUrl(encoded)
+
+        val diskCache = ctx.imageLoader.diskCache
+            ?: throw FileNotFoundException("Coil disk cache unavailable")
+
+        val snapshot = diskCache.openSnapshot(url)
+            ?: throw FileNotFoundException("Artwork not found in Coil cache")
+
+        try {
+            val file = snapshot.data.toFile()
+            if (!file.exists() || file.length() == 0L) {
+                throw FileNotFoundException("Artwork file is empty")
+            }
+            return block(file)
+        } finally {
+            snapshot.close()
+        }
+    }
+
+    override fun openFile(uri: Uri, mode: String): ParcelFileDescriptor? {
+        Timber.tag("ArtworkProvider")
+            .d("openFile called: uri=$uri, mode=$mode, callingUid=${Binder.getCallingUid()}")
+
+        enforceAllowedCaller()
+        if (!mode.startsWith("r")) {
+            throw FileNotFoundException("Only read mode is supported")
+        }
+
+        return withArtworkFile(uri) { file ->
+            ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
+        }
+    }
+
+    override fun openAssetFile(uri: Uri, mode: String): AssetFileDescriptor {
+        Timber.tag("ArtworkProvider")
+            .d("openAssetFile called: uri=$uri, mode=$mode, callingUid=${Binder.getCallingUid()}")
+
+        enforceAllowedCaller()
+        if (!mode.startsWith("r")) {
+            throw FileNotFoundException("Only read mode is supported")
+        }
+
+        return withArtworkFile(uri) { file ->
+            val pfd = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
+            AssetFileDescriptor(pfd, 0, file.length())
+        }
+    }
+
+    override fun getType(uri: Uri): String = "image/*"
+
+    override fun query(
+        uri: Uri,
+        projection: Array<out String>?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+        sortOrder: String?,
+    ): Cursor? = null
+
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+    ): Int = 0
+
+    override fun delete(
+        uri: Uri,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+    ): Int = 0
+}

--- a/app/src/main/kotlin/com/metrolist/music/playback/aa/ArtworkUriResolver.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/aa/ArtworkUriResolver.kt
@@ -13,6 +13,7 @@ import coil3.request.ErrorResult
 import coil3.request.ImageRequest
 import com.metrolist.music.R
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -244,7 +245,10 @@ class ArtworkUriResolver @Inject constructor(
                         addFailedUrl(url)
                     }
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (_: Throwable) {
+                addFailedUrl(url)
             } finally {
                 prefetchedUrls.remove(url)
             }

--- a/app/src/main/kotlin/com/metrolist/music/playback/aa/ArtworkUriResolver.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/aa/ArtworkUriResolver.kt
@@ -48,6 +48,7 @@ class ArtworkUriResolver @Inject constructor(
     private val failedUrls = ConcurrentHashMap<String, Long>()
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val semaphore = Semaphore(MAX_CONCURRENT_DOWNLOADS)
+    private var onArtworkReadyListener: ((String) -> Unit)? = null
 
     private data class ValidatedFileIdentity(val size: Long, val lastModified: Long)
     private val validatedFiles: MutableMap<String, ValidatedFileIdentity> =
@@ -247,11 +248,16 @@ class ArtworkUriResolver @Inject constructor(
         }
     }
 
+    fun setOnArtworkReadyListener(listener: ((String) -> Unit)?) {
+        onArtworkReadyListener = listener
+    }
+
     internal fun onPrefetchCompleted(url: String, isError: Boolean) {
         if (isError || validatedIdentity(url) == null) {
             addFailedUrl(url)
         } else {
             failedUrls.remove(url)
+            onArtworkReadyListener?.invoke(url)
         }
     }
 

--- a/app/src/main/kotlin/com/metrolist/music/playback/aa/ArtworkUriResolver.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/aa/ArtworkUriResolver.kt
@@ -1,0 +1,97 @@
+package com.metrolist.music.playback.aa
+
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import androidx.annotation.DrawableRes
+import coil3.imageLoader
+import coil3.request.CachePolicy
+import coil3.request.ImageRequest
+import com.metrolist.music.R
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ArtworkUriResolver @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private companion object {
+        const val MAX_CONCURRENT_DOWNLOADS = 10
+        const val MAX_PENDING_PREFETCHES = 100
+    }
+
+    private val prefetchedUrls = ConcurrentHashMap.newKeySet<String>()
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val semaphore = Semaphore(MAX_CONCURRENT_DOWNLOADS)
+
+    fun resolve(
+        url: String?,
+        @DrawableRes placeholder: Int = R.drawable.music_note,
+    ): Uri {
+        if (url.isNullOrBlank()) {
+            return drawableUri(placeholder)
+        }
+
+        if (isInCoilDiskCache(url)) {
+            return ArtworkProvider.uriFor(context, url)
+        }
+
+        schedulePrefetch(url)
+        return drawableUri(placeholder)
+    }
+
+    private fun isInCoilDiskCache(url: String): Boolean {
+        return try {
+            val snapshot = context.imageLoader.diskCache?.openSnapshot(url)
+                ?: return false
+
+            try {
+                true
+            } finally {
+                snapshot.close()
+            }
+        } catch (_: Throwable) {
+            false
+        }
+    }
+
+    private fun schedulePrefetch(url: String) {
+        val isScheduleAllowed = synchronized(prefetchedUrls) {
+            prefetchedUrls.size < MAX_PENDING_PREFETCHES && prefetchedUrls.add(url)
+        }
+        if (!isScheduleAllowed) return
+
+        scope.launch {
+            try {
+                semaphore.withPermit {
+                    val request = ImageRequest.Builder(context)
+                        .data(url)
+                        .memoryCachePolicy(CachePolicy.DISABLED)
+                        .diskCachePolicy(CachePolicy.ENABLED)
+                        .build()
+
+                    context.imageLoader.execute(request)
+                }
+            } catch (_: Throwable) {
+            } finally {
+                prefetchedUrls.remove(url)
+            }
+        }
+    }
+
+    private fun drawableUri(@DrawableRes id: Int): Uri =
+        Uri.Builder()
+            .scheme(ContentResolver.SCHEME_ANDROID_RESOURCE)
+            .authority(context.resources.getResourcePackageName(id))
+            .appendPath(context.resources.getResourceTypeName(id))
+            .appendPath(context.resources.getResourceEntryName(id))
+            .build()
+}

--- a/app/src/main/kotlin/com/metrolist/music/playback/aa/ArtworkUriResolver.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/aa/ArtworkUriResolver.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import timber.log.Timber
 import java.io.File
+import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -39,6 +40,7 @@ class ArtworkUriResolver @Inject constructor(
         const val MAX_ARTWORK_DIMENSION = 4096
         const val VALIDATION_DECODE_SIZE = 32
         const val MIN_ARTWORK_FILE_SIZE = 100L
+        const val MAX_VALIDATED_FILES_SIZE = 2000
     }
 
     private val prefetchedUrls = ConcurrentHashMap.newKeySet<String>()
@@ -47,7 +49,14 @@ class ArtworkUriResolver @Inject constructor(
     private val semaphore = Semaphore(MAX_CONCURRENT_DOWNLOADS)
 
     private data class ValidatedFileIdentity(val size: Long, val lastModified: Long)
-    private val validatedFiles = ConcurrentHashMap<String, ValidatedFileIdentity>()
+    private val validatedFiles: MutableMap<String, ValidatedFileIdentity> =
+        Collections.synchronizedMap(
+            object : LinkedHashMap<String, ValidatedFileIdentity>(64, 0.75f, true) {
+                override fun removeEldestEntry(
+                    eldest: MutableMap.MutableEntry<String, ValidatedFileIdentity>,
+                ): Boolean = size > MAX_VALIDATED_FILES_SIZE
+            },
+        )
 
     fun resolve(
         url: String?,
@@ -57,35 +66,39 @@ class ArtworkUriResolver @Inject constructor(
             return drawableUri(placeholder)
         }
 
-        if (isInCoilDiskCache(url)) {
-            return ArtworkProvider.uriFor(context, url)
+        validatedIdentity(url)?.let {
+            return ArtworkProvider.uriFor(context, url, it)
         }
 
         schedulePrefetch(url)
         return drawableUri(placeholder)
     }
 
-    private fun isInCoilDiskCache(url: String): Boolean {
-        val diskCache = context.imageLoader.diskCache ?: return false
+    private fun validatedIdentity(url: String): String? {
+        val diskCache = context.imageLoader.diskCache ?: return null
 
         val snapshot = try {
             diskCache.openSnapshot(url)
         } catch (_: Throwable) {
             null
-        } ?: return false
+        } ?: return null
 
-        val isValid = try {
+        val identity = try {
             val file = snapshot.data.toFile()
-            file.exists() && file.length() > 0L && isValidImageFile(file)
+            if (file.exists() && file.length() > 0L && isValidImageFile(file)) {
+                "${file.length()}:${file.lastModified()}"
+            } else {
+                null
+            }
         } catch (_: Throwable) {
-            false
+            null
         }
         snapshot.close()
 
-        if (!isValid) {
+        if (identity == null) {
             runCatching { diskCache.remove(url) }
         }
-        return isValid
+        return identity
     }
 
     internal fun isValidImageFile(file: File): Boolean {

--- a/app/src/main/kotlin/com/metrolist/music/playback/aa/ArtworkUriResolver.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/aa/ArtworkUriResolver.kt
@@ -54,7 +54,8 @@ class ArtworkUriResolver @Inject constructor(
                 ?: return false
 
             try {
-                true
+                val file = snapshot.data.toFile()
+                file.exists() && file.length() > 0L
             } finally {
                 snapshot.close()
             }

--- a/app/src/main/kotlin/com/metrolist/music/playback/aa/ArtworkUriResolver.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/aa/ArtworkUriResolver.kt
@@ -2,10 +2,13 @@ package com.metrolist.music.playback.aa
 
 import android.content.ContentResolver
 import android.content.Context
+import android.graphics.BitmapFactory
 import android.net.Uri
 import androidx.annotation.DrawableRes
+import androidx.media3.common.util.SystemClock
 import coil3.imageLoader
 import coil3.request.CachePolicy
+import coil3.request.ErrorResult
 import coil3.request.ImageRequest
 import com.metrolist.music.R
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -15,6 +18,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
+import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -27,9 +31,12 @@ class ArtworkUriResolver @Inject constructor(
         const val MAX_CONCURRENT_DOWNLOADS = 10
         const val MAX_PENDING_PREFETCHES = 100
         const val PREFETCH_DECODE_SIZE = 100
+        const val MAX_FAILED_URLS = 500
+        const val FAILED_RETRY_DELAY_MS = 10 * 60 * 1000L
     }
 
     private val prefetchedUrls = ConcurrentHashMap.newKeySet<String>()
+    private val failedUrls = ConcurrentHashMap<String, Long>()
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val semaphore = Semaphore(MAX_CONCURRENT_DOWNLOADS)
 
@@ -37,7 +44,7 @@ class ArtworkUriResolver @Inject constructor(
         url: String?,
         @DrawableRes placeholder: Int = R.drawable.music_note,
     ): Uri {
-        if (url.isNullOrBlank()) {
+        if (url.isNullOrBlank() || isFailedRecently(url)) {
             return drawableUri(placeholder)
         }
 
@@ -60,7 +67,7 @@ class ArtworkUriResolver @Inject constructor(
 
         val isValid = try {
             val file = snapshot.data.toFile()
-            file.exists() && file.length() > 0L
+            file.exists() && file.length() > 0L && isValidImageFile(file)
         } catch (_: Throwable) {
             false
         }
@@ -72,7 +79,19 @@ class ArtworkUriResolver @Inject constructor(
         return isValid
     }
 
+    private fun isValidImageFile(file: File): Boolean {
+        return try {
+            val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+            BitmapFactory.decodeFile(file.absolutePath, options)
+            options.outWidth > 0 && options.outHeight > 0
+        } catch (_: Throwable) {
+            false
+        }
+    }
+
     private fun schedulePrefetch(url: String) {
+        if (context.imageLoader.diskCache == null) return
+
         val isScheduleAllowed = synchronized(prefetchedUrls) {
             prefetchedUrls.size < MAX_PENDING_PREFETCHES && prefetchedUrls.add(url)
         }
@@ -88,12 +107,39 @@ class ArtworkUriResolver @Inject constructor(
                         .diskCachePolicy(CachePolicy.WRITE_ONLY)
                         .build()
 
-                    context.imageLoader.execute(request)
+                    val result = context.imageLoader.execute(request)
+                    if (result is ErrorResult) {
+                        addFailedUrl(url)
+                    }
                 }
             } catch (_: Throwable) {
             } finally {
                 prefetchedUrls.remove(url)
             }
+        }
+    }
+
+    private fun isFailedRecently(url: String): Boolean {
+        val failedAt = failedUrls[url] ?: return false
+        val now = SystemClock.DEFAULT.elapsedRealtime()
+
+        if (now - failedAt >= FAILED_RETRY_DELAY_MS) {
+            failedUrls.remove(url, failedAt)
+            return false
+        }
+
+        return true
+    }
+
+    private fun addFailedUrl(url: String) {
+        val now = SystemClock.DEFAULT.elapsedRealtime()
+        failedUrls[url] = now
+
+        if (failedUrls.size <= MAX_FAILED_URLS) return
+
+        while (failedUrls.size > MAX_FAILED_URLS) {
+            val oldest = failedUrls.entries.minByOrNull { it.value } ?: break
+            failedUrls.remove(oldest.key, oldest.value)
         }
     }
 

--- a/app/src/main/kotlin/com/metrolist/music/playback/aa/ArtworkUriResolver.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/aa/ArtworkUriResolver.kt
@@ -243,6 +243,8 @@ class ArtworkUriResolver @Inject constructor(
                     val result = context.imageLoader.execute(request)
                     if (result is ErrorResult) {
                         addFailedUrl(url)
+                    }  else {
+                        failedUrls.remove(url)
                     }
                 }
             } catch (e: CancellationException) {

--- a/app/src/main/kotlin/com/metrolist/music/playback/aa/ArtworkUriResolver.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/aa/ArtworkUriResolver.kt
@@ -84,20 +84,20 @@ class ArtworkUriResolver @Inject constructor(
             null
         } ?: return null
 
+        val file = snapshot.data.toFile()
+        val seenIdentity = "${file.length()}:${file.lastModified()}"
         val identity = try {
-            val file = snapshot.data.toFile()
-            if (file.exists() && file.length() > 0L && isValidImageFile(file)) {
-                "${file.length()}:${file.lastModified()}"
-            } else {
-                null
-            }
+            if (file.exists() && file.length() > 0L && isValidImageFile(file)) seenIdentity else null
         } catch (_: Throwable) {
             null
         }
         snapshot.close()
 
         if (identity == null) {
-            runCatching { diskCache.remove(url) }
+            // In case a concurrent prefetch with the same url completes successfully
+            if ("${file.length()}:${file.lastModified()}" == seenIdentity) {
+                runCatching { diskCache.remove(url) }
+            }
         }
         return identity
     }
@@ -241,11 +241,7 @@ class ArtworkUriResolver @Inject constructor(
                         .build()
 
                     val result = context.imageLoader.execute(request)
-                    if (result is ErrorResult) {
-                        addFailedUrl(url)
-                    }  else {
-                        failedUrls.remove(url)
-                    }
+                    onPrefetchCompleted(url, result is ErrorResult)
                 }
             } catch (e: CancellationException) {
                 throw e
@@ -257,7 +253,15 @@ class ArtworkUriResolver @Inject constructor(
         }
     }
 
-    private fun isFailedRecently(url: String): Boolean {
+    internal fun onPrefetchCompleted(url: String, isError: Boolean) {
+        if (isError || validatedIdentity(url) == null) {
+            addFailedUrl(url)
+        } else {
+            failedUrls.remove(url)
+        }
+    }
+
+    internal fun isFailedRecently(url: String): Boolean {
         val failedAt = failedUrls[url] ?: return false
         val now = SystemClock.DEFAULT.elapsedRealtime()
 

--- a/app/src/main/kotlin/com/metrolist/music/playback/aa/ArtworkUriResolver.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/aa/ArtworkUriResolver.kt
@@ -85,20 +85,14 @@ class ArtworkUriResolver @Inject constructor(
         } ?: return null
 
         val file = snapshot.data.toFile()
-        val seenIdentity = "${file.length()}:${file.lastModified()}"
         val identity = try {
-            if (file.exists() && file.length() > 0L && isValidImageFile(file)) seenIdentity else null
+            if (file.exists() && file.length() > 0L && isValidImageFile(file)) {
+                "${file.length()}:${file.lastModified()}"
+            } else null
         } catch (_: Throwable) {
             null
         }
         snapshot.close()
-
-        if (identity == null) {
-            // In case a concurrent prefetch with the same url completes successfully
-            if ("${file.length()}:${file.lastModified()}" == seenIdentity) {
-                runCatching { diskCache.remove(url) }
-            }
-        }
         return identity
     }
 

--- a/app/src/main/kotlin/com/metrolist/music/playback/aa/ArtworkUriResolver.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/aa/ArtworkUriResolver.kt
@@ -26,6 +26,7 @@ class ArtworkUriResolver @Inject constructor(
     private companion object {
         const val MAX_CONCURRENT_DOWNLOADS = 10
         const val MAX_PENDING_PREFETCHES = 100
+        const val PREFETCH_DECODE_SIZE = 100
     }
 
     private val prefetchedUrls = ConcurrentHashMap.newKeySet<String>()
@@ -49,19 +50,26 @@ class ArtworkUriResolver @Inject constructor(
     }
 
     private fun isInCoilDiskCache(url: String): Boolean {
-        return try {
-            val snapshot = context.imageLoader.diskCache?.openSnapshot(url)
-                ?: return false
+        val diskCache = context.imageLoader.diskCache ?: return false
 
-            try {
-                val file = snapshot.data.toFile()
-                file.exists() && file.length() > 0L
-            } finally {
-                snapshot.close()
-            }
+        val snapshot = try {
+            diskCache.openSnapshot(url)
+        } catch (_: Throwable) {
+            null
+        } ?: return false
+
+        val isValid = try {
+            val file = snapshot.data.toFile()
+            file.exists() && file.length() > 0L
         } catch (_: Throwable) {
             false
         }
+        snapshot.close()
+
+        if (!isValid) {
+            runCatching { diskCache.remove(url) }
+        }
+        return isValid
     }
 
     private fun schedulePrefetch(url: String) {
@@ -75,8 +83,9 @@ class ArtworkUriResolver @Inject constructor(
                 semaphore.withPermit {
                     val request = ImageRequest.Builder(context)
                         .data(url)
+                        .size(PREFETCH_DECODE_SIZE)
                         .memoryCachePolicy(CachePolicy.DISABLED)
-                        .diskCachePolicy(CachePolicy.ENABLED)
+                        .diskCachePolicy(CachePolicy.WRITE_ONLY)
                         .build()
 
                     context.imageLoader.execute(request)

--- a/app/src/main/kotlin/com/metrolist/music/playback/aa/ArtworkUriResolver.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/aa/ArtworkUriResolver.kt
@@ -2,6 +2,7 @@ package com.metrolist.music.playback.aa
 
 import android.content.ContentResolver
 import android.content.Context
+import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
 import androidx.annotation.DrawableRes
@@ -18,6 +19,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
+import timber.log.Timber
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
@@ -32,13 +34,20 @@ class ArtworkUriResolver @Inject constructor(
         const val MAX_PENDING_PREFETCHES = 100
         const val PREFETCH_DECODE_SIZE = 100
         const val MAX_FAILED_URLS = 500
-        const val FAILED_RETRY_DELAY_MS = 10 * 60 * 1000L
+        const val FAILED_RETRY_DELAY_MS = 5 * 60 * 1000L
+
+        const val MAX_ARTWORK_DIMENSION = 4096
+        const val VALIDATION_DECODE_SIZE = 32
+        const val MIN_ARTWORK_FILE_SIZE = 100L
     }
 
     private val prefetchedUrls = ConcurrentHashMap.newKeySet<String>()
     private val failedUrls = ConcurrentHashMap<String, Long>()
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val semaphore = Semaphore(MAX_CONCURRENT_DOWNLOADS)
+
+    private data class ValidatedFileIdentity(val size: Long, val lastModified: Long)
+    private val validatedFiles = ConcurrentHashMap<String, ValidatedFileIdentity>()
 
     fun resolve(
         url: String?,
@@ -79,15 +88,125 @@ class ArtworkUriResolver @Inject constructor(
         return isValid
     }
 
-    private fun isValidImageFile(file: File): Boolean {
+    internal fun isValidImageFile(file: File): Boolean {
+        if (!file.exists()) return false
+        val fileSize = file.length()
+        if (fileSize < MIN_ARTWORK_FILE_SIZE) return false
+
+        val identity = ValidatedFileIdentity(fileSize, file.lastModified())
+        if (validatedFiles[file.absolutePath] == identity) return true
+
+        if (!hasKnownImageSignature(file)) return false
+
+        // Stage 1: bounds check
+        val boundsOptions = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        try {
+            BitmapFactory.decodeFile(file.absolutePath, boundsOptions)
+        } catch (_: Throwable) {
+            return false
+        }
+
+        val width = boundsOptions.outWidth
+        val height = boundsOptions.outHeight
+
+        if (width <= 0 || height <= 0) return false
+        if (width > MAX_ARTWORK_DIMENSION || height > MAX_ARTWORK_DIMENSION) return false
+
+        //Check JPEG truncation
+        if (isJpeg(file) && !containsJpegEoi(file)) return false
+
+        // Stage 2: sampled decode
+        val sampleSize = calculateInSampleSize(width, height)
+        val decodeOptions = BitmapFactory.Options().apply {
+            inSampleSize = sampleSize
+            inPreferredConfig = Bitmap.Config.ARGB_8888
+        }
+        val bitmap = try {
+            BitmapFactory.decodeFile(file.absolutePath, decodeOptions)
+        } catch (_: Throwable) {
+            null
+        }
+
+        val isValid = bitmap != null && bitmap.width > 0 && bitmap.height > 0
+        bitmap?.recycle()
+
+        if (isValid) {
+            validatedFiles[file.absolutePath] = identity
+        } else {
+            Timber.tag("ArtworkUriResolver")
+                .d("Artwork file $file is invalid")
+            validatedFiles.remove(file.absolutePath)
+        }
+
+        return isValid
+    }
+
+    private fun calculateInSampleSize(width: Int, height: Int): Int {
+        var sampleSize = 1
+        while (width / (sampleSize * 2) >= VALIDATION_DECODE_SIZE
+                && height / (sampleSize * 2) >= VALIDATION_DECODE_SIZE) {
+            sampleSize *= 2
+        }
+        return sampleSize
+    }
+
+    private fun hasKnownImageSignature(file: File): Boolean {
         return try {
-            val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-            BitmapFactory.decodeFile(file.absolutePath, options)
-            options.outWidth > 0 && options.outHeight > 0
+            file.inputStream().use { input ->
+                val header = ByteArray(12)
+                val read = input.read(header)
+                when {
+                    // JPEG: FF D8 FF
+                    read >= 3 &&
+                            header[0] == 0xFF.toByte() &&
+                            header[1] == 0xD8.toByte() &&
+                            header[2] == 0xFF.toByte() -> true
+                    // PNG: 89 50 4E 47
+                    read >= 4 &&
+                            header[0] == 0x89.toByte() &&
+                            header[1] == 0x50.toByte() &&
+                            header[2] == 0x4E.toByte() &&
+                            header[3] == 0x47.toByte() -> true
+                    // WebP: RIFF....WEBP
+                    read >= 12 &&
+                            header[0] == 0x52.toByte() && header[1] == 0x49.toByte() &&
+                            header[2] == 0x46.toByte() && header[3] == 0x46.toByte() &&
+                            header[8] == 0x57.toByte() && header[9] == 0x45.toByte() &&
+                            header[10] == 0x42.toByte() && header[11] == 0x50.toByte() -> true
+                    // GIF: GIF8
+                    read >= 4 &&
+                            header[0] == 0x47.toByte() && header[1] == 0x49.toByte() &&
+                            header[2] == 0x46.toByte() && header[3] == 0x38.toByte() -> true
+                    else -> false
+                }
+            }
         } catch (_: Throwable) {
             false
         }
     }
+
+    private fun isJpeg(file: File): Boolean =
+        try {
+            file.inputStream().use { it.read() == 0xFF && it.read() == 0xD8 }
+        } catch (_: Throwable) {
+            false
+        }
+
+    private fun containsJpegEoi(file: File): Boolean =
+        try {
+            file.inputStream().buffered().use { input ->
+                var prev = input.read()
+                while (prev != -1) {
+                    val curr = input.read()
+                    if (curr == -1) return false
+                    if (prev == 0xFF && curr == 0xD9) return true
+                    prev = curr
+                }
+                false
+            }
+        } catch (_: Throwable) {
+            false
+        }
 
     private fun schedulePrefetch(url: String) {
         if (context.imageLoader.diskCache == null) return

--- a/app/src/test/kotlin/com/metrolist/music/playback/aa/ArtworkUriResolverValidationTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/playback/aa/ArtworkUriResolverValidationTest.kt
@@ -207,4 +207,17 @@ class ArtworkUriResolverValidationTest {
         val lo = bytes[markerIndex + 3].toInt() and 0xFF
         return (hi shl 8) or lo
     }
+
+    @Test
+    fun prefetchSuccessWithoutValidSnapshot_retainsBackoff() {
+        // Simulates the outcome of a successful prefetch on the network side
+        // but with no disk cache entries to serve.
+        val url = "https://random.url.com/artwork-missing"
+        resolver.onPrefetchCompleted(url, isError = false)
+
+        Assert.assertTrue(
+            "Backoff must remain if there is no serviceable snapshot",
+            resolver.isFailedRecently(url),
+        )
+    }
 }

--- a/app/src/test/kotlin/com/metrolist/music/playback/aa/ArtworkUriResolverValidationTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/playback/aa/ArtworkUriResolverValidationTest.kt
@@ -1,0 +1,210 @@
+package com.metrolist.music.playback.aa
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Color
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.ByteArrayOutputStream
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+class ArtworkUriResolverValidationTest {
+    private lateinit var context: Context
+    private lateinit var resolver: ArtworkUriResolver
+
+    private companion object {
+        const val MIN_VALID_FILE_SIZE = 100     // Equal to ArtworkUriResolver.MIN_ARTWORK_FILE_SIZE
+    }
+
+    @Before
+    fun setUp() {
+        context = InstrumentationRegistry.getInstrumentation().targetContext
+        resolver = ArtworkUriResolver(context)
+    }
+
+
+    @Test
+    fun truncatedJpeg_boundsPassButValidationFails() {
+        val fullBytes = createImageBytes(Bitmap.CompressFormat.JPEG)
+
+        val sosIndex = findJpegSos(fullBytes)
+        Assert.assertTrue("SOS marker should be present", sosIndex > 0)
+
+        val sosLength = jpegSegmentLength(fullBytes, sosIndex)
+        val truncateAt = sosIndex + 2 + sosLength
+
+        Assert.assertTrue(
+            "Truncated file must exceed the minimum byte threshold",
+            truncateAt >= MIN_VALID_FILE_SIZE
+        )
+        Assert.assertTrue(
+            "Truncated file must be smaller than the original",
+            truncateAt < fullBytes.size
+        )
+
+        val truncatedBytes = fullBytes.copyOfRange(0, truncateAt)
+        val file = File.createTempFile("aa_truncated", ".jpg", context.cacheDir)
+
+        println(fullBytes.contentToString())
+        println(truncatedBytes.contentToString())
+
+        try {
+            file.writeBytes(truncatedBytes)
+            val boundsOptions = BitmapFactory.Options().apply {
+                inJustDecodeBounds = true
+            }
+            BitmapFactory.decodeFile(file.absolutePath, boundsOptions)
+
+            Assert.assertTrue(
+                "Bounds check should pass because the SOF is intact",
+                boundsOptions.outWidth > 0 && boundsOptions.outHeight > 0
+            )
+
+            Assert.assertFalse(
+                "Truncated JPEG should not pass full validation",
+                resolver.isValidImageFile(file)
+            )
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test
+    fun validJpeg_passesValidation() {
+        val file = File.createTempFile("aa_valid", ".jpg", context.cacheDir)
+
+        try {
+            file.writeBytes(createImageBytes(Bitmap.CompressFormat.JPEG))
+
+            Assert.assertTrue(
+                "Valid JPEG must pass validation",
+                resolver.isValidImageFile(file)
+            )
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test
+    fun emptyFile_failsValidation() {
+        val file = File.createTempFile("aa_empty", ".jpg", context.cacheDir)
+
+        try {
+            file.writeBytes(ByteArray(0))
+
+            Assert.assertFalse(
+                "Empty file must fail validation",
+                resolver.isValidImageFile(file)
+            )
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test
+    fun randomBytes_failValidation() {
+        val file = File.createTempFile("aa_random", ".jpg", context.cacheDir)
+
+        try {
+            val randomBytes = ByteArray(500) { (Math.random() * 256).toInt().toByte() }
+            file.writeBytes(randomBytes)
+
+            Assert.assertFalse(
+                "Random bytes must not pass validation",
+                resolver.isValidImageFile(file)
+            )
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test
+    fun validationCache_invalidatedWhenFileChanges() {
+        val file = File.createTempFile("aa_cache", ".jpg", context.cacheDir)
+
+        try {
+            file.writeBytes(createImageBytes(Bitmap.CompressFormat.JPEG))
+
+            Assert.assertTrue(
+                "Initial valid JPEG must pass validation",
+                resolver.isValidImageFile(file)
+            )
+
+            // Overwrite with invalid data
+            file.writeBytes(ByteArray(500) { 0 })
+
+            Assert.assertFalse(
+                "Cache must invalidate when the file changes",
+                resolver.isValidImageFile(file)
+            )
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test
+    fun png_ValidAndTruncated() {
+        val fullBytes = createImageBytes(Bitmap.CompressFormat.PNG)
+        val truncateAt = fullBytes.size / 2
+        Assert.assertTrue(
+            "Truncated file must exceed the minimum byte threshold",
+            truncateAt >= MIN_VALID_FILE_SIZE
+        )
+        val truncatedBytes = fullBytes.copyOfRange(0, truncateAt)
+
+        val validFile = File.createTempFile("aa_valid_png", ".png", context.cacheDir)
+        val truncatedFile = File.createTempFile("aa_truncated_png", ".png", context.cacheDir)
+        try {
+            validFile.writeBytes(createImageBytes(Bitmap.CompressFormat.PNG))
+            Assert.assertTrue(
+                "Valid PNG must pass validation",
+                resolver.isValidImageFile(validFile)
+            )
+
+            truncatedFile.writeBytes(truncatedBytes)
+            Assert.assertFalse(
+                "Truncated PNG should not pass full validation",
+                resolver.isValidImageFile(truncatedFile)
+            )
+        } finally {
+            validFile.delete()
+            truncatedFile.delete()
+        }
+    }
+
+
+    // Helper
+    private fun createImageBytes(
+        format: Bitmap.CompressFormat,
+        size: Int = 100,
+        color: Int = Color.RED
+    ): ByteArray {
+        val bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
+        bitmap.eraseColor(color)
+        val baos = ByteArrayOutputStream()
+        bitmap.compress(format, 100, baos)
+        bitmap.recycle()
+        return baos.toByteArray()
+    }
+
+    private fun findJpegSos(bytes: ByteArray): Int {
+        for (i in 0 until bytes.size - 1) {
+            if (bytes[i] == 0xFF.toByte() && bytes[i + 1] == 0xDA.toByte()) {
+                return i
+            }
+        }
+        return -1
+    }
+
+    private fun jpegSegmentLength(bytes: ByteArray, markerIndex: Int): Int {
+        val hi = bytes[markerIndex + 2].toInt() and 0xFF
+        val lo = bytes[markerIndex + 3].toInt() and 0xFF
+        return (hi shl 8) or lo
+    }
+}


### PR DESCRIPTION
add ArtworkProvider and resolver to handle artwork for Android Auto

## Problem
In one of the latest commits artworks of songs on android auto were reverted to use ArtworkUri instead of ArtworkData (based on the already present cache on the phone) because it caused OOM crashes. This reintroduces the problem where, because of how Android Auto caches URIs, if a song is displayed while the phone is offline, the URI of that artwork song is cached as an empty artwork, which does not fix by itself (the only ""fix"" is to delete the Android Auto cache so you can recache the URIs).

## Cause
Already explained in the problem section, the problem is Android Auto itself.

## Solution
Reuse again the already present cache on the phone, but this time by providing an URI instead of Data. This should not cause OOM crashes.
This is done by creating an ArtworkProvider (ContentProvider) that allows only packages related to Android Auto and resolving the URIs by checking beforehand if the artwork is already in the CoilCache of the phone. If so, it sends a content:// uri for that artwork to Android Auto, if not it instead return a placeholder URI and schedule a prefetch that will download the artworks in background (hard limited to 100 pending, to not risk an overload -- if a playlist contains more than 100, just open the playlist more times). To load the downloaded artworks you just need to exit and reenter that specific playlist.

Note: Android Auto will still cache the URIs that we provide by using the implemented ContentProvider, so in fact for a specific song the ContentProvider is used only one time because AA will use the cached artwork, but this time the cached art will just be the artwork in the CoilCache, without the chance that it will be empty because in fact it is downloaded on the phone, bypassing the problem that i want to solve.

## Testing
Tested by using the AA Desktop Head Unit on Android Studio.

## Related Issues
- Related to #3510 , #4280 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved artwork handling during media playback and Android Auto experiences.
  - Added secure, read-only artwork access for supported playback integrations.
  - Artwork is identified as image content for compatible playback experiences.
  - Added a music-note placeholder when artwork is missing or unavailable.
  - Missing artwork can be fetched automatically in the background.
  - Media library artwork updates automatically when downloads complete.

- **Bug Fixes**
  - Invalid, incomplete, or corrupted cached artwork is now rejected safely.
  - Artwork validation detects changed or unsupported image data.
  - Failed artwork requests retain retry backoff when no valid artwork is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->