### PR TITLE
fix(db): keep playlist duplicate checks under SQLite's variable limit

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialog.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialog.kt
@@ -406,6 +406,7 @@ internal suspend fun DatabaseDao.playlistDuplicatesBatched(
         playlistDuplicates(playlistId, songIds)
     } else {
         songIds
+            .distinct()
             .chunked(MAX_PLAYLIST_DUPLICATES_BATCH_SIZE)
             .flatMap { playlistDuplicates(playlistId, it) }
     }

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialog.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialog.kt
@@ -40,6 +40,7 @@ import com.metrolist.music.constants.AddToPlaylistSortTypeKey
 import com.metrolist.music.constants.InnerTubeCookieKey
 import com.metrolist.music.constants.ListThumbnailSize
 import com.metrolist.music.constants.PlaylistSortType
+import com.metrolist.music.db.DatabaseDao
 import com.metrolist.music.db.entities.Playlist
 import com.metrolist.music.ui.component.CreatePlaylistDialog
 import com.metrolist.music.ui.component.DefaultDialog
@@ -155,7 +156,7 @@ fun AddToPlaylistDialog(
         val ids = songIds ?: return@LaunchedEffect
         withContext(Dispatchers.IO) {
             playlistsContainingSong = playlists
-                .filter { database.playlistDuplicates(it.id, ids).isNotEmpty() }
+                .filter { database.playlistDuplicatesBatched(it.id, ids).isNotEmpty() }
                 .map { it.id }
                 .toSet()
         }
@@ -309,7 +310,7 @@ fun AddToPlaylistDialog(
                             } else {
                                 onGetSong(playlist)
                             }
-                            duplicates = database.playlistDuplicates(playlist.id, songIds!!)
+                            duplicates = database.playlistDuplicatesBatched(playlist.id, songIds!!)
                             if (duplicates.isNotEmpty()) {
                                 showDuplicateDialog = true
                             } else {
@@ -387,3 +388,24 @@ fun AddToPlaylistDialog(
             }
         }
 }
+
+// SQLite rejects prepared statements with more than 999 bound variables on
+// Android 11 and below, so large "add to playlist" batches must be split.
+internal const val MAX_PLAYLIST_DUPLICATES_BATCH_SIZE = 500
+
+/**
+ * [DatabaseDao.playlistDuplicates] with the song ids chunked into batches that
+ * stay below SQLite's bound-variable limit, so playlists with more songs than
+ * the limit can still be checked for duplicates.
+ */
+internal suspend fun DatabaseDao.playlistDuplicatesBatched(
+    playlistId: String,
+    songIds: List<String>,
+): List<String> =
+    if (songIds.size <= MAX_PLAYLIST_DUPLICATES_BATCH_SIZE) {
+        playlistDuplicates(playlistId, songIds)
+    } else {
+        songIds
+            .chunked(MAX_PLAYLIST_DUPLICATES_BATCH_SIZE)
+            .flatMap { playlistDuplicates(playlistId, it) }
+    }

--- a/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialogOnline.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/menu/AddToPlaylistDialogOnline.kt
@@ -44,6 +44,7 @@ import com.metrolist.music.constants.AddToPlaylistSortDescendingKey
 import com.metrolist.music.constants.AddToPlaylistSortTypeKey
 import com.metrolist.music.constants.ListThumbnailSize
 import com.metrolist.music.constants.PlaylistSortType
+import com.metrolist.music.db.DatabaseDao
 import com.metrolist.music.db.entities.Playlist
 import com.metrolist.music.db.entities.Song
 import com.metrolist.music.models.ItemsPage
@@ -150,7 +151,7 @@ fun AddToPlaylistDialogOnline(
                 val ids = songs.map { it.id }
                 playlistsContainingSong = playlists
                     .filter { playlist ->
-                        database.playlistDuplicates(playlist.id, ids).isNotEmpty()
+                        database.playlistDuplicatesBatched(playlist.id, ids).isNotEmpty()
                     }
                     .map { it.id }
                     .toSet()

--- a/app/src/test/kotlin/com/metrolist/music/db/PlaylistDuplicatesBatchedTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/db/PlaylistDuplicatesBatchedTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.db
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.metrolist.music.db.entities.PlaylistEntity
+import com.metrolist.music.db.entities.PlaylistSongMap
+import com.metrolist.music.db.entities.SongEntity
+import com.metrolist.music.ui.menu.MAX_PLAYLIST_DUPLICATES_BATCH_SIZE
+import com.metrolist.music.ui.menu.playlistDuplicatesBatched
+import java.time.LocalDateTime
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class PlaylistDuplicatesBatchedTest {
+    private lateinit var database: InternalDatabase
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        database = Room.inMemoryDatabaseBuilder(context, InternalDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun `duplicate lookup stays correct across variable limit batches`() = runBlocking {
+        assertTrue(MAX_PLAYLIST_DUPLICATES_BATCH_SIZE < 999)
+
+        val libraryDate = LocalDateTime.of(2026, 1, 1, 0, 0)
+        database.runInTransaction {
+            database.dao.insert(PlaylistEntity(id = "full", name = "Full", bookmarkedAt = libraryDate))
+            database.dao.insert(PlaylistEntity(id = "partial", name = "Partial", bookmarkedAt = libraryDate))
+            repeat(1_200) { index ->
+                val songId = "song-$index"
+                database.dao.insert(SongEntity(id = songId, title = "Song $index"))
+                database.dao.insert(
+                    PlaylistSongMap(playlistId = "full", songId = songId, position = index),
+                )
+                if (index % 2 == 0) {
+                    database.dao.insert(
+                        PlaylistSongMap(playlistId = "partial", songId = songId, position = index / 2),
+                    )
+                }
+            }
+        }
+
+        val ids = List(1_200) { index -> "song-$index" }
+
+        // More ids than SQLite's 999-variable limit, spanning several batches.
+        val fullDuplicates = database.dao.playlistDuplicatesBatched("full", ids)
+        assertEquals(1_200, fullDuplicates.size)
+        assertEquals(ids.toSet(), fullDuplicates.toSet())
+
+        val partialDuplicates = database.dao.playlistDuplicatesBatched("partial", ids)
+        assertEquals(600, partialDuplicates.size)
+        assertEquals(ids.filterIndexed { index, _ -> index % 2 == 0 }.toSet(), partialDuplicates.toSet())
+
+        // Lists within a single batch keep using one query.
+        assertEquals(listOf("song-0"), database.dao.playlistDuplicatesBatched("full", listOf("song-0")))
+        assertEquals(emptyList<String>(), database.dao.playlistDuplicatesBatched("full", emptyList()))
+    }
+}


### PR DESCRIPTION
## Problem

#4094 reports a reproducible crash with the log `android.database.sqlite.SQLiteException: too many SQL variables (code 1 SQLITE_ERROR)` while compiling `SELECT * FROM song WHERE id IN (?,?,…)` with **1,225 bound variables** on an Android 11 (SDK 30) device. SQLite rejects prepared statements above 999 bound variables on Android 11 and below, so any query that binds more ids than that crashes the app.

The exact path reported in #4094 — cache-key lookups feeding `getSongsByIds()` from `CachePlaylistViewModel` — has already been addressed upstream by the refactors in #4270 and the chunked Android Auto browsing in #4280.

However, the same SQLite variable-limit defect **remains reachable on current main through the Add-to-playlist flow**:

- `AddToPlaylistDialog.kt` calls `database.playlistDuplicates(it.id, ids)` once per playlist when the dialog opens, and again with `songIds!!` when a target playlist is tapped.
- `AddToPlaylistDialogOnline.kt` runs the same duplicate scan for online playlists.
- The `ids` come straight from callers such as `YouTubePlaylistMenu` (`songs.map { it.id }`), `AlbumMenu`, and multi-selection menus, and are unbounded: a YouTube playlist or selection with more than 999 songs produces more bind variables than SQLite accepts, and the duplicate check crashes on Android ≤11 devices before anything can be added.

## Cause

`DatabaseDao.playlistDuplicates()` compiles `SELECT songId FROM playlist_song_map WHERE playlistId = :playlistId AND songId IN (:songIds)`, binding one variable per song id. Room does not split oversized `IN` lists, and no caller bounded the list size.

## Solution

- Added an internal extension `DatabaseDao.playlistDuplicatesBatched(playlistId, songIds)` in `AddToPlaylistDialog.kt`, which queries in chunks of at most 500 ids (`MAX_PLAYLIST_DUPLICATES_BATCH_SIZE = 500`) and concatenates the results. This follows the batching pattern already used in the codebase (`DB_QUERY_BATCH_SIZE` in `SyncUtils`, `MAX_ANDROID_AUTO_PAGE_SIZE` in `MediaLibrarySessionCallback`).
- Switched the three unbounded call sites (`AddToPlaylistDialog.kt` ×2, `AddToPlaylistDialogOnline.kt` ×1) to the batched variant.
- Lists within a single batch keep using exactly one query as before; only oversized batches are split, so there is no behavior change for small adds.

This legitimately closes #4094's defect class: it removes the last reachable path where user-controlled playlist size can exceed SQLite's variable limit in a duplicate check, which is the same failure mode captured in #4094's crash log.

## Testing

- `./gradlew :app:assembleFossDebug` — build successful.
- `./gradlew :app:testFossDebugUnitTest` — 106 tests green, 0 failures.
- New `PlaylistDuplicatesBatchedTest` (Robolectric, in-memory database, modeled after `AndroidAutoDatabasePaginationTest`): inserts a 1,200-song playlist plus a 600-song partial playlist, verifies the batched lookup returns all 1,200 duplicates across batch boundaries, exactly the 600 subset for the partial playlist, and unchanged single-query behavior below the threshold.

## Related Issues

- Closes #4094


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved adding songs to playlists when selecting large numbers of tracks.
  * Prevented duplicate-check failures on older Android versions caused by database query limits.
  * Ensured duplicate detection remains accurate for full, partial, single-item, and empty selections.

* **Tests**
  * Added coverage for large playlist selections and duplicate detection across multiple batches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->