### PR TITLE
fix(innertube): parse album artists from home shelves correctly

### DIFF
--- a/innertube/src/main/kotlin/com/metrolist/innertube/pages/HomePage.kt
+++ b/innertube/src/main/kotlin/com/metrolist/innertube/pages/HomePage.kt
@@ -218,19 +218,15 @@ data class HomePage(
                         )
                     }
                     renderer.isAlbum -> {
+                        val subtitleRuns = renderer.subtitle?.runs
                         AlbumItem(
                             browseId = renderer.navigationEndpoint.browseEndpoint?.browseId ?: return null,
                             playlistId = renderer.thumbnailOverlay?.musicItemThumbnailOverlayRenderer?.content
                                 ?.musicPlayButtonRenderer?.playNavigationEndpoint
                                 ?.watchPlaylistEndpoint?.playlistId ?: return null,
                             title = renderer.title.runs?.firstOrNull()?.text ?: return null,
-                            artists = renderer.subtitle?.runs?.oddElements()?.drop(1)?.map {
-                                Artist(
-                                    name = it.text,
-                                    id = it.navigationEndpoint?.browseEndpoint?.browseId
-                                )
-                            },
-                            year = null,
+                            artists = subtitleRuns?.let { PageHelper.extractArtists(it) },
+                            year = subtitleRuns?.lastOrNull()?.text?.toIntOrNull(),
                             thumbnail = renderer.thumbnailRenderer.getThumbnailUrl() ?: return null,
                             explicit = renderer.subtitleBadges?.find {
                                 it.musicInlineBadgeRenderer?.icon?.iconType == "MUSIC_EXPLICIT_BADGE"

--- a/innertube/src/test/kotlin/com/metrolist/innertube/pages/HomePageAlbumTest.kt
+++ b/innertube/src/test/kotlin/com/metrolist/innertube/pages/HomePageAlbumTest.kt
@@ -1,0 +1,161 @@
+package com.metrolist.innertube.pages
+
+import com.metrolist.innertube.models.AlbumItem
+import com.metrolist.innertube.models.Artist
+import com.metrolist.innertube.models.BrowseEndpoint
+import com.metrolist.innertube.models.BrowseEndpoint.BrowseEndpointContextSupportedConfigs
+import com.metrolist.innertube.models.BrowseEndpoint.BrowseEndpointContextSupportedConfigs.BrowseEndpointContextMusicConfig
+import com.metrolist.innertube.models.BrowseEndpoint.BrowseEndpointContextSupportedConfigs.BrowseEndpointContextMusicConfig.Companion.MUSIC_PAGE_TYPE_ALBUM
+import com.metrolist.innertube.models.MusicCarouselShelfRenderer
+import com.metrolist.innertube.models.MusicResponsiveListItemRenderer
+import com.metrolist.innertube.models.MusicTwoRowItemRenderer
+import com.metrolist.innertube.models.NavigationEndpoint
+import com.metrolist.innertube.models.Run
+import com.metrolist.innertube.models.Runs
+import com.metrolist.innertube.models.Thumbnail
+import com.metrolist.innertube.models.ThumbnailRenderer
+import com.metrolist.innertube.models.Thumbnails
+import com.metrolist.innertube.models.WatchEndpoint
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HomePageAlbumTest {
+
+    @Test
+    fun `album card artists contain only actual artists and the year is propagated`() {
+        val album = parseAlbum(
+            albumRenderer(
+                listOf(
+                    Run("Album", null),
+                    Run(" • ", null),
+                    Run("Lupus Nocte", NavigationEndpoint(browseEndpoint = BrowseEndpoint(browseId = "UC123"))),
+                    Run(" • ", null),
+                    Run("2023", null),
+                ),
+            ),
+        )
+
+        assertEquals(listOf(Artist("Lupus Nocte", "UC123")), album.artists)
+        assertEquals(2023, album.year)
+    }
+
+    @Test
+    fun `album card with unlinked artist keeps the artist and drops the year`() {
+        val album = parseAlbum(
+            albumRenderer(
+                listOf(
+                    Run("Album", null),
+                    Run(" • ", null),
+                    Run("Lupus Nocte", null),
+                    Run(" • ", null),
+                    Run("2023", null),
+                ),
+            ),
+        )
+
+        assertEquals(listOf(Artist("Lupus Nocte", null)), album.artists)
+        assertEquals(2023, album.year)
+    }
+
+    @Test
+    fun `album card with multiple linked artists keeps all artists`() {
+        val album = parseAlbum(
+            albumRenderer(
+                listOf(
+                    Run("Album", null),
+                    Run(" • ", null),
+                    Run("Lupus Nocte", NavigationEndpoint(browseEndpoint = BrowseEndpoint(browseId = "UC1"))),
+                    Run(" • ", null),
+                    Run("Second Artist", NavigationEndpoint(browseEndpoint = BrowseEndpoint(browseId = "UC2"))),
+                    Run(" • ", null),
+                    Run("2023", null),
+                ),
+            ),
+        )
+
+        assertEquals(
+            listOf(Artist("Lupus Nocte", "UC1"), Artist("Second Artist", "UC2")),
+            album.artists,
+        )
+        assertEquals(2023, album.year)
+    }
+
+    @Test
+    fun `album card never presents the year as an artist`() {
+        val album = parseAlbum(
+            albumRenderer(
+                listOf(
+                    Run("Album", null),
+                    Run(" • ", null),
+                    Run("Lupus Nocte", NavigationEndpoint(browseEndpoint = BrowseEndpoint(browseId = "UC123"))),
+                    Run(" • ", null),
+                    Run("2023", null),
+                ),
+            ),
+        )
+
+        assertTrue(album.artists.orEmpty().none { it.name == "2023" })
+    }
+
+    private fun albumRenderer(subtitleRuns: List<Run>) =
+        MusicTwoRowItemRenderer(
+            title = Runs(listOf(Run("Midnight", null))),
+            subtitle = Runs(subtitleRuns),
+            subtitleBadges = null,
+            menu = null,
+            thumbnailRenderer = ThumbnailRenderer(
+                musicThumbnailRenderer = ThumbnailRenderer.MusicThumbnailRenderer(
+                    thumbnail = Thumbnails(listOf(Thumbnail("https://example.com/cover.jpg", null, null))),
+                    thumbnailCrop = null,
+                    thumbnailScale = null,
+                ),
+                musicAnimatedThumbnailRenderer = null,
+                croppedSquareThumbnailRenderer = null,
+            ),
+            navigationEndpoint = NavigationEndpoint(
+                browseEndpoint = BrowseEndpoint(
+                    browseId = "MPREb_album",
+                    browseEndpointContextSupportedConfigs = BrowseEndpointContextSupportedConfigs(
+                        BrowseEndpointContextMusicConfig(MUSIC_PAGE_TYPE_ALBUM),
+                    ),
+                ),
+            ),
+            thumbnailOverlay = MusicResponsiveListItemRenderer.Overlay(
+                MusicResponsiveListItemRenderer.Overlay.MusicItemThumbnailOverlayRenderer(
+                    MusicResponsiveListItemRenderer.Overlay.MusicItemThumbnailOverlayRenderer.Content(
+                        MusicResponsiveListItemRenderer.Overlay.MusicItemThumbnailOverlayRenderer.Content.MusicPlayButtonRenderer(
+                            NavigationEndpoint(watchPlaylistEndpoint = WatchEndpoint(playlistId = "OLAK5uy_playlist")),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+    private fun parseAlbum(renderer: MusicTwoRowItemRenderer): AlbumItem {
+        val shelf = MusicCarouselShelfRenderer(
+            header = MusicCarouselShelfRenderer.Header(
+                MusicCarouselShelfRenderer.Header.MusicCarouselShelfBasicHeaderRenderer(
+                    strapline = null,
+                    title = Runs(listOf(Run("Quick Picks", null))),
+                    thumbnail = null,
+                    moreContentButton = null,
+                ),
+            ),
+            contents = listOf(
+                MusicCarouselShelfRenderer.Content(
+                    musicTwoRowItemRenderer = renderer,
+                    musicResponsiveListItemRenderer = null,
+                    musicMultiRowListItemRenderer = null,
+                    musicNavigationButtonRenderer = null,
+                ),
+            ),
+            itemSize = "MUSIC_TWO_ROW_ITEM_RENDERER",
+            numItemsPerColumn = null,
+        )
+        val section = HomePage.Section.fromMusicCarouselShelfRenderer(shelf)
+            ?: throw AssertionError("Section was not parsed")
+        return section.items.singleOrNull() as? AlbumItem
+            ?: throw AssertionError("Expected a single AlbumItem, got ${section.items}")
+    }
+}


### PR DESCRIPTION
## Problem

The `HomePage.fromMusicTwoRowItemRenderer()` album branch still uses positional `oddElements().drop(1)` parsing for subtitle runs.

For realistic album subtitles shaped like `Album • Artist • 2023`, the current parser converts both the actual artist and `2023` into artist entries while leaving the album `year` field null. The year is then rendered as a bogus artist on home album shelves.

## Root cause

The sibling song branch in the same function was migrated to `PageHelper.extractArtists()` as part of the earlier artist parsing fixes, but the album branch retained the older positional parser.

## Solution

Use `PageHelper.extractArtists()` for the album subtitle runs (which handles separator, conjunction, and metadata filtering) and extract the year from the final numeric subtitle run.

## Testing

- Regression tests reproduce the original incorrect artist list and pass with the fix:
  - linked artist case
  - unlinked artist case
  - multiple artists
  - year excluded from the artists and propagated correctly
- `./gradlew :innertube:testDebugUnitTest`
- `./gradlew :app:compileFossDebugKotlin`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved album information parsing to capture all listed artists.
  - Preserved artists even when they don’t have linked profile details.
  - Correctly identifies release years without displaying them as artists.

- **Tests**
  - Added coverage for albums with multiple artists, unlinked artists, and release-year metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->