### PR TITLE
Fix voice search fallback to results and improve matching

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MediaLibrarySessionCallback.kt
@@ -828,8 +828,8 @@ constructor(
                             searchResults.firstOrNull { it.id == songId }
                         }
 
-                    if(context.dataStore.get(AutoRadioQueueKey, true)) {
-                        val radioQueue = YouTubeQueue.radio(selectedSong?.toMediaMetadata() ?: return@future defaultResult)
+                    if(context.dataStore.get(AutoRadioQueueKey, true) && selectedSong != null) {
+                        val radioQueue = YouTubeQueue.radio(selectedSong.toMediaMetadata())
                         val radioStatus = runCatching {
                             withContext(Dispatchers.IO) {
                                 radioQueue
@@ -851,14 +851,17 @@ constructor(
                         }
                     }
 
-                    val items = listOf(selectedSong?.toMediaItem() ?: return@future defaultResult)
+                    val items = selectedSong?.let { listOf(it.toMediaItem()) } ?: searchResults.map { it.toMediaItem() }
+                    if (items.isEmpty()) return@future defaultResult
+
+                    val queueTitle = selectedSong?.song?.title ?: searchQuery
                     withContext(Dispatchers.Main) {
                         service.adoptQueue(
                             ListQueue(
-                                title = selectedSong.song.title,
+                                title = queueTitle,
                                 items = items,
                             ),
-                            title = selectedSong.song.title,
+                            title = queueTitle,
                         )
                     }
                     MediaItemsWithStartPosition(

--- a/app/src/main/kotlin/com/metrolist/music/playback/VoiceSearchMatcher.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/VoiceSearchMatcher.kt
@@ -75,9 +75,15 @@ object VoiceSearchMatcher {
 
         val titleCoverage = matchedTitle.toDouble() / titleTokens.size
         val queryCoverage = matchedQuery.toDouble() / queryTokens.size
-        return if (titleCoverage + queryCoverage > 0)
+        val score = if (titleCoverage + queryCoverage > 0)
             (2.0 * titleCoverage * queryCoverage) / (titleCoverage + queryCoverage)   // harmonic mean
         else 0.0
+
+        return if (queryCoverage > 0.9 && titleCoverage <= 0.5) {
+            score * 0.85
+        } else {
+            score
+        }
     }
 
 


### PR DESCRIPTION
## Problem
When trying to play artist songs or casual songs (like "2015 hits") via voice play, it would play default result and not what i asked for or simply plays a song that has a title containing the artist name.

## Cause
- My previous implementation didn't handle correctly the voice search selected song when no song was selected (null).
- The candidate scoring simply did an harmonic mean, but the low title coverage should be more important.

## Solution
- Handle the selected song so if there is none, it will fallback to searchResults.map.
- Adjust candidate score to be lower if the query coverage is high and the the title coverage is low.

## Testing
Tested on Android Auto Desktop Head Unit (DHU).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Android Auto voice-search playback when no single song is selected; matching search results can now play as a playlist instead of stopping.
  - Prevented radio playback from starting without a valid song selection.
  - Improved voice-search matching by reducing misleading matches where a query closely matches the artist but poorly matches the song title.
  - Queue titles now more accurately reflect the selected song or search query.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->