### PR TITLE
feat(comments): add rotating featured comments in Player

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
@@ -58,6 +58,8 @@ val SwipeToRemoveSongKey = booleanPreferencesKey("SwipeToRemoveSong")
 val UseNewPlayerDesignKey = booleanPreferencesKey("useNewPlayerDesign")
 val UseNewMiniPlayerDesignKey = booleanPreferencesKey("useNewMiniPlayerDesign")
 val HidePlayerThumbnailKey = booleanPreferencesKey("hidePlayerThumbnail")
+
+val ShowTimedCommentsKey = booleanPreferencesKey("showTimedComments")
 val CropAlbumArtKey = booleanPreferencesKey("cropAlbumArt")
 val SeekExtraSeconds = booleanPreferencesKey("seekExtraSeconds")
 val PauseOnMute = booleanPreferencesKey("pauseOnMute")

--- a/app/src/main/kotlin/com/metrolist/music/features/comments/TimedCommentsRepository.kt
+++ b/app/src/main/kotlin/com/metrolist/music/features/comments/TimedCommentsRepository.kt
@@ -1,0 +1,115 @@
+package com.metrolist.music.features.comments
+
+import com.metrolist.innertube.YouTube
+import com.metrolist.innertube.models.TimedComment
+import com.metrolist.innertube.models.YouTubeClient
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * In-memory, track-scoped comments cache. It loads one window at a time so the UI can start
+ * quickly and asks for the next page only when the currently visible window is nearly consumed.
+ */
+object TimedCommentsRepository {
+    private const val CACHE_TTL_MS = 15 * 60 * 1000L
+    private const val COMMENTS_PER_WINDOW = 10
+    private val cache = ConcurrentHashMap<String, CacheEntry>()
+    private val fetchMutex = Mutex()
+
+    suspend fun loadNextWindow(
+        videoId: String,
+        reset: Boolean = false,
+    ): WindowResult = fetchMutex.withLock {
+        val now = System.currentTimeMillis()
+        var current = if (reset) {
+            CacheEntry()
+        } else {
+            cache[videoId]?.takeIf { it.expiresAt > now } ?: CacheEntry()
+        }
+
+        if (!current.exhausted) {
+            val targetCount = current.comments.size + COMMENTS_PER_WINDOW
+            val seenContinuations = mutableSetOf<String>()
+            while (current.comments.size < targetCount && !current.exhausted) {
+                current.continuation?.let { token ->
+                    if (!seenContinuations.add(token)) {
+                        current = current.copy(exhausted = true)
+                        break
+                    }
+                }
+                if (current.pending.isNotEmpty()) {
+                    val needed = targetCount - current.comments.size
+                    val nextComments = current.pending.take(needed)
+                    current = current.copy(
+                        comments = current.comments + nextComments,
+                        pending = current.pending.drop(nextComments.size),
+                        exhausted = current.continuation == null && current.pending.size <= nextComments.size,
+                        expiresAt = now + CACHE_TTL_MS,
+                    )
+                    continue
+                }
+
+                val page = withContext(Dispatchers.IO) {
+                    YouTube.featuredCommentsPage(
+                        videoId = videoId,
+                        continuation = current.continuation,
+                        client = current.client,
+                    )
+                }
+                if (page.isFailure) break
+
+                val response = page.getOrThrow()
+                val merged =
+                    (current.comments + current.pending + response.comments)
+                        .distinctBy { it.id }
+                val needed = targetCount - current.comments.size
+                val nextComments = merged.drop(current.comments.size).take(needed)
+                val nextPending = merged.drop(current.comments.size + nextComments.size)
+                current = current.copy(
+                    comments = current.comments + nextComments,
+                    pending = nextPending,
+                    continuation = response.continuation,
+                    client = response.client,
+                    exhausted = response.continuation == null && nextPending.isEmpty(),
+                    expiresAt = now + CACHE_TTL_MS,
+                )
+                if (response.comments.isEmpty() && response.continuation == null) break
+            }
+        }
+
+        if (current.comments.isEmpty() && !current.exhausted) {
+            // Keep the entry retryable when the initial request fails.
+            cache.remove(videoId)
+        } else {
+            cache[videoId] = current
+        }
+        current.toResult()
+    }
+
+    fun clearAll() {
+        cache.clear()
+    }
+
+    private data class CacheEntry(
+        val comments: List<TimedComment> = emptyList(),
+        val pending: List<TimedComment> = emptyList(),
+        val continuation: String? = null,
+        val client: YouTubeClient? = null,
+        val exhausted: Boolean = false,
+        val expiresAt: Long = Long.MAX_VALUE,
+    ) {
+        fun toResult() =
+            WindowResult(
+                comments = comments,
+                hasMore = !exhausted,
+            )
+    }
+
+    data class WindowResult(
+        val comments: List<TimedComment>,
+        val hasMore: Boolean,
+    )
+}

--- a/app/src/main/kotlin/com/metrolist/music/features/comments/ui/TimedCommentsStrip.kt
+++ b/app/src/main/kotlin/com/metrolist/music/features/comments/ui/TimedCommentsStrip.kt
@@ -1,0 +1,194 @@
+package com.metrolist.music.features.comments.ui
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.basicMarquee
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil3.compose.AsyncImage
+import com.metrolist.music.R
+import com.metrolist.music.features.comments.TimedCommentsRepository
+import com.metrolist.innertube.models.TimedComment
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+private const val COMMENT_DISPLAY_INTERVAL_MS = 5_000L
+private const val LOAD_TRIGGER_INDEX = 4
+private const val LOAD_TRIGGER_STEP = 10
+
+@Composable
+fun TimedCommentsStrip(
+    videoId: String?,
+    positionMs: Long,
+    enabled: Boolean,
+    textColor: androidx.compose.ui.graphics.Color,
+    modifier: Modifier = Modifier,
+) {
+    var activeComment by remember(videoId) { mutableStateOf<TimedComment?>(null) }
+
+    LaunchedEffect(enabled, videoId) {
+        activeComment = null
+        if (!enabled || videoId.isNullOrBlank()) return@LaunchedEffect
+
+        var loaded = TimedCommentsRepository.loadNextWindow(videoId, reset = true)
+        var comments = loaded.comments
+        var hasMore = loaded.hasMore
+        var displayIndex = 0
+        var requestedThreshold = -1
+        var nextWindowJob: Job? = null
+
+        while (isActive) {
+            if (comments.isEmpty()) {
+                if (!hasMore) break
+                delay(1_000L)
+                loaded = TimedCommentsRepository.loadNextWindow(videoId)
+                comments = loaded.comments
+                hasMore = loaded.hasMore
+                continue
+            }
+
+            if (displayIndex >= comments.size) displayIndex = 0
+            activeComment = comments[displayIndex]
+
+            val shouldLoadNextWindow =
+                displayIndex >= LOAD_TRIGGER_INDEX &&
+                    (displayIndex - LOAD_TRIGGER_INDEX) % LOAD_TRIGGER_STEP == 0 &&
+                    requestedThreshold != displayIndex &&
+                    hasMore
+            if (shouldLoadNextWindow && nextWindowJob?.isActive != true) {
+                val threshold = displayIndex
+                val previousCount = comments.size
+                nextWindowJob = launch {
+                    val next = TimedCommentsRepository.loadNextWindow(videoId)
+                    if (isActive) {
+                        loaded = next
+                        comments = next.comments
+                        hasMore = next.hasMore
+                        if (next.comments.size > previousCount || !next.hasMore) {
+                            requestedThreshold = threshold
+                        }
+                    }
+                }
+            }
+
+            delay(COMMENT_DISPLAY_INTERVAL_MS)
+            displayIndex =
+                if (displayIndex + 1 < comments.size) {
+                    displayIndex + 1
+                } else {
+                    0
+                }
+        }
+    }
+
+    if (!enabled) return
+
+    AnimatedVisibility(
+        visible = activeComment != null,
+        enter = expandVertically(expandFrom = Alignment.Top) + slideInVertically(initialOffsetY = { -it / 4 }) + fadeIn(),
+        exit = shrinkVertically(shrinkTowards = Alignment.Top) + fadeOut(),
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(50.dp)
+            .padding(horizontal = 24.dp, vertical = 8.dp)
+            .offset(x = 3.dp, y = (-3).dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        CommentAvatar(
+            avatarUrl = activeComment?.avatarUrl,
+            modifier = Modifier.size(34.dp),
+        )
+
+        Box(
+            modifier = Modifier.weight(1f),
+            contentAlignment = Alignment.CenterStart,
+        ) {
+            AnimatedContent(
+                targetState = activeComment,
+                transitionSpec = {
+                    (slideInHorizontally { width -> width / 3 } + fadeIn()) togetherWith
+                        (slideOutHorizontally { width -> -width / 3 } + fadeOut())
+                },
+                label = "featuredCommentTransition",
+            ) { comment ->
+                comment?.let {
+                    Text(
+                        text = it.text,
+                        color = textColor,
+                        style = MaterialTheme.typography.bodyMedium.copy(fontSize = 14.sp),
+                        maxLines = 1,
+                        overflow = TextOverflow.Clip,
+                        modifier = Modifier.basicMarquee(
+                            iterations = Int.MAX_VALUE,
+                            initialDelayMillis = 900,
+                            velocity = 35.dp,
+                        ),
+                    )
+                }
+            }
+        }
+        }
+    }
+}
+
+@Composable
+private fun CommentAvatar(
+    avatarUrl: String?,
+    modifier: Modifier = Modifier,
+) {
+    if (avatarUrl.isNullOrBlank()) {
+        Icon(
+            painter = painterResource(R.drawable.person),
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = modifier
+                .clip(CircleShape)
+                .padding(4.dp),
+        )
+    } else {
+        AsyncImage(
+            model = avatarUrl,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = modifier.clip(CircleShape),
+        )
+    }
+}

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Player.kt
@@ -141,6 +141,7 @@ import com.metrolist.music.R
 import com.metrolist.music.constants.CropAlbumArtKey
 import com.metrolist.music.constants.DarkModeKey
 import com.metrolist.music.constants.HidePlayerThumbnailKey
+import com.metrolist.music.constants.ShowTimedCommentsKey
 import com.metrolist.music.constants.HideStatusBarOnFullscreenKey
 import com.metrolist.music.constants.KeepScreenOn
 import com.metrolist.music.constants.PlayerBackgroundStyle
@@ -173,6 +174,8 @@ import com.metrolist.music.ui.component.ResizableIconButton
 import com.metrolist.music.ui.component.SquigglySlider
 import com.metrolist.music.ui.component.WavySlider
 import com.metrolist.music.ui.component.rememberBottomSheetState
+import com.metrolist.music.features.comments.TimedCommentsRepository
+import com.metrolist.music.features.comments.ui.TimedCommentsStrip
 import com.metrolist.music.ui.menu.PlayerMenu
 import com.metrolist.music.ui.screens.settings.DarkMode
 import com.metrolist.music.ui.theme.PlayerColorExtractor
@@ -222,6 +225,7 @@ fun BottomSheetPlayer(
             defaultValue = true,
         )
     val (hidePlayerThumbnail, onHidePlayerThumbnailChange) = rememberPreference(HidePlayerThumbnailKey, false)
+    val showTimedComments by rememberPreference(ShowTimedCommentsKey, defaultValue = false)
     val (hideStatusBarOnFullscreen) = rememberPreference(HideStatusBarOnFullscreenKey, false)
     val cropAlbumArt by rememberPreference(CropAlbumArtKey, false)
 
@@ -346,6 +350,22 @@ fun BottomSheetPlayer(
     val castPosition by castHandler?.castPosition?.collectAsStateWithLifecycle() ?: remember { mutableLongStateOf(0L) }
     val castDuration by castHandler?.castDuration?.collectAsStateWithLifecycle() ?: remember { mutableLongStateOf(0L) }
     val castIsPlaying by castHandler?.castIsPlaying?.collectAsState() ?: remember { mutableStateOf(false) }
+
+    LaunchedEffect(mediaMetadata?.id) {
+        TimedCommentsRepository.clearAll()
+    }
+
+    LaunchedEffect(playbackState) {
+        if (playbackState == STATE_ENDED) {
+            TimedCommentsRepository.clearAll()
+        }
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            TimedCommentsRepository.clearAll()
+        }
+    }
 
     val focusRequester = remember { FocusRequester() }
 
@@ -1887,6 +1907,12 @@ fun BottomSheetPlayer(
                             }
                         }
                     }
+                    TimedCommentsStrip(
+                        videoId = mediaMetadata?.id,
+                        positionMs = effectivePosition,
+                        enabled = state.isExpanded && showTimedComments && playbackState != STATE_ENDED,
+                        textColor = TextBackgroundColor,
+                    )
 
                     Column(
                         horizontalAlignment = Alignment.CenterHorizontally,
@@ -1949,6 +1975,12 @@ fun BottomSheetPlayer(
                             }
                         }
                     }
+                    TimedCommentsStrip(
+                        videoId = mediaMetadata?.id,
+                        positionMs = effectivePosition,
+                        enabled = state.isExpanded && showTimedComments && playbackState != STATE_ENDED,
+                        textColor = TextBackgroundColor,
+                    )
 
                     mediaMetadata?.let {
                         controlsContent(it)

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/ContentSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/ContentSettings.kt
@@ -68,6 +68,7 @@ import com.metrolist.music.constants.EnablePaxsenixKey
 import com.metrolist.music.constants.EnableLyricsPlus
 import com.metrolist.music.constants.HideExplicitKey
 import com.metrolist.music.constants.HideVideoSongsKey
+import com.metrolist.music.constants.ShowTimedCommentsKey
 import com.metrolist.music.constants.HideYoutubeShortsKey
 import com.metrolist.music.constants.LanguageCodeToName
 import com.metrolist.music.constants.LyricsProviderOrderKey
@@ -126,6 +127,7 @@ fun ContentSettings(
     val (enableBetterLyrics, onEnableBetterLyricsChange) = rememberPreference(key = EnableBetterLyricsKey, defaultValue = true)
     val (enablePaxsenix, onEnablePaxsenixChange) = rememberPreference(key = EnablePaxsenixKey, defaultValue = true)
     val (enableLyricsPlus, onEnableLyricsPlusChange) = rememberPreference(key = EnableLyricsPlus, defaultValue = true)
+    val (showTimedComments, onShowTimedCommentsChange) = rememberPreference(key = ShowTimedCommentsKey, defaultValue = false)
     val (lyricsProviderOrder, onLyricsProviderOrderChange) = rememberPreference(
         key = LyricsProviderOrderKey,
         defaultValue = LyricsProviderRegistry.serializeProviderOrder(LyricsProviderRegistry.getDefaultProviderOrder())
@@ -977,6 +979,35 @@ fun ContentSettings(
                     icon = painterResource(R.drawable.language_korean_latin),
                     title = { Text(stringResource(R.string.lyrics_romanization)) },
                     onClick = { navController.navigate("settings/content/romanization") }
+                )
+            )
+        )
+
+        Spacer(modifier = Modifier.height(27.dp))
+
+        Material3SettingsGroup(
+            title = "Player",
+            items = listOf(
+                Material3SettingsItem(
+                    icon = painterResource(R.drawable.account),
+                    title = { Text(stringResource(R.string.show_timed_comments)) },
+                    description = { Text(stringResource(R.string.show_timed_comments_desc)) },
+                    trailingContent = {
+                        Switch(
+                            checked = showTimedComments,
+                            onCheckedChange = onShowTimedCommentsChange,
+                            thumbContent = {
+                                Icon(
+                                    painter = painterResource(
+                                        id = if (showTimedComments) R.drawable.check else R.drawable.close
+                                    ),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(SwitchDefaults.IconSize)
+                                )
+                            }
+                        )
+                    },
+                    onClick = { onShowTimedCommentsChange(!showTimedComments) }
                 )
             )
         )

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -141,6 +141,8 @@
     <string name="enable_lyricsplus_desc">Synchronized lyrics from multiple sources</string>
     <string name="lyrics_provider_selection">Provider selection</string>
     <string name="lyrics_provider_selection_desc">Choose which lyrics providers are enabled</string>
+    <string name="show_timed_comments">Show featured comments</string>
+    <string name="show_timed_comments_desc">Show highlighted user comments below the artwork</string>
     <string name="auto_scroll">Re-sync</string>
     <string name="slim">Slim</string>
     <string name="slim_navbar">Slim bottom navigation bar</string>

--- a/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/YouTube.kt
@@ -22,6 +22,7 @@ import com.metrolist.innertube.models.SectionListRenderer
 import com.metrolist.innertube.models.SongItem
 import com.metrolist.innertube.models.TasteArtist
 import com.metrolist.innertube.models.TasteProfile
+import com.metrolist.innertube.models.TimedComment
 import com.metrolist.innertube.models.WatchEndpoint
 import com.metrolist.innertube.models.WatchEndpoint.WatchEndpointMusicSupportedConfigs.WatchEndpointMusicConfig.Companion.MUSIC_VIDEO_TYPE_ATV
 import com.metrolist.innertube.models.YTItem
@@ -80,6 +81,11 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
 import timber.log.Timber
 import java.net.Proxy
 import kotlin.random.Random
@@ -89,6 +95,8 @@ import kotlin.random.Random
  * Modified from [ViMusic](https://github.com/vfsfitvnm/ViMusic)
  */
 object YouTube {
+    private const val MAX_COMMENT_PAGES = 100
+
     private val innerTube = InnerTube()
 
     var locale: YouTubeLocale
@@ -3346,6 +3354,275 @@ object YouTube {
                 .parseToJsonElement(innerTube.accountsList().bodyAsText())
                 .extractYouTubeAccounts()
         }
+
+    data class FeaturedCommentsPage(
+        val comments: List<TimedComment>,
+        val continuation: String?,
+        val client: YouTubeClient,
+    )
+
+    /**
+     * Loads one page of highlighted/top user comments. The first call discovers the regular
+     * comments continuation, and later calls use the returned token directly so the caller can
+     * progressively fetch comments without waiting for the complete feed.
+     */
+    suspend fun featuredCommentsPage(
+        videoId: String,
+        continuation: String? = null,
+        client: YouTubeClient? = null,
+    ): Result<FeaturedCommentsPage> = runCatching {
+        if (continuation != null) {
+            var lastError: Throwable? = null
+            val clients = if (client != null) listOf(client) else listOf(WEB, WEB_REMIX)
+            for (activeClient in clients) {
+                try {
+                    val response =
+                        Json.parseToJsonElement(
+                            innerTube
+                                .next(activeClient, null, null, null, null, null, continuation)
+                                .bodyAsText(),
+                        ).asObject()
+                    return@runCatching FeaturedCommentsPage(
+                        comments = response.parseFeaturedComments(),
+                        continuation = response.findContinuationToken(),
+                        client = activeClient,
+                    )
+                } catch (error: Throwable) {
+                    if (error is kotlin.coroutines.cancellation.CancellationException) throw error
+                    lastError = error
+                }
+            }
+            throw (lastError ?: IllegalStateException("No comments continuation response"))
+        }
+
+        val clients = listOf(WEB, WEB_REMIX)
+        var fallbackPage: FeaturedCommentsPage? = null
+        var lastError: Throwable? = null
+        for (activeClient in clients) {
+            try {
+                val response =
+                    Json.parseToJsonElement(
+                        innerTube
+                            .next(activeClient, videoId, null, null, null, null, null)
+                            .bodyAsText(),
+                    ).asObject()
+                val page = FeaturedCommentsPage(
+                    comments = response.parseFeaturedComments(),
+                    continuation =
+                        response.findFeaturedCommentContinuationToken()
+                            ?: response.findCommentContinuationToken(),
+                    client = activeClient,
+                )
+                if (page.continuation != null || page.comments.isNotEmpty() || activeClient == WEB_REMIX) {
+                    return@runCatching page
+                }
+                fallbackPage = page
+            } catch (error: Throwable) {
+                if (error is kotlin.coroutines.cancellation.CancellationException) throw error
+                lastError = error
+            }
+        }
+        fallbackPage ?: throw (lastError ?: IllegalStateException("No comments response"))
+    }
+
+    private fun JsonElement.asObject(): JsonObject = this as? JsonObject ?: error("Expected a JSON object")
+
+    private fun JsonObject.objectValue(key: String): JsonObject? = this[key] as? JsonObject
+
+    private fun JsonObject.arrayValue(key: String): JsonArray? = this[key] as? JsonArray
+
+    private fun JsonObject.stringValue(key: String): String? =
+        (this[key] as? JsonPrimitive)?.contentOrNull
+
+    private fun JsonElement.findObjectValues(key: String): List<JsonObject> {
+        val matches = mutableListOf<JsonObject>()
+
+        fun visit(element: JsonElement) {
+            when (element) {
+                is JsonObject -> {
+                    (element[key] as? JsonObject)?.let(matches::add)
+                    element.values.forEach(::visit)
+                }
+                is JsonArray -> element.forEach(::visit)
+                else -> Unit
+            }
+        }
+
+        visit(this)
+        return matches
+    }
+
+    private fun JsonElement.findContinuationTokens(): List<String> {
+        val tokens = mutableListOf<String>()
+
+        fun visit(element: JsonElement) {
+            when (element) {
+                is JsonObject -> {
+                    element.continuationToken()?.let(tokens::add)
+                    element.values.forEach(::visit)
+                }
+                is JsonArray -> element.forEach(::visit)
+                else -> Unit
+            }
+        }
+
+        visit(this)
+        return tokens.distinct()
+    }
+
+    private fun JsonObject.runsText(key: String): String =
+        objectValue(key)
+            ?.arrayValue("runs")
+            ?.mapNotNull { (it as? JsonObject)?.stringValue("text") }
+            ?.joinToString("")
+            .orEmpty()
+
+    private fun JsonObject.textValue(key: String): String? {
+        val value = this[key] ?: return null
+        return (value as? JsonPrimitive)?.contentOrNull
+            ?: (value as? JsonObject)?.stringValue("simpleText")
+            ?: (value as? JsonObject)
+                ?.arrayValue("runs")
+                ?.mapNotNull { (it as? JsonObject)?.stringValue("text") }
+                ?.joinToString("")
+                ?.takeIf { it.isNotBlank() }
+    }
+
+    private fun JsonObject.continuationToken(): String? =
+        objectValue("continuationEndpoint")
+            ?.objectValue("continuationCommand")
+            ?.stringValue("token")
+
+    private fun JsonObject.findFeaturedCommentContinuationToken(): String? {
+        val featuredTitles =
+            listOf(
+                "top comments",
+                "featured comments",
+                "popular comments",
+                "bình luận nổi bật",
+                "bình luận hàng đầu",
+                "bình luận phổ biến",
+            )
+        return findObjectValues("sortFilterSubMenuRenderer")
+            .asSequence()
+            .flatMap { it.arrayValue("subMenuItems").orEmpty().asSequence() }
+            .mapNotNull { item ->
+                val itemObject = item as? JsonObject ?: return@mapNotNull null
+                val title = itemObject.textValue("title")?.lowercase() ?: return@mapNotNull null
+                if (featuredTitles.none(title::contains)) return@mapNotNull null
+                itemObject
+                    .objectValue("serviceEndpoint")
+                    ?.objectValue("continuationCommand")
+                    ?.stringValue("token")
+                    ?: itemObject
+                        .objectValue("continuationEndpoint")
+                        ?.objectValue("continuationCommand")
+                        ?.stringValue("token")
+            }
+            .firstOrNull()
+    }
+
+    private fun JsonObject.findCommentContinuationToken(): String? {
+        val standardRoot =
+            objectValue("contents")
+                ?.objectValue("twoColumnWatchNextResults")
+                ?.objectValue("results")
+                ?.objectValue("results")
+
+        // Match ViviMusic's proven WEB comments flow first. The direct continuation is the
+        // comment-item-section token and avoids accidentally selecting a related-video token.
+        val standardContent =
+            listOfNotNull(
+                standardRoot?.arrayValue("contents"),
+                standardRoot?.arrayValue("content"),
+            ).asSequence()
+                .flatMap { it.asSequence() }
+                .mapNotNull { it as? JsonObject }
+
+        standardContent
+            .mapNotNull { it.objectValue("continuationItemRenderer")?.continuationToken() }
+            .firstOrNull()
+            ?.let { return it }
+
+        standardContent
+            .mapNotNull { it.objectValue("itemSectionRenderer") }
+            .flatMap { section -> section.arrayValue("contents").orEmpty().asSequence() }
+            .mapNotNull { it as? JsonObject }
+            .mapNotNull { it.objectValue("continuationItemRenderer")?.continuationToken() }
+            .firstOrNull()
+            ?.let { return it }
+
+        // Some video responses wrap the comments section in a named renderer instead of the
+        // usual itemSectionRenderer. Search only those comment-related branches before falling
+        // back to the broader response scan.
+        standardRoot
+            ?.findObjectValues("commentItemSectionRenderer")
+            ?.asSequence()
+            ?.flatMap { it.findContinuationTokens().asSequence() }
+            ?.firstOrNull()
+            ?.let { return it }
+
+        val engagementRoot =
+            arrayValue("engagementPanels")
+                ?.asSequence()
+                ?.mapNotNull { it as? JsonObject }
+                ?.mapNotNull { it.objectValue("engagementPanelSectionListRenderer") }
+                ?.firstOrNull { it.stringValue("panelIdentifier") == "engagement-panel-comments-section" }
+        engagementRoot?.findContinuationTokens()?.firstOrNull()?.let { return it }
+
+        // YouTube periodically moves the comments section between renderer shapes. Keep a
+        // recursive fallback so a layout change does not make an otherwise valid video empty.
+        return findContinuationTokens().firstOrNull()
+    }
+
+    private fun JsonObject.findContinuationToken(): String? {
+        val endpointToken =
+            arrayValue("onResponseReceivedEndpoints")
+                ?.flatMap { endpoint ->
+                    val endpointObject = endpoint as? JsonObject ?: return@flatMap emptyList()
+                    listOfNotNull(
+                        endpointObject
+                            .objectValue("reloadContinuationItemsCommand")
+                            ?.arrayValue("continuationItems"),
+                        endpointObject
+                            .objectValue("appendContinuationItemsAction")
+                            ?.arrayValue("continuationItems"),
+                    ).flatten()
+                }
+                ?.firstNotNullOfOrNull { item ->
+                    (item as? JsonObject)
+                        ?.objectValue("continuationItemRenderer")
+                        ?.continuationToken()
+                }
+        return endpointToken ?: findContinuationTokens().firstOrNull()
+    }
+
+    private fun JsonObject.parseFeaturedComments(): List<TimedComment> {
+        val legacy = findObjectValues("commentRenderer").mapNotNull { renderer ->
+            val commentId = renderer.stringValue("commentId") ?: return@mapNotNull null
+            val text = renderer.runsText("contentText").trim()
+            if (text.isBlank()) return@mapNotNull null
+            val avatarUrl =
+                renderer
+                    .objectValue("authorThumbnail")
+                    ?.arrayValue("thumbnails")
+                    ?.lastOrNull()
+                    ?.let { (it as? JsonObject)?.stringValue("url") }
+            TimedComment(commentId, text = text, avatarUrl = avatarUrl)
+        }
+
+        val framework = findObjectValues("commentEntityPayload").mapNotNull { payload ->
+            val properties = payload.objectValue("properties") ?: return@mapNotNull null
+            val commentId = properties.stringValue("commentId") ?: return@mapNotNull null
+            val text = properties.objectValue("content")?.stringValue("content").orEmpty().trim()
+            if (text.isBlank()) return@mapNotNull null
+            val avatarUrl = payload.objectValue("author")?.stringValue("avatarThumbnailUrl")
+            TimedComment(commentId, text = text, avatarUrl = avatarUrl)
+        }
+
+        return (legacy + framework).distinctBy { it.id }
+    }
+
 
     suspend fun feedback(tokens: List<String>): Result<Boolean> =
         runCatching {

--- a/innertube/src/main/kotlin/com/metrolist/innertube/models/TimedComment.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/models/TimedComment.kt
@@ -1,0 +1,12 @@
+package com.metrolist.innertube.models
+
+/**
+ * A user comment selected from YouTube's highlighted/top comments feed.
+ * The existing name is retained for compatibility with the surrounding player feature.
+ */
+data class TimedComment(
+    val id: String,
+    val timestampMs: Long = 0L,
+    val text: String,
+    val avatarUrl: String?,
+)


### PR DESCRIPTION
## Problem
The Player has no compact way to show highlighted YouTube user comments while a song is playing, and the comments experience is unavailable in landscape layout.

## Cause
The app did not expose the YouTube featured-comments continuation feed, an incremental in-memory loader, or a Player setting and lifecycle integration for the comments strip.

## Solution
- Add a renderer-tolerant YouTube `featuredCommentsPage` API for highlighted/top comments and continuation tokens.
- Add a track-scoped in-memory repository that loads 10 comments initially and requests the next batch near item 5, without preloading the entire feed.
- Add a compact animated strip with a fixed 5,000 ms rotation, sequential ordering, looping after the end, fixed avatars, and one-line marquee text.
- Integrate the strip below the artwork in both portrait and landscape Player layouts, with cleanup on track changes, playback end, and Player disposal.
- Add an English-only Content setting to enable or disable the strip.

## Testing
- `:innertube:compileDebugKotlin` — passed.
- Full app Kotlin compilation was attempted, but the sandbox Gradle/Kotlin daemon was terminated by the environment during compilation; no source compilation error was reported before termination.

## Related Issues
- Related to the featured comments request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional “Show featured comments” setting in Player preferences.
  * Displays highlighted comments below the artwork during playback, with avatars and animated rotation.
  * Loads additional comments progressively as playback continues.
* **Bug Fixes**
  * Comment loading can retry after an initial request failure and avoids duplicate or repeated results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->