### PR TITLE
Fix audio processing in VolumeNormalizationAudioProcessor

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/audio/VolumeNormalizationAudioProcessor.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/audio/VolumeNormalizationAudioProcessor.kt
@@ -16,7 +16,8 @@ class VolumeNormalizationAudioProcessor : AudioProcessor {
     private var channelCount = 0
     private var encoding = C.ENCODING_INVALID
     private var bytesPerSample = 0
-    private var isActive = false
+    private var bytesPerFrame = 0
+    private var active = false
 
     @Volatile
     var enabled = false
@@ -38,7 +39,8 @@ class VolumeNormalizationAudioProcessor : AudioProcessor {
 
     companion object {
         private const val TAG = "VolumeNormalizationProcessor"
-        private val EMPTY_BUFFER: ByteBuffer = ByteBuffer.allocateDirect(0).order(ByteOrder.nativeOrder())
+        private val EMPTY_BUFFER: ByteBuffer =
+            ByteBuffer.allocateDirect(0).order(ByteOrder.nativeOrder())
     }
 
     @Synchronized
@@ -63,56 +65,64 @@ class VolumeNormalizationAudioProcessor : AudioProcessor {
             else -> throw AudioProcessor.UnhandledAudioFormatException(inputAudioFormat)
         }
 
-        Timber.tag(TAG).d("Configured: sampleRate=$sampleRate, channels=$channelCount, encoding=$encoding")
+        bytesPerFrame = bytesPerSample * channelCount
+        active = true
 
-        isActive = true
+        Timber.tag(TAG).d(
+            "Configured: sampleRate=$sampleRate, channels=$channelCount, encoding=$encoding"
+        )
+
         return AudioProcessor.AudioFormat(sampleRate, channelCount, encoding)
     }
 
-    override fun isActive(): Boolean = isActive
+    override fun isActive(): Boolean = active
 
     override fun queueInput(inputBuffer: ByteBuffer) {
         val gain = currentGain
         val applyGain = enabled && gain.targetGainMb != 0
 
         val inputSize = inputBuffer.remaining()
-        if (inputSize == 0) return
+        if (inputSize == 0) {
+            outputBuffer = EMPTY_BUFFER
+            return
+        }
 
-        val sampleCount = inputSize / bytesPerSample
-        val out = replaceOutputBuffer(sampleCount * bytesPerSample)
+        val outputSize = inputSize
+        val out = replaceOutputBuffer(outputSize)
 
         inputBuffer.order(ByteOrder.LITTLE_ENDIAN)
         out.order(ByteOrder.LITTLE_ENDIAN)
 
+        val frameCount = inputSize / bytesPerFrame
+
         when (encoding) {
             C.ENCODING_PCM_16BIT -> {
-                repeat(sampleCount) {
-                    val sample = inputBuffer.getShort()
+                repeat(frameCount * channelCount) {
+                    val sample = inputBuffer.getShort().toInt()
                     val processed = if (applyGain) {
                         (sample * gain.linearGain)
                             .coerceIn(-32768.0, 32767.0)
                             .toInt()
-                            .toShort()
                     } else {
                         sample
                     }
-                    out.putShort(processed)
+                    out.putShort(processed.toShort())
                 }
             }
 
             C.ENCODING_PCM_24BIT -> {
-                repeat(sampleCount) {
+                repeat(frameCount * channelCount) {
                     val b0 = inputBuffer.get().toInt() and 0xFF
                     val b1 = inputBuffer.get().toInt() and 0xFF
                     val b2 = inputBuffer.get().toInt()
                     val sample = (b2 shl 16) or (b1 shl 8) or b0
-
+                    val signed = (sample shl 8) shr 8
                     val processed = if (applyGain) {
-                        (sample * gain.linearGain)
+                        (signed * gain.linearGain)
                             .coerceIn(-8388608.0, 8388607.0)
                             .toInt()
                     } else {
-                        sample
+                        signed
                     }
                     out.put((processed and 0xFF).toByte())
                     out.put(((processed shr 8) and 0xFF).toByte())
@@ -121,7 +131,7 @@ class VolumeNormalizationAudioProcessor : AudioProcessor {
             }
 
             C.ENCODING_PCM_32BIT -> {
-                repeat(sampleCount) {
+                repeat(frameCount * channelCount) {
                     val sample = inputBuffer.getInt()
                     val processed = if (applyGain) {
                         (sample * gain.linearGain)
@@ -136,7 +146,7 @@ class VolumeNormalizationAudioProcessor : AudioProcessor {
             }
 
             C.ENCODING_PCM_FLOAT -> {
-                repeat(sampleCount) {
+                repeat(frameCount * channelCount) {
                     val sample = inputBuffer.getFloat()
                     val processed = if (applyGain) {
                         (sample * gain.linearGain.toFloat()).coerceIn(-1.0f, 1.0f)
@@ -146,9 +156,15 @@ class VolumeNormalizationAudioProcessor : AudioProcessor {
                     out.putFloat(processed)
                 }
             }
+
+            else -> throw AudioProcessor.UnhandledAudioFormatException(
+                AudioProcessor.AudioFormat(sampleRate, channelCount, encoding)
+            )
         }
 
+        inputBuffer.position(inputBuffer.limit())
         out.flip()
+        outputBuffer = out
     }
 
     override fun queueEndOfStream() {
@@ -161,9 +177,7 @@ class VolumeNormalizationAudioProcessor : AudioProcessor {
         return buffer
     }
 
-    override fun isEnded(): Boolean {
-        return inputEnded && outputBuffer === EMPTY_BUFFER
-    }
+    override fun isEnded(): Boolean = inputEnded && outputBuffer === EMPTY_BUFFER
 
     @Deprecated("Deprecated in AudioProcessor")
     override fun flush() {
@@ -179,8 +193,8 @@ class VolumeNormalizationAudioProcessor : AudioProcessor {
         channelCount = 0
         encoding = C.ENCODING_INVALID
         bytesPerSample = 0
-        isActive = false
-        // DO NOT reset enabled or currentGain, as they are controlled by the service
+        bytesPerFrame = 0
+        active = false
     }
 
     private fun replaceOutputBuffer(size: Int): ByteBuffer {
@@ -189,14 +203,6 @@ class VolumeNormalizationAudioProcessor : AudioProcessor {
         } else {
             buffer.clear()
         }
-        outputBuffer = buffer
         return buffer
-    }
-
-    private fun read24Bit(buffer: ByteBuffer): Int {
-        val b0 = buffer.get().toInt() and 0xFF
-        val b1 = buffer.get().toInt() and 0xFF
-        val b2 = buffer.get().toInt()
-        return (b2 shl 16) or (b1 shl 8) or b0
     }
 }

--- a/app/src/main/kotlin/com/metrolist/music/playback/audio/VolumeNormalizationAudioProcessor.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/audio/VolumeNormalizationAudioProcessor.kt
@@ -8,10 +8,24 @@ import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import kotlin.math.pow
 
+/**
+ * An audio processor that applies volume normalization (gain adjustment) to audio samples.
+ *
+ * This processor supports multiple PCM audio formats (16-bit, 24-bit, 32-bit, and float) and
+ * applies a linear gain multiplier to normalize audio levels. The gain can be toggled on/off
+ * and adjusted dynamically via [setTargetGain].
+ *
+ * Gain values are specified in millibels (mB) and converted to linear multipliers using the
+ * formula: linearGain = 10^(gainMb / 2000).
+ *
+ * Thread-safety: The [enabled] flag and [currentGain] are volatile for safe cross-thread access,
+ * while [setTargetGain] is synchronized to ensure atomic updates.
+ */
 @UnstableApi
 @Suppress("DEPRECATION")
 class VolumeNormalizationAudioProcessor : AudioProcessor {
 
+    // Audio format configuration properties
     private var sampleRate = 0
     private var channelCount = 0
     private var encoding = C.ENCODING_INVALID
@@ -19,6 +33,10 @@ class VolumeNormalizationAudioProcessor : AudioProcessor {
     private var bytesPerFrame = 0
     private var active = false
 
+    /**
+     * Flag to control whether gain normalization is currently applied.
+     * When true, the target gain is applied to audio samples; when false, samples pass through unchanged.
+     */
     @Volatile
     var enabled = false
         set(value) {
@@ -28,12 +46,22 @@ class VolumeNormalizationAudioProcessor : AudioProcessor {
             }
         }
 
+    // Buffer management
     private var buffer: ByteBuffer = EMPTY_BUFFER
     private var outputBuffer: ByteBuffer = EMPTY_BUFFER
     private var inputEnded = false
 
+    /**
+     * Encapsulates the current gain state.
+     *
+     * @param targetGainMb The target gain in millibels (mB)
+     * @param linearGain The pre-calculated linear gain multiplier for efficient sample processing
+     */
     private data class GainState(val targetGainMb: Int, val linearGain: Double)
 
+    /**
+     * The current gain state. Marked volatile for safe concurrent access from multiple threads.
+     */
     @Volatile
     private var currentGain: GainState = GainState(0, 1.0)
 
@@ -43,6 +71,19 @@ class VolumeNormalizationAudioProcessor : AudioProcessor {
             ByteBuffer.allocateDirect(0).order(ByteOrder.nativeOrder())
     }
 
+    /**
+     * Sets the target gain for normalization.
+     *
+     * The gain value is specified in millibels (mB). For example:
+     * - 0 mB = no change (linear gain of 1.0)
+     * - 1000 mB = 10x amplification
+     * - -1000 mB = 0.1x attenuation (10% of original)
+     *
+     * The method only updates the gain if the new value differs from the current target,
+     * minimizing unnecessary recalculations.
+     *
+     * @param gainMb The target gain in millibels. The linear gain is calculated as 10^(gainMb / 2000)
+     */
     @Synchronized
     fun setTargetGain(gainMb: Int) {
         if (currentGain.targetGainMb != gainMb) {
@@ -52,11 +93,23 @@ class VolumeNormalizationAudioProcessor : AudioProcessor {
         }
     }
 
+    /**
+     * Configures the processor for a specific audio format.
+     *
+     * This method is called before any audio processing begins and sets up the processor
+     * with the sample rate, channel count, and encoding format of the input audio.
+     * The bytes-per-sample and bytes-per-frame are calculated based on the encoding.
+     *
+     * @param inputAudioFormat The input audio format configuration
+     * @return The output audio format (typically unchanged from input, as only gain is applied)
+     * @throws AudioProcessor.UnhandledAudioFormatException if the encoding is not supported
+     */
     override fun configure(inputAudioFormat: AudioProcessor.AudioFormat): AudioProcessor.AudioFormat {
         sampleRate = inputAudioFormat.sampleRate
         channelCount = inputAudioFormat.channelCount
         encoding = inputAudioFormat.encoding
 
+        // Determine bytes per sample based on encoding format
         bytesPerSample = when (encoding) {
             C.ENCODING_PCM_16BIT -> 2
             C.ENCODING_PCM_24BIT -> 3
@@ -65,6 +118,7 @@ class VolumeNormalizationAudioProcessor : AudioProcessor {
             else -> throw AudioProcessor.UnhandledAudioFormatException(inputAudioFormat)
         }
 
+        // Calculate total bytes needed for a single audio frame (all channels)
         bytesPerFrame = bytesPerSample * channelCount
         active = true
 
@@ -75,8 +129,23 @@ class VolumeNormalizationAudioProcessor : AudioProcessor {
         return AudioProcessor.AudioFormat(sampleRate, channelCount, encoding)
     }
 
+    /**
+     * Returns whether this processor is currently active.
+     *
+     * @return true if the processor has been configured and is active, false otherwise
+     */
     override fun isActive(): Boolean = active
 
+    /**
+     * Processes a buffer of audio samples, applying gain normalization if enabled.
+     *
+     * This method handles multiple PCM audio formats by reading samples, applying the gain
+     * multiplier (if enabled), and clipping to the valid range for the format, then writing
+     * to the output buffer. Each format has its own processing logic due to different sample sizes
+     * and value ranges.
+     *
+     * @param inputBuffer The input buffer containing raw audio samples
+     */
     override fun queueInput(inputBuffer: ByteBuffer) {
         val gain = currentGain
         val applyGain = enabled && gain.targetGainMb != 0
@@ -90,15 +159,18 @@ class VolumeNormalizationAudioProcessor : AudioProcessor {
         val outputSize = inputSize
         val out = replaceOutputBuffer(outputSize)
 
+        // Ensure consistent byte ordering for sample processing
         inputBuffer.order(ByteOrder.LITTLE_ENDIAN)
         out.order(ByteOrder.LITTLE_ENDIAN)
 
         val frameCount = inputSize / bytesPerFrame
 
+        // Process samples based on encoding format
         when (encoding) {
             C.ENCODING_PCM_16BIT -> {
                 repeat(frameCount * channelCount) {
                     val sample = inputBuffer.getShort().toInt()
+                    // Apply gain and clamp to 16-bit signed range [-32768, 32767]
                     val processed = if (applyGain) {
                         (sample * gain.linearGain)
                             .coerceIn(-32768.0, 32767.0)
@@ -112,11 +184,15 @@ class VolumeNormalizationAudioProcessor : AudioProcessor {
 
             C.ENCODING_PCM_24BIT -> {
                 repeat(frameCount * channelCount) {
+                    // Read 24-bit sample as 3 individual bytes
                     val b0 = inputBuffer.get().toInt() and 0xFF
                     val b1 = inputBuffer.get().toInt() and 0xFF
                     val b2 = inputBuffer.get().toInt()
+                    // Reconstruct 24-bit sample from bytes
                     val sample = (b2 shl 16) or (b1 shl 8) or b0
+                    // Sign-extend from 24-bit to 32-bit
                     val signed = (sample shl 8) shr 8
+                    // Apply gain and clamp to 24-bit signed range [-8388608, 8388607]
                     val processed = if (applyGain) {
                         (signed * gain.linearGain)
                             .coerceIn(-8388608.0, 8388607.0)
@@ -124,6 +200,7 @@ class VolumeNormalizationAudioProcessor : AudioProcessor {
                     } else {
                         signed
                     }
+                    // Write 24-bit sample back as 3 bytes
                     out.put((processed and 0xFF).toByte())
                     out.put(((processed shr 8) and 0xFF).toByte())
                     out.put(((processed shr 16) and 0xFF).toByte())
@@ -133,6 +210,7 @@ class VolumeNormalizationAudioProcessor : AudioProcessor {
             C.ENCODING_PCM_32BIT -> {
                 repeat(frameCount * channelCount) {
                     val sample = inputBuffer.getInt()
+                    // Apply gain and clamp to 32-bit signed range [-2147483648, 2147483647]
                     val processed = if (applyGain) {
                         (sample * gain.linearGain)
                             .coerceIn(-2147483648.0, 2147483647.0)
@@ -148,6 +226,7 @@ class VolumeNormalizationAudioProcessor : AudioProcessor {
             C.ENCODING_PCM_FLOAT -> {
                 repeat(frameCount * channelCount) {
                     val sample = inputBuffer.getFloat()
+                    // Apply gain and clamp to float range [-1.0f, 1.0f]
                     val processed = if (applyGain) {
                         (sample * gain.linearGain.toFloat()).coerceIn(-1.0f, 1.0f)
                     } else {
@@ -162,29 +241,60 @@ class VolumeNormalizationAudioProcessor : AudioProcessor {
             )
         }
 
+        // Mark input buffer as fully consumed
         inputBuffer.position(inputBuffer.limit())
         out.flip()
         outputBuffer = out
     }
 
+    /**
+     * Signals that no more input will be queued.
+     *
+     * This method is called when the audio stream has ended, allowing the processor
+     * to finalize any pending operations.
+     */
     override fun queueEndOfStream() {
         inputEnded = true
     }
 
+    /**
+     * Retrieves the processed output buffer.
+     *
+     * The output buffer is cleared after retrieval to prevent reuse of stale data.
+     *
+     * @return The buffer containing processed audio samples, or an empty buffer if no output is available
+     */
     override fun getOutput(): ByteBuffer {
         val buffer = outputBuffer
         outputBuffer = EMPTY_BUFFER
         return buffer
     }
 
+    /**
+     * Returns whether the processor has finished processing all input.
+     *
+     * @return true if all input has been processed and no output remains in the buffer, false otherwise
+     */
     override fun isEnded(): Boolean = inputEnded && outputBuffer === EMPTY_BUFFER
 
+    /**
+     * Flushes any pending output and resets the stream end flag.
+     *
+     * This method is deprecated in the AudioProcessor interface but is retained for compatibility.
+     */
     @Deprecated("Deprecated in AudioProcessor")
     override fun flush() {
         outputBuffer = EMPTY_BUFFER
         inputEnded = false
     }
 
+    /**
+     * Resets the processor to its initial state.
+     *
+     * Clears all buffers and resets configuration. This method is deprecated in the
+     * AudioProcessor interface but is retained for compatibility. After reset, [configure]
+     * must be called again before processing new audio.
+     */
     @Deprecated("Deprecated in AudioProcessor")
     override fun reset() {
         flush()
@@ -197,6 +307,16 @@ class VolumeNormalizationAudioProcessor : AudioProcessor {
         active = false
     }
 
+    /**
+     * Ensures the output buffer has sufficient capacity, reusing or allocating as needed.
+     *
+     * This method optimizes memory allocation by reusing the internal buffer if it has
+     * sufficient capacity, otherwise allocating a new direct buffer. This reduces garbage
+     * collection pressure during continuous audio processing.
+     *
+     * @param size The required buffer size in bytes
+     * @return A ByteBuffer with at least the specified capacity, ready for writing
+     */
     private fun replaceOutputBuffer(size: Int): ByteBuffer {
         if (buffer.capacity() < size) {
             buffer = ByteBuffer.allocateDirect(size).order(ByteOrder.nativeOrder())


### PR DESCRIPTION
## Problem
The app’s volume normalization effect was not working correctly in playback. In some cases, audio could stay unchanged, become distorted, or even appear as silence because the processor was not returning processed output properly.

## Cause
The root cause was broken audio buffer handling inside the custom audio processor, along with incorrect 24-bit PCM decoding. The processor was also behaving like a fixed-gain effect rather than a true normalization step.

## Solution
- Fixed the processor output flow so processed audio is returned correctly to the player.
- Corrected input buffer consumption and output buffer lifecycle.
- Added proper frame-based processing using channel-aware sizing.
- Fixed 24-bit PCM sign extension so negative samples stay valid.
- Kept gain/clipping logic within safe PCM limits.
- Preserved external state such as enable/disable and target gain across resets.

## Testing
- Verified playback in the Android app with the effect disabled and enabled.
- Tested known PCM input to confirm output was produced correctly.
- Checked 16-bit, 24-bit, 32-bit, and float PCM paths.
- Confirmed negative 24-bit samples were handled correctly.
- Listened for silence, clipping, distortion, and stutter during real app playback.

## Related Issues
- Closes #4116 
- Related to #4312 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved volume normalization across supported audio formats, including correct handling of 24-bit audio.
  * Fixed processing for empty audio input and ensured audio buffers advance correctly.
  * Improved handling of unsupported audio encodings.
  * Improved processor state reset behavior for more reliable playback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->