### PR TITLE
fix(lyrics): keep Cyrillic romanization on one alphabet per song

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/lyrics/LyricsUtils.kt
@@ -266,7 +266,9 @@ object LyricsUtils {
 
         "ѓ" to "gj", "ѕ" to "dz", "и" to "i", "ј" to "j", "љ" to "lj",
         "њ" to "nj", "ќ" to "kj", "џ" to "dž", "ч" to "č", "ш" to "sh",
-        "ж" to "zh", "ц" to "c", "х" to "h"
+        "ж" to "zh", "ц" to "c", "х" to "h",
+
+        "Ѐ" to "E", "ѐ" to "e", "Ѝ" to "I", "ѝ" to "i"
     )
 
     private val RUSSIAN_CYRILLIC_LETTERS = setOf(
@@ -334,7 +336,9 @@ object LyricsUtils {
 
         "а", "б", "в", "г", "д", "ѓ", "е", "ж", "з", "ѕ", "и", "ј", "к", "л",
         "љ", "м", "н", "њ", "о", "п", "р", "с", "т", "ќ", "у", "ф", "х",
-        "ц", "ч", "џ", "ш"
+        "ц", "ч", "џ", "ш",
+
+        "Ѐ", "ѐ", "Ѝ", "ѝ"
     )
 
     private val UKRAINIAN_SPECIFIC_CYRILLIC_LETTERS = setOf(

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/OriginalLyrics.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/OriginalLyrics.kt
@@ -294,31 +294,31 @@ fun OriginalLyrics(
                                 }
 
                                 "Ukrainian" in enabledLanguages && isUkrainian(text) -> {
-                                    value = romanizeCyrillic(entry.text)
+                                    value = romanizeCyrillic(entry.text, "Ukrainian")
                                 }
 
                                 "Russian" in enabledLanguages && isRussian(text) -> {
-                                    value = romanizeCyrillic(entry.text)
+                                    value = romanizeCyrillic(entry.text, "Russian")
                                 }
 
                                 "Serbian" in enabledLanguages && isSerbian(text) -> {
-                                    value = romanizeCyrillic(entry.text)
+                                    value = romanizeCyrillic(entry.text, "Serbian")
                                 }
 
                                 "Bulgarian" in enabledLanguages && isBulgarian(text) -> {
-                                    value = romanizeCyrillic(entry.text)
+                                    value = romanizeCyrillic(entry.text, "Bulgarian")
                                 }
 
                                 "Belarusian" in enabledLanguages && isBelarusian(text) -> {
-                                    value = romanizeCyrillic(entry.text)
+                                    value = romanizeCyrillic(entry.text, "Belarusian")
                                 }
 
                                 "Kyrgyz" in enabledLanguages && isKyrgyz(text) -> {
-                                    value = romanizeCyrillic(entry.text)
+                                    value = romanizeCyrillic(entry.text, "Kyrgyz")
                                 }
 
                                 "Macedonian" in enabledLanguages && isMacedonian(text) -> {
-                                    value = romanizeCyrillic(entry.text)
+                                    value = romanizeCyrillic(entry.text, "Macedonian")
                                 }
                             }
 
@@ -342,13 +342,13 @@ fun OriginalLyrics(
                             "Korean" in enabledLanguages && isKorean(text) -> value = romanizeKorean(line)
                             "Chinese" in enabledLanguages && isChinese(text) -> value = romanizeChinese(line)
                             "Hindi" in enabledLanguages && isHindi(text) -> value = romanizeHindi(line)
-                            "Ukrainian" in enabledLanguages && isUkrainian(text) -> value = romanizeCyrillic(line)
-                            "Russian" in enabledLanguages && isRussian(text) -> value = romanizeCyrillic(line)
-                            "Serbian" in enabledLanguages && isSerbian(text) -> value = romanizeCyrillic(line)
-                            "Bulgarian" in enabledLanguages && isBulgarian(text) -> value = romanizeCyrillic(line)
-                            "Belarusian" in enabledLanguages && isBelarusian(text) -> value = romanizeCyrillic(line)
-                            "Kyrgyz" in enabledLanguages && isKyrgyz(text) -> value = romanizeCyrillic(line)
-                            "Macedonian" in enabledLanguages && isMacedonian(text) -> value = romanizeCyrillic(line)
+                            "Ukrainian" in enabledLanguages && isUkrainian(text) -> value = romanizeCyrillic(line, "Ukrainian")
+                            "Russian" in enabledLanguages && isRussian(text) -> value = romanizeCyrillic(line, "Russian")
+                            "Serbian" in enabledLanguages && isSerbian(text) -> value = romanizeCyrillic(line, "Serbian")
+                            "Bulgarian" in enabledLanguages && isBulgarian(text) -> value = romanizeCyrillic(line, "Bulgarian")
+                            "Belarusian" in enabledLanguages && isBelarusian(text) -> value = romanizeCyrillic(line, "Belarusian")
+                            "Kyrgyz" in enabledLanguages && isKyrgyz(text) -> value = romanizeCyrillic(line, "Kyrgyz")
+                            "Macedonian" in enabledLanguages && isMacedonian(text) -> value = romanizeCyrillic(line, "Macedonian")
                         }
 
                         newEntry.romanizedTextFlow.value = value

--- a/app/src/test/kotlin/com/metrolist/music/lyrics/MacedonianRomanizationTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/lyrics/MacedonianRomanizationTest.kt
@@ -1,0 +1,93 @@
+package com.metrolist.music.lyrics
+
+import com.metrolist.music.lyrics.LyricsUtils.isMacedonian
+import com.metrolist.music.lyrics.LyricsUtils.romanize
+import com.metrolist.music.lyrics.LyricsUtils.romanizeCyrillic
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Macedonian writes the stressed forms of "e" and "i" with a grave accent, so that
+ * "everything" is spelled differently from "is" and "her" from "and". Both letters are
+ * part of the alphabet and appear in ordinary lyrics.
+ */
+@RunWith(RobolectricTestRunner::class)
+class MacedonianRomanizationTest {
+
+    /** "Everything I have, both a house and a field" - the accent sits on the first word. */
+    private val lineWithGraveE = "Сѐ што имам и куќа и нива"
+
+    /** "her" - the grave separates the pronoun from the conjunction. */
+    private val lineWithGraveI = "Ги виде ѝ рече"
+
+    @Test
+    fun `a line carrying the grave accented e is still recognised as Macedonian`() {
+        assertTrue(
+            "expected Macedonian detection for a line spelled with the grave accent",
+            isMacedonian(lineWithGraveE),
+        )
+    }
+
+    @Test
+    fun `a line carrying the grave accented i is still recognised as Macedonian`() {
+        assertTrue(
+            "expected Macedonian detection for a line spelled with the grave accent",
+            isMacedonian(lineWithGraveI),
+        )
+    }
+
+    /**
+     * Detection runs over the whole lyrics, so a single accented letter anywhere used to
+     * make every language check fail and left the entire song unromanised.
+     */
+    @Test
+    fun `lyrics containing a grave accent are romanised rather than dropped`() = runBlocking {
+        val romanized = romanizeCyrillic(lineWithGraveE)
+
+        assertNotNull("expected the line to be romanised", romanized)
+        assertTrue(
+            "expected latin output, got $romanized",
+            romanized!!.none { it in 'Ѐ'..'ӿ' },
+        )
+    }
+
+    @Test
+    fun `the grave accented vowels romanise to their plain latin letters`() = runBlocking {
+        assertEquals("Se shto imam i kukja i niva", romanizeCyrillic(lineWithGraveE, "Macedonian"))
+    }
+
+    /**
+     * The reported song. Detection runs over the whole lyrics, so every line has to be
+     * read with that one alphabet - a line that happens to use only letters shared with
+     * Russian or Serbian must not be re-read as those languages.
+     */
+    private val macedonianSong = listOf(
+        "Една цреша што мене ме чека",
+        "Сѐ што имам и куќа и нива",
+        "Но црешата да ја најдам жива",
+        "Што е тоа во луѓето тажно",
+    )
+
+    @Test
+    fun `every line of a song is read with the same alphabet`() = runBlocking {
+        val lyrics = macedonianSong.joinToString(System.lineSeparator())
+        val romanized = macedonianSong.map {
+            romanize(lyrics, it, listOf("Macedonian"), romanizeCyrillicByLine = false)
+        }
+
+        romanized.forEachIndexed { index, value ->
+            assertNotNull("line ${index + 1} was left unromanised", value)
+        }
+
+        // Macedonian reads ц as "c"; reading the line as Russian would give "ts".
+        assertTrue("got ${romanized[0]}", romanized[0]!!.contains("cresha"))
+        // Macedonian reads ж as "zh"; reading the line as Serbian would give "ž".
+        assertTrue("got ${romanized[2]}", romanized[2]!!.contains("zhiva"))
+        assertTrue("got ${romanized[3]}", romanized[3]!!.contains("tazhno"))
+    }
+}


### PR DESCRIPTION
Fixes #4099

## Problem

Two separate things go wrong when romanizing Macedonian lyrics, and together they produce
exactly what was reported.

**The detected language is thrown away.** `OriginalLyrics` picks the language from the whole
lyrics, then calls `romanizeCyrillic(line)` without passing it, so every line is detected again on
its own. Detection is an ordered chain that checks Macedonian last, and each check requires every
Cyrillic letter in the text to belong to that alphabet — so a line is read as whichever language
comes first and happens to cover the letters it uses:

| line | letters present | read as | output |
|---|---|---|---|
| `Една цреша што мене ме чека` | all shared with Russian | Russian | `tsresha` |
| `Но црешата да ја најдам жива` | `ј` rules out Russian, Serbian covers it | Serbian | `crešata … živa` |
| `Што е тоа во луѓето тажно` | `ѓ` is Macedonian-only | Macedonian | `lugjeto tazhno` |

That is the reported ž/zh, c/ts, š/sh drift: one song read with three alphabets.

**The stressed vowels are not in the alphabet.** `ѐ` and `ѝ` appear nowhere in `LyricsUtils` — not
in a letter set, not in a map. Since detection requires every Cyrillic character to be a known
letter, a single one of them makes all seven checks fail and the line falls through to `null`, so
it is not romanized at all. That is the `Сѐ што имам и куќа и нива` line reported as missing.

## Changes

- `OriginalLyrics`: pass the detected language to `romanizeCyrillic` at both call sites, so a song
  is read with one alphabet. `LyricsUtils.romanize()` already does this — these two blocks were the
  ones that didn't.
- `LyricsUtils`: add `Ѐ ѐ Ѝ ѝ` to the Macedonian alphabet and map them to `E e I i`.

## Not included

The Macedonian map is also internally mixed — `Ч` → `Č` and `Џ` → `Dž` use diacritics while `Ш` →
`Sh` and `Ж` → `Zh` use digraphs. The reporter would prefer diacritics throughout. That is a choice
about the romanization scheme rather than a defect, so I left it alone; happy to follow up if you
want a particular one.

## Testing

`./gradlew testFossDebugUnitTest` — 23 classes, 91 tests, all passing.

New `MacedonianRomanizationTest` (5 tests) covers both halves: detection and romanization of the
accented vowels, and that each line of the reported song is read with the same alphabet. All four
of the original assertions fail on current `main` and pass with this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cyrillic lyric romanization for Ukrainian, Russian, Serbian, Bulgarian, Belarusian, Kyrgyz, and Macedonian.
  * Macedonian lyrics containing accented Cyrillic letters are now correctly detected and converted to Latin text.
  * Improved consistency when romanizing both parsed and plain lyrics across an entire song.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->