### PR TITLE
fix: apply offset to interval indicator

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/component/ExperimentalLyrics.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/ExperimentalLyrics.kt
@@ -756,9 +756,9 @@ fun ExperimentalLyrics(
                                 is LyricsListItem.Indicator -> {
                                     val visible =
                                         isAutoScrollEnabled &&
-                                            currentPositionState >= listItem.gapStartMs &&
-                                            currentPositionState <= listItem.gapEndMs - 650L
-                                    IntervalIndicator(listItem.gapStartMs, listItem.gapEndMs - 650L, currentPositionState, visible, expressiveAccent, 
+                                            currentEffectivePosition >= listItem.gapStartMs &&
+                                            currentEffectivePosition <= listItem.gapEndMs - 650L
+                                    IntervalIndicator(listItem.gapStartMs, listItem.gapEndMs - 650L, currentEffectivePosition, visible, expressiveAccent,
                                         Modifier.fillMaxWidth().onSizeChanged { itemHeights[listIndex] = it.height }.padding(horizontal = 24.dp).wrapContentWidth(Alignment.CenterHorizontally))
                                 }
                                 is LyricsListItem.Line -> {


### PR DESCRIPTION
## Problem
The interval indicator doesn't account for the lyrics offset. It stays in sync with the raw position instead of the offset-adjusted position, so its visibility and progress are wrong whenever an offset is set.

## Cause
The indicator's visibility check and progress value were driven by `currentPositionState` instead of `currentEffectivePosition`.

## Solution
- Replaced `currentPositionState` with `currentEffectivePosition`, for both the `visible` calculation and the value passed into `IntervalIndicator`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lyrics gap indicator accuracy by accounting for the song’s lyrics timing offset.
  * Ensured gap indicators render at the correct position during playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->