### PR TITLE
feat(build): add optimized debug build mode

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,6 +22,7 @@ if (localPropertiesFile.exists()) {
 val baseApplicationId = "com.metrolist.music"
 val applicationIdOverride = System.getenv("METROLIST_APPLICATION_ID")?.takeIf { it.isNotBlank() }
 val appNameOverride = System.getenv("METROLIST_APP_NAME")?.takeIf { it.isNotBlank() }
+val optimizedDebugBuild = System.getenv("METROLIST_OPTIMIZED_DEBUG") == "true"
 val buildCommit =
     System.getenv("METROLIST_BUILD_COMMIT")
         ?.trim()
@@ -198,7 +199,15 @@ android {
             if (applicationIdOverride == null) {
                 applicationIdSuffix = ".debug"
             }
-            isDebuggable = true
+            isDebuggable = !optimizedDebugBuild
+            isMinifyEnabled = optimizedDebugBuild
+            isShrinkResources = optimizedDebugBuild
+            if (optimizedDebugBuild) {
+                proguardFiles(
+                    getDefaultProguardFile("proguard-android-optimize.txt"),
+                    "proguard-rules.pro",
+                )
+            }
             if (appNameOverride == null) {
                 resValue("string", "app_name", "Metrolist Debug")
             }


### PR DESCRIPTION
## Summary

- add an opt-in `METROLIST_OPTIMIZED_DEBUG=true` build mode
- enable R8 code optimization and resource shrinking for debug-signed builds
- disable debugger overhead while retaining debug signing and optional package/name overrides
- leave the default debug build behavior unchanged

This is useful for CI, testing, and side-by-side builds that need release-like runtime performance without access to the release signing key.

## Validation

- `METROLIST_OPTIMIZED_DEBUG=true METROLIST_APPLICATION_ID=com.metrolist.music.debug METROLIST_APP_NAME=Metrolist ./gradlew :app:assembleFossDebug`
- APK signature verified with Android `apksigner`
- package metadata verified with `aapt2`
- optimized APK reduced from approximately 48 MB to 25 MB in the tested FOSS build
- tested on a physical Android device; resolved the UI lag observed in the ordinary debug build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optimized debug build option controlled by the `METROLIST_OPTIMIZED_DEBUG` environment variable.
  * Optimized debug builds now support code shrinking, resource shrinking, and release-style optimization rules.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->