### PR TITLE
Localize search section titles

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/search/OnlineSearchResult.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/search/OnlineSearchResult.kt
@@ -75,6 +75,7 @@ import com.metrolist.innertube.YouTube.SearchFilter.Companion.FILTER_PODCAST
 import com.metrolist.innertube.YouTube.SearchFilter.Companion.FILTER_PROFILE
 import com.metrolist.innertube.YouTube.SearchFilter.Companion.FILTER_SONG
 import com.metrolist.innertube.YouTube.SearchFilter.Companion.FILTER_VIDEO
+import com.metrolist.innertube.YouTubeConstants
 import com.metrolist.innertube.models.AlbumItem
 import com.metrolist.innertube.models.ArtistItem
 import com.metrolist.innertube.models.EpisodeItem
@@ -494,7 +495,7 @@ fun OnlineSearchResult(
                     if (searchFilter == null) {
                         searchSummary?.summaries?.forEach { summary ->
                             item {
-                                NavigationTitle(summary.title)
+                                NavigationTitle(summary.title.toLocalizedSearchSection())
                             }
 
                             itemsIndexed(
@@ -574,3 +575,19 @@ fun OnlineSearchResult(
         }
     }
 }
+
+@Composable
+private fun String.toLocalizedSearchSection(): String =
+    when (this) {
+        YouTubeConstants.DEFAULT_TOP_RESULT -> stringResource(R.string.top_result)
+        YouTubeConstants.DEFAULT_OTHER_RESULTS -> stringResource(R.string.other)
+        "Songs" -> stringResource(R.string.songs)
+        "Videos" -> stringResource(R.string.filter_videos)
+        "Albums" -> stringResource(R.string.albums)
+        "Artists" -> stringResource(R.string.artists)
+        "Playlists" -> stringResource(R.string.playlists)
+        "Podcasts" -> stringResource(R.string.filter_podcasts)
+        "Episodes" -> stringResource(R.string.filter_episodes)
+        "Profiles" -> stringResource(R.string.filter_profiles)
+        else -> this
+    }

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -990,4 +990,6 @@
     <string name="stream_source_android_vr_desc">Android VR clients (all versions).</string>
     <string name="stream_source_web_creator">WEB_CREATOR</string>
     <string name="stream_source_web_creator_desc">Creator web client.</string>
+    <string name="top_result">Top result</string>
+    <string name="other">Other</string>
 </resources>


### PR DESCRIPTION
## Problem
<!-- Describe the issue or limitation this PR addresses  
DO NOT PR NEW FEATURES, WE'RE ON A FEATURE FREEZE!!! -->
Search section titles (e.g. "Top result", "Songs", "Albums") were displayed as hardcoded English strings, making them impossible to localize.
## Cause
<!-- Explain the root cause of the problem -->
The raw internal string identifiers were being used directly as the UI display text.
## Solution
<!-- List the changes made to fix the issue -->
- Re-opened and cleaned up the changes from stale PR #4213 directly on top of the latest main.
- Reused existing string resources (e.g., filter_videos, filter_podcasts, etc.) instead of creating new ones. Added only the missing base strings (top_result and other) to app/src/main/res/values/metrolist_strings.xml in accordance with the project's Weblate policy.
## Testing
<!-- Describe how the changes were tested -->
Verified clean Android build and confirmed search section titles render localized strings correctly while maintaining original grouping and sorting logic.
## Related Issues
<!-- List any related issues or PRs -->
- Closes #4213
- Related to #4213


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Search section headers are now localized on the online search screen.
  - Added localized labels for top results and other results, along with categories such as songs, videos, albums, artists, playlists, podcasts, episodes, and profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->